### PR TITLE
Separate settings for API, Callback-Handler and Image-Handler

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include tests *.json *.py
+recursive-exclude docs *

--- a/src/edutap/wallet_google/handlers/fastapi.py
+++ b/src/edutap/wallet_google/handlers/fastapi.py
@@ -16,11 +16,11 @@ import asyncio
 
 # define routers for all use cases: callback, images, and the combined router (at bottom of file)
 router_callback = APIRouter(
-    prefix=session_manager.settings.handler_prefix_callback,
+    prefix=session_manager.callback_settings.router_prefix,
     tags=["edutap.wallet_google"],
 )
 router_images = APIRouter(
-    prefix=session_manager.settings.handler_prefix_images,
+    prefix=session_manager.image_settings.router_prefix,
     tags=["edutap.wallet_google"],
 )
 
@@ -64,12 +64,12 @@ async def handle_callback(request: Request, callback_data: CallbackData):
                     ),
                     return_exceptions=True,
                 ),
-                timeout=session_manager.settings.handlers_callback_timeout,
+                timeout=session_manager.callback_settings.timeout,
             )
         )
     except asyncio.TimeoutError:
         logger.exception(
-            f"Timeout after {session_manager.settings.handlers_callback_timeout}s while handling the callbacks.",
+            f"Timeout after {session_manager.callback_settings.timeout}s while handling the callbacks.",
         )
         raise HTTPException(
             status_code=500, detail="Error while handling the callbacks (timeout)."
@@ -110,11 +110,11 @@ async def handle_image(request: Request, encrypted_image_id: str):
     try:
         result = await asyncio.wait_for(
             handler.image_by_id(image_id),
-            timeout=session_manager.settings.handlers_image_timeout,
+            timeout=session_manager.image_settings.timeout,
         )
     except asyncio.TimeoutError:
         logger.exception(
-            "Timeout Timeout after {session_manager.settings.handlers_image_timeout}s while handling the image.",
+            "Timeout Timeout after {session_manager.image_settings.timeout}s while handling the image.",
         )
         raise HTTPException(
             status_code=500, detail="Error while handling the image (timeout)."
@@ -138,7 +138,7 @@ async def handle_image(request: Request, encrypted_image_id: str):
     return Response(
         content=result.data,
         media_type=result.mimetype,
-        headers={"Cache-Control": session_manager.settings.handler_image_cache_control},
+        headers={"Cache-Control": session_manager.image_settings.cache_control},
     )
 
 

--- a/src/edutap/wallet_google/handlers/validate.py
+++ b/src/edutap/wallet_google/handlers/validate.py
@@ -147,8 +147,8 @@ def verified_signed_message(data: CallbackData) -> SignedMessage:
     issuer_id = message.classId.split(".")[0]
 
     # shortcut if signature validation is disabled
-    settings = session_manager.settings
-    if settings.handler_callback_verify_signature == "0":
+    settings = session_manager.callback_settings
+    if settings.verify_signature == "0":
         return message
 
     if data.protocolVersion != PROTOCOL_VERSION:

--- a/src/edutap/wallet_google/session.py
+++ b/src/edutap/wallet_google/session.py
@@ -1,4 +1,6 @@
 from .registry import lookup_metadata_by_name
+from .settings import CallbackHandlerSettings
+from .settings import ImageHandlerSettings
 from .settings import Settings
 from google.auth.transport.requests import AuthorizedSession
 from google.oauth2.service_account import Credentials
@@ -57,6 +59,20 @@ class SessionManager:
         if settings is None:
             self._settings = Settings()
         return self._settings
+
+    @property
+    def callback_settings(self) -> CallbackHandlerSettings:
+        settings = getattr(self, "_callback_settings", None)
+        if settings is None:
+            self._callback_settings = CallbackHandlerSettings()
+        return self._callback_settings
+
+    @property
+    def image_settings(self) -> ImageHandlerSettings:
+        settings = getattr(self, "_image_settings", None)
+        if settings is None:
+            self._image_settings = ImageHandlerSettings()
+        return self._image_settings
 
     def _make_session(self) -> AuthorizedSession:
         if not self.settings.credentials_file.is_file():

--- a/src/edutap/wallet_google/settings.py
+++ b/src/edutap/wallet_google/settings.py
@@ -32,25 +32,18 @@ class Settings(BaseSettings):
         extra="ignore",
     )
 
-    record_api_calls_dir: Path | None = None
     api_url: AnyHttpUrl = AnyHttpUrl(API_URL)
     save_url: AnyHttpUrl = AnyHttpUrl(SAVE_URL)
 
     handler_prefix: str = "/wallet/google"
-    handler_prefix_callback: str = ""
-    handler_prefix_images: str = ""
-    handler_callback_verify_signature: str = "1"
-    handler_image_cache_control: str = "no-cache"
-    handlers_callback_timeout: float = 5.0
-    handlers_image_timeout: float = 5.0
-
-    credentials_file: Path = ROOT_DIR / "tests" / "data" / "credentials_fake.json"
-    credentials_scopes: list[str] = SCOPES
-    test_issuer_id: str = Field(default="")
 
     fernet_encryption_key: str = ""
 
-    google_environment: Literal["production", "testing"] = "testing"
+    credentials_file: Path = ROOT_DIR / "tests" / "data" / "credentials_fake.json"
+    credentials_scopes: list[str] = SCOPES
+
+    record_api_calls_dir: Path | None = None
+    test_issuer_id: str = Field(default="")
 
     cached_credentials_info: dict[str, str] = {}
 
@@ -69,3 +62,48 @@ class Settings(BaseSettings):
                 f"EDUTAP_WALLET_GOOGLE_CREDENTIALS_FILE={self.credentials_file} content is not a dict"
             )
         return self.cached_credentials_info
+
+
+class CallbackHandlerSettings(BaseSettings):
+    """Settings for Google Wallet Preferences.
+
+    For more on how these settings work follow https://docs.pydantic.dev/latest/concepts/pydantic_settings/
+
+    Any default can be overridden by setting the corresponding environment variable prefixed with `EDUTAP_WALLET_GOOGLE_`.
+    If a `.env` file is present in the root directory of the project, the environment variables will be loaded from there.
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix=ENV_PREFIX + "HANDLER_CALLBACK_",
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        extra="ignore",
+    )
+
+    google_environment: Literal["production", "testing"] = "testing"
+    verify_signature: str = "1"
+    router_prefix: str = ""
+    timeout: float = 5.0
+
+
+class ImageHandlerSettings(BaseSettings):
+    """Settings for Google Wallet Preferences.
+
+    For more on how these settings work follow https://docs.pydantic.dev/latest/concepts/pydantic_settings/
+
+    Any default can be overridden by setting the corresponding environment variable prefixed with `EDUTAP_WALLET_GOOGLE_`.
+    If a `.env` file is present in the root directory of the project, the environment variables will be loaded from there.
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix=ENV_PREFIX + "HANDLER_IMAGE_",
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        extra="ignore",
+    )
+
+    router_prefix: str = ""
+    cache_control: str = "no-cache"
+    timeout: float = 5.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,6 +97,22 @@ def mock_settings():
 
 
 @pytest.fixture
+def mock_callback_settings():
+    from edutap.wallet_google.session import session_manager
+
+    yield session_manager.callback_settings
+    del session_manager._callback_settings
+
+
+@pytest.fixture
+def mock_image_settings():
+    from edutap.wallet_google.session import session_manager
+
+    yield session_manager.image_settings
+    del session_manager._image_settings
+
+
+@pytest.fixture
 def mock_fernet_encryption_key(mock_settings):
     mock_settings.fernet_encryption_key = "TDTPJVv24gha-jRX0apPgPpMDN2wX1kVSNNZdWXcz8E="
 

--- a/tests/test_handler_fastapi.py
+++ b/tests/test_handler_fastapi.py
@@ -16,11 +16,11 @@ real_callback_data = {
 }
 
 
-def test_callback_disabled_signature_check_OK(mock_settings):
+def test_callback_disabled_signature_check_OK(mock_callback_settings):
     from edutap.wallet_google.models.handlers import CallbackData
 
     # test callback handler without signature check
-    mock_settings.handler_callback_verify_signature = "0"
+    mock_callback_settings.verify_signature = "0"
 
     callback_data = CallbackData(**real_callback_data)
 
@@ -36,11 +36,11 @@ def test_callback_disabled_signature_check_OK(mock_settings):
     assert resp.json() == {"status": "success"}
 
 
-def test_callback_disabled_signature_check_ERROR(mock_settings):
+def test_callback_disabled_signature_check_ERROR(mock_callback_settings):
     from edutap.wallet_google.models.handlers import CallbackData
 
     # test callback handler without signature check
-    mock_settings.handler_callback_verify_signature = "0"
+    mock_callback_settings.verify_signature = "0"
 
     callback_data = CallbackData(**real_callback_data)
     callback_data.signedMessage = '{"classId":"1.x","objectId":"1.y","eventType":"save","expTimeMillis":1734366082269,"count":1,"nonce":""}'
