### PR TITLE
[bug] Fix api import - enable `from edutap import wallet_google` and use `wallet_google.api...`

### DIFF
--- a/src/edutap/wallet_google/__init__.py
+++ b/src/edutap/wallet_google/__init__.py
@@ -1,2 +1,4 @@
-# import to register models
+# import to enable direkt usage import from parent namespace
+# models also registers the models in the registry
+from . import api  # noqa: F401
 from . import models  # noqa: F401

--- a/src/edutap/wallet_google/models/datatypes/general.py
+++ b/src/edutap/wallet_google/models/datatypes/general.py
@@ -4,9 +4,9 @@ from .enums import AnimationType
 from .enums import NfcConstraint
 from .enums import ScreenshotEligibility
 from .localized_string import LocalizedString
+from pydantic import AnyHttpUrl
 from pydantic import AnyUrl
 from pydantic import Field
-from pydantic import HttpUrl
 from typing import Annotated
 from typing_extensions import deprecated
 
@@ -112,9 +112,9 @@ class CallbackOptions(Model):
     see: https://developers.google.com/wallet/generic/rest/v1/CallbackOptions
     """
 
-    url: HttpUrl | None = None
+    url: AnyHttpUrl | None = None
     updateRequestUrl: Annotated[
-        HttpUrl | None,
+        AnyHttpUrl | None,
         Field(
             deprecated=deprecated(
                 'The Parameter "updateRequestUrl" is deprecated on "CallbackOption", use "url" instead.'


### PR DESCRIPTION
From parent namespace the following was not possible before:
```python
from edutap import wallet_google
wallet_google.api.new(...)
```
Which works with this fix.