### PR TITLE
[feat] Allow multiple entrypoints of the same group in one pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "edutap.wallet-google"
-version = "2.0.0b1"
+version = "2.0.0b2.dev0"
 description = "Library for Google Wallet Communication"
 keywords = ["wallet", "google", "api", "pass", 'fastapi', 'digital identity']
 readme = "README.md"

--- a/src/edutap/wallet_google/plugins.py
+++ b/src/edutap/wallet_google/plugins.py
@@ -5,7 +5,7 @@ from importlib.metadata import entry_points
 
 def get_image_providers() -> list[ImageProvider]:
     eps = entry_points(group="edutap.wallet_google.plugins")
-    plugins = [ep.load() for ep in eps if ep.name == "ImageProvider"]
+    plugins = [ep.load() for ep in eps if "ImageProvider" in ep.name]
     if not plugins:
         raise NotImplementedError("No image provider plug-in found")
     for plugin in plugins:
@@ -16,7 +16,7 @@ def get_image_providers() -> list[ImageProvider]:
 
 def get_callback_handlers() -> list[CallbackHandler]:
     eps = entry_points(group="edutap.wallet_google.plugins")
-    plugins = [ep.load() for ep in eps if ep.name == "CallbackHandler"]
+    plugins = [ep.load() for ep in eps if "CallbackHandler" in ep.name]
     if not plugins:
         raise NotImplementedError("No callback handler plugin found.")
     for plugin in plugins:

--- a/src/edutap/wallet_google/plugins.py
+++ b/src/edutap/wallet_google/plugins.py
@@ -16,7 +16,7 @@ def get_image_providers() -> list[ImageProvider]:
 
 def get_callback_handlers() -> list[CallbackHandler]:
     eps = entry_points(group="edutap.wallet_google.plugins")
-    plugins = [ep.load() for ep in eps if "CallbackHandler" in ep.name]
+    plugins = [ep.load() for ep in eps if ep.name.startswith("CallbackHandler")]
     if not plugins:
         raise NotImplementedError("No callback handler plugin found.")
     for plugin in plugins:

--- a/src/edutap/wallet_google/plugins.py
+++ b/src/edutap/wallet_google/plugins.py
@@ -5,7 +5,7 @@ from importlib.metadata import entry_points
 
 def get_image_providers() -> list[ImageProvider]:
     eps = entry_points(group="edutap.wallet_google.plugins")
-    plugins = [ep.load() for ep in eps if "ImageProvider" in ep.name]
+    plugins = [ep.load() for ep in eps if ep.name.startswith("ImageProvider")]
     if not plugins:
         raise NotImplementedError("No image provider plug-in found")
     for plugin in plugins:


### PR DESCRIPTION
in pyproject.toml files you declare an entry point by 

```
[project.entry-points.'plugin name']
Name = 'module:Class'
```

in our context:

```
[project.entry-points.'edutap.wallet_google.plugins']
CallbackHandler = 'module:Class'
```

pyproject.toml does not support to declare multiple plugin handlers on the same name.

We only check for one specific name here. Which could be ok for the ImageProvider as there should be only one, but the CallbackHandler can be multiple. 

So check if the name is in the Plugin Name and not that it is equal to the Plugin Name