@@ -57,11 +57,13 @@ def test_callback_disabled_signature_check_ERROR(mock_settings):
     assert resp.text == '{"detail":"Error while handling the callbacks (exception)."}'
 
 
-def test_callback_disabled_signature_check_NOTIMPLEMENTED(monkeypatch, mock_settings):
+def test_callback_disabled_signature_check_NOTIMPLEMENTED(
+    monkeypatch, mock_callback_settings
+):
     from edutap.wallet_google.models.handlers import CallbackData
 
     # test callback handler without signature check
-    mock_settings.handler_callback_verify_signature = "0"
+    mock_callback_settings.verify_signature = "0"
 
     def raise_not_implemented():
         raise NotImplementedError
@@ -87,13 +89,13 @@ def test_callback_disabled_signature_check_NOTIMPLEMENTED(monkeypatch, mock_sett
     assert resp.text == '{"detail":"No callback handlers were registered."}'
 
 
-def test_callback_disabled_signature_check_TIMEOUT(mock_settings):
+def test_callback_disabled_signature_check_TIMEOUT(mock_callback_settings):
     from edutap.wallet_google.models.handlers import CallbackData
 
     # test callback handler without signature check
-    mock_settings.handler_callback_verify_signature = "0"
+    mock_callback_settings.verify_signature = "0"
     # set low timeout to trigger a timeout cancellation
-    mock_settings.handlers_callback_timeout = 0.1
+    mock_callback_settings.timeout = 0.1
 
     callback_data = CallbackData(**real_callback_data)
     callback_data.signedMessage = '{"classId":"TIMEOUT.x","objectId":"1.x","eventType":"save","expTimeMillis":250,"count":1,"nonce":"abcde"}'
@@ -134,8 +136,8 @@ def test_image_ERROR(mock_fernet_encryption_key):
     assert resp.text == '{"detail":"Image not found."}'
 
 
-def test_image_TIMEOUT(mock_settings, mock_fernet_encryption_key):
-    mock_settings.handlers_image_timeout = 0.1
+def test_image_TIMEOUT(mock_image_settings, mock_fernet_encryption_key):
+    mock_image_settings.timeout = 0.1
 
     from edutap.wallet_google.handlers.fastapi import router
     from edutap.wallet_google.utils import encrypt_data

--- a/tests/test_handler_validate.py
+++ b/tests/test_handler_validate.py
@@ -4,10 +4,13 @@ import json
 import pytest
 
 
-def test_google_public_key_cached_empty(mock_settings):
+def test_google_public_key_cached_empty(mock_callback_settings):
     from edutap.wallet_google.handlers.validate import google_root_signing_public_keys
 
-    assert google_root_signing_public_keys(mock_settings.google_environment) is not None
+    assert (
+        google_root_signing_public_keys(mock_callback_settings.google_environment)
+        is not None
+    )
 
     from edutap.wallet_google.handlers.validate import (
         GOOGLE_ROOT_SIGNING_PUBLIC_KEYS_VALUE,
@@ -15,11 +18,14 @@ def test_google_public_key_cached_empty(mock_settings):
 
     assert (
         GOOGLE_ROOT_SIGNING_PUBLIC_KEYS_VALUE.get(
-            mock_settings.google_environment, None
+            mock_callback_settings.google_environment, None
         )
         is not None
     )
-    assert google_root_signing_public_keys(mock_settings.google_environment) is not None
+    assert (
+        google_root_signing_public_keys(mock_callback_settings.google_environment)
+        is not None
+    )
 
 
 callback_data_for_test_failure = {
@@ -45,10 +51,10 @@ callback_data_for_test_failure = {
 
 
 @pytest.mark.skip(reason="Not implemented")
-def test_handler_validate_invalid(mock_settings):
+def test_handler_validate_invalid(mock_callback_settings):
     from edutap.wallet_google.handlers.validate import verified_signed_message
 
-    mock_settings.handler_callback_verify_signature = "1"
+    mock_callback_settings.verify_signature = "1"
 
     data = CallbackData.model_validate(callback_data_for_test_failure)
     with pytest.raises(Exception):
@@ -68,10 +74,10 @@ callback_data = {
 }
 
 
-def test_handler_validate_ok(mock_settings):
+def test_handler_validate_ok(mock_callback_settings):
     from edutap.wallet_google.handlers.validate import verified_signed_message
 
-    mock_settings.handler_callback_verify_signature = "0"
+    mock_callback_settings.verify_signature = "0"
 
     data = CallbackData.model_validate(callback_data)
     verified_signed_message(data)


### PR DESCRIPTION
When we use the Handlers standalone it makes not sense to supply a credential file to the application. But that is required by the settings for API and Session.