### PR TITLE
Multi-issuer environment: Session credentials dynamic using plugins - with fallback to old behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This is supported by
 - Pydantic models of the classes, objects, and their data-types according to the Google Wallet documentation;
 - an extensible registry for models of these classes and objects;
 - a session manager for authorized HTTPS communication with the Google Restful API;
-- a plugin system with protocols to decouple the actual business logic for the callback/ image provider.
+- a plugin system with protocols to decouple the actual business logic for the callback/ image/ credential providers.
 
 ## Documentation
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -125,7 +125,7 @@ There are two routers available for callback and images, plus one combined provi
 
   Default: `5.0`
 
-- `EDUTAP_WALLET_GOOGLE_FERNET_ENCRYPTIONS_KEY`
+- `EDUTAP_WALLET_GOOGLE_FERNET_ENCRYPTION_KEY`
 
   Image Identifiers in the images handler are encrypted symmetrically.
   To generate key use the provided script `generate-fernet-key` or any tool to generate a Fernet key,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "edutap.wallet-google"
-version = "2.0.0b7"
+version = "2.0.0b9-dev07"
 description = "Library for Google Wallet Communication"
 keywords = ["wallet", "google", "api", "pass", 'fastapi', 'digital identity']
 readme = "README.md"

--- a/src/edutap/wallet_google/api.py
+++ b/src/edutap/wallet_google/api.py
@@ -7,7 +7,7 @@ from .models.datatypes.message import Message
 from .models.misc import AddMessageRequest
 from .models.passes.bases import ClassModel
 from .models.passes.bases import ObjectModel
-from .plugins import get_credential_providers
+from .plugins import get_credentials_providers
 from .registry import lookup_metadata_by_model_instance
 from .registry import lookup_metadata_by_model_type
 from .registry import lookup_metadata_by_name
@@ -368,7 +368,7 @@ def listing(
         # In multi-issuer setups this might be a problem, so we fail when there are providers registered
         # but no issuer_id is given in this case.
         if issuer_id is None:
-            providers = get_credential_providers()
+            providers = get_credentials_providers()
             if not providers:
                 raise ValueError(
                     "issuer_id must be given to list issuers in multi-issuer setups"

--- a/src/edutap/wallet_google/api.py
+++ b/src/edutap/wallet_google/api.py
@@ -116,7 +116,10 @@ def new(
     return _validate_data(model, data)
 
 
-def create(data: Model, credentials: dict | None = None) -> Model:
+def create(
+    data: Model,
+    credentials: dict | None = None,
+) -> Model:
     """
     Creates a Google Wallet items. `C` in CRUD.
 
@@ -165,7 +168,11 @@ def create(data: Model, credentials: dict | None = None) -> Model:
         raise
 
 
-def read(name: str, resource_id: str, credentials: dict | None = None) -> Model:
+def read(
+    name: str,
+    resource_id: str,
+    credentials: dict | None = None,
+) -> Model:
     """
     Reads a Google Wallet Class or Object. `R` in CRUD.
 
@@ -201,7 +208,10 @@ def read(name: str, resource_id: str, credentials: dict | None = None) -> Model:
 
 
 def update(
-    data: Model, *, partial: bool = True, credentials: dict | None = None
+    data: Model,
+    *,
+    partial: bool = True,
+    credentials: dict | None = None,
 ) -> Model:
     """
     Updates a Google Wallet Class or Object. `U` in CRUD.

--- a/src/edutap/wallet_google/api.py
+++ b/src/edutap/wallet_google/api.py
@@ -513,9 +513,9 @@ def save_link(
         )
     )
 
-    signer = crypt.RSASigner.from_service_account_file(
-        session_manager.settings.credentials_file
-    )
+    issuer_id = _issuer_from_resource_id(models[0].id)
+    credentials_file_data = session_manager.credentials_file_data_for_issuer(issuer_id)
+    signer = crypt.RSASigner.from_service_account_info(credentials_file_data)
     jwt_string = jwt.encode(
         signer,
         claims.model_dump(

--- a/src/edutap/wallet_google/plugins.py
+++ b/src/edutap/wallet_google/plugins.py
@@ -1,4 +1,5 @@
 from .protocols import CallbackHandler
+from .protocols import CredentialProvider
 from .protocols import ImageProvider
 from importlib.metadata import entry_points
 
@@ -8,11 +9,15 @@ import typing
 _POSSIBLE_PLUGINS = {
     "ImageProvider": ImageProvider,
     "CallbackHandler": CallbackHandler,
+    "CredentialProvider": CredentialProvider,
 }
 
-_PLUGIN_REGISTRY: dict[str, list[CallbackHandler | ImageProvider]] = {
+_PLUGIN_REGISTRY: dict[
+    str, list[CallbackHandler | ImageProvider | CredentialProvider]
+] = {
     "ImageProvider": [],
     "CallbackHandler": [],
+    "CredentialProvider": [],
 }
 
 
@@ -27,7 +32,7 @@ def get_plugins(name: str) -> list[CallbackHandler | ImageProvider]:
     plugins = [ep.load() for ep in eps if ep.name.startswith(name)]
     plugins += _PLUGIN_REGISTRY.get(name, [])
     if not plugins:
-        raise NotImplementedError("No image provider plug-in found")
+        raise NotImplementedError(f"No {name} plug-in found")
     for plugin in plugins:
         if not isinstance(plugin, _POSSIBLE_PLUGINS[name]):
             raise ValueError(f"{plugin} not implements {name}")
@@ -40,3 +45,7 @@ def get_image_providers() -> list[ImageProvider]:
 
 def get_callback_handlers() -> list[CallbackHandler]:
     return typing.cast(list[CallbackHandler], get_plugins("CallbackHandler"))
+
+
+def get_credential_providers() -> list[CredentialProvider]:
+    return typing.cast(list[CredentialProvider], get_plugins("CredentialProvider"))

--- a/src/edutap/wallet_google/plugins.py
+++ b/src/edutap/wallet_google/plugins.py
@@ -1,5 +1,5 @@
 from .protocols import CallbackHandler
-from .protocols import CredentialProvider
+from .protocols import CredentialsProvider
 from .protocols import ImageProvider
 from importlib.metadata import entry_points
 
@@ -9,15 +9,15 @@ import typing
 _POSSIBLE_PLUGINS = {
     "ImageProvider": ImageProvider,
     "CallbackHandler": CallbackHandler,
-    "CredentialProvider": CredentialProvider,
+    "CredentialsProvider": CredentialsProvider,
 }
 
 _PLUGIN_REGISTRY: dict[
-    str, list[CallbackHandler | ImageProvider | CredentialProvider]
+    str, list[CallbackHandler | ImageProvider | CredentialsProvider]
 ] = {
     "ImageProvider": [],
     "CallbackHandler": [],
-    "CredentialProvider": [],
+    "CredentialsProvider": [],
 }
 
 
@@ -47,5 +47,5 @@ def get_callback_handlers() -> list[CallbackHandler]:
     return typing.cast(list[CallbackHandler], get_plugins("CallbackHandler"))
 
 
-def get_credential_providers() -> list[CredentialProvider]:
-    return typing.cast(list[CredentialProvider], get_plugins("CredentialProvider"))
+def get_credentials_providers() -> list[CredentialsProvider]:
+    return typing.cast(list[CredentialsProvider], get_plugins("CredentialsProvider"))

--- a/src/edutap/wallet_google/protocols.py
+++ b/src/edutap/wallet_google/protocols.py
@@ -37,3 +37,15 @@ class CallbackHandler(Protocol):
 
         :raises: ValueError
         """
+
+
+@runtime_checkable
+class CredentialProvider(Protocol):
+
+    def credential_for_issuer(self, issuer_id: str) -> str:
+        """
+        :param issuer_id: Unique issuer identifier as string.
+        :return: data of the credentials file.
+
+        :raises: LookupError if issuer_id was not found.
+        """

--- a/src/edutap/wallet_google/protocols.py
+++ b/src/edutap/wallet_google/protocols.py
@@ -40,9 +40,9 @@ class CallbackHandler(Protocol):
 
 
 @runtime_checkable
-class CredentialProvider(Protocol):
+class CredentialsProvider(Protocol):
 
-    def credential_for_issuer(self, issuer_id: str) -> dict:
+    def credentials_for_issuer(self, issuer_id: str) -> dict:
         """
         :param issuer_id: Unique issuer identifier as string.
         :return: data of the credentials file as dict.

--- a/src/edutap/wallet_google/protocols.py
+++ b/src/edutap/wallet_google/protocols.py
@@ -42,10 +42,10 @@ class CallbackHandler(Protocol):
 @runtime_checkable
 class CredentialProvider(Protocol):
 
-    def credential_for_issuer(self, issuer_id: str) -> str:
+    def credential_for_issuer(self, issuer_id: str) -> dict:
         """
         :param issuer_id: Unique issuer identifier as string.
-        :return: data of the credentials file.
+        :return: data of the credentials file as dict.
 
         :raises: LookupError if issuer_id was not found.
         """

--- a/src/edutap/wallet_google/session.py
+++ b/src/edutap/wallet_google/session.py
@@ -86,7 +86,9 @@ class SessionManager:
         return session
 
     def session(
-        self, issuer_id: str | None = None, credentials: dict | None = None
+        self,
+        issuer_id: str | None = None,
+        credentials: dict | None = None,
     ) -> AuthorizedSession:
         if issuer_id and credentials:
             raise RuntimeError(

--- a/src/edutap/wallet_google/session.py
+++ b/src/edutap/wallet_google/session.py
@@ -59,7 +59,7 @@ class SessionManager:
             self._settings = Settings()
         return self._settings
 
-    def _credentials_for_issuer(self, issuer_id: str) -> Credentials:
+    def credentials_file_data_for_issuer(self, issuer_id: str) -> str:
         try:
             providers = get_credential_providers()
         except NotImplementedError:
@@ -69,7 +69,7 @@ class SessionManager:
                     f"EDUTAP_WALLET_GOOGLE_CREDENTIALS_FILE={self.settings.credentials_file} does not exist."
                 )
             with self.settings.credentials_file.open("r") as fd:
-                data = json.load(fd)
+                return fd.read()
         else:
             raw = None
             for provider in providers:
@@ -80,9 +80,12 @@ class SessionManager:
                     continue
             if raw is None:
                 raise LookupError(f"No credentials found for issuer {issuer_id}")
-            data = json.loads(raw)
+            return raw
+
+    def _credentials_for_issuer(self, issuer_id: str) -> Credentials:
+        credentials_file_data = self.credentials_file_data_for_issuer(issuer_id)
         return Credentials.from_service_account_info(
-            data,
+            json.loads(credentials_file_data),
             scopes=self.settings.credentials_scopes,
         )
 

--- a/src/edutap/wallet_google/session.py
+++ b/src/edutap/wallet_google/session.py
@@ -1,4 +1,4 @@
-from .plugins import get_credential_providers
+from .plugins import get_credentials_providers
 from .registry import lookup_metadata_by_name
 from .settings import Settings
 from google.auth.transport.requests import AuthorizedSession
@@ -67,10 +67,10 @@ class SessionManager:
             return json.loads(fd.read())
 
     def credentials_by_issuer(self, issuer_id: str) -> dict:
-        providers = get_credential_providers()
+        providers = get_credentials_providers()
         for provider in providers:
             try:
-                return provider.credential_for_issuer(issuer_id)
+                return provider.credentials_for_issuer(issuer_id)
             except LookupError:
                 continue
         raise LookupError(f"No credentials found for issuer {issuer_id}")

--- a/src/edutap/wallet_google/session.py
+++ b/src/edutap/wallet_google/session.py
@@ -5,6 +5,7 @@ from google.auth.transport.requests import AuthorizedSession
 from google.oauth2.service_account import Credentials
 from requests.adapters import HTTPAdapter
 
+import functools
 import json
 import threading
 
@@ -59,6 +60,7 @@ class SessionManager:
             self._settings = Settings()
         return self._settings
 
+    @functools.cache
     def credentials_from_file(self) -> dict:
         credentials_file = self.settings.credentials_file
         if not credentials_file.is_file():
@@ -66,6 +68,7 @@ class SessionManager:
         with credentials_file.open() as fd:
             return json.loads(fd.read())
 
+    @functools.lru_cache(maxsize=100)
     def credentials_by_issuer(self, issuer_id: str) -> dict:
         providers = get_credentials_providers()
         for provider in providers:

--- a/src/edutap/wallet_google/session.py
+++ b/src/edutap/wallet_google/session.py
@@ -77,7 +77,7 @@ class SessionManager:
                     raw = provider.credential_for_issuer(issuer_id)
                     break
                 except LookupError:
-                    pass
+                    continue
             if raw is None:
                 raise LookupError(f"No credentials found for issuer {issuer_id}")
             data = json.loads(raw)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,17 +58,17 @@ def mock_session(monkeypatch, requests_mock, clean_session_threadlocals):
 
     import requests
 
-    def mock_make_session(self, issuer_id):
+    def mock_make_session(self, credentials):
         return requests.Session()
 
     monkeypatch.setattr(SessionManager, "_make_session", mock_make_session)
 
-    def mock_get_credential_providers():
+    def mock_get_credentials_providers():
         raise NotImplementedError()
 
     monkeypatch.setattr(
-        "edutap.wallet_google.session.get_credential_providers",
-        mock_get_credential_providers,
+        "edutap.wallet_google.session.get_credentials_providers",
+        mock_get_credentials_providers,
     )
 
     yield requests_mock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,16 +44,20 @@ def mock_session(monkeypatch, requests_mock):
 
     import requests
 
-    _THREADLOCAL.session = None
+    before = getattr(_THREADLOCAL, "sessions", {})
+    try:
+        delattr(_THREADLOCAL, "sessions")
+    except AttributeError:
+        pass
 
-    def mock_session(self):
+    def mock_make_session(self, issuer_id):
         return requests.Session()
 
-    monkeypatch.setattr(SessionManager, "session", property(mock_session))
+    monkeypatch.setattr(SessionManager, "_make_session", mock_make_session)
 
     yield requests_mock
 
-    _THREADLOCAL.session = None
+    _THREADLOCAL.sessions = before
 
 
 @pytest.fixture

--- a/tests/data/test_wallet_google_plugins/plugins.py
+++ b/tests/data/test_wallet_google_plugins/plugins.py
@@ -45,15 +45,15 @@ class TestCallbackHandler:
         raise ValueError("test case errors if nonce is 0")
 
 
-class TestCredentialProvider:
+class TestCredentialsProvider:
     """
-    Implementation of edutap.wallet_google.protocols.CredentialProvider
+    Implementation of edutap.wallet_google.protocols.CredentialsProvider
 
     Used in tests to simulate a crednetial providertox -e lint
      and possible errors.
     """
 
-    def credential_for_issuer(self, issuer_id: str) -> str:
+    def credentials_for_issuer(self, issuer_id: str) -> str:
         # return some predictable data for unit testing
         if issuer_id == "OK":
             return "{}"

--- a/tests/data/test_wallet_google_plugins/plugins.py
+++ b/tests/data/test_wallet_google_plugins/plugins.py
@@ -1,4 +1,5 @@
 from edutap.wallet_google.models.handlers import ImageData
+from time import sleep
 
 import asyncio
 
@@ -42,3 +43,24 @@ class TestCallbackHandler:
         elif nonce:
             return
         raise ValueError("test case errors if nonce is 0")
+
+
+class TestCredentialProvider:
+    """
+    Implementation of edutap.wallet_google.protocols.CredentialProvider
+
+    Used in tests to simulate a crednetial providertox -e lint
+     and possible errors.
+    """
+
+    def credential_for_issuer(self, issuer_id: str) -> str:
+        # return some predictable data for unit testing
+        if issuer_id == "OK":
+            return "{}"
+        if issuer_id == "ERROR":
+            raise LookupError("Image not found.")
+        if issuer_id == "CANCEL":
+            raise LookupError("Cancelled")
+        if issuer_id == "TIMEOUT":
+            sleep(0.5)
+        raise Exception("Unexpected issuer_id")

--- a/tests/data/test_wallet_google_plugins/plugins.py
+++ b/tests/data/test_wallet_google_plugins/plugins.py
@@ -53,14 +53,14 @@ class TestCredentialsProvider:
      and possible errors.
     """
 
-    def credentials_for_issuer(self, issuer_id: str) -> str:
+    def credentials_for_issuer(self, issuer_id: str) -> dict:
         # return some predictable data for unit testing
         if issuer_id == "OK":
-            return "{}"
+            return {}
         if issuer_id == "ERROR":
-            raise LookupError("Image not found.")
+            raise LookupError("Credentials not found.")
         if issuer_id == "CANCEL":
             raise LookupError("Cancelled")
         if issuer_id == "TIMEOUT":
             sleep(0.5)
-        raise Exception("Unexpected issuer_id")
+        raise LookupError("Unexpected issuer_id")

--- a/tests/data/test_wallet_google_plugins/pyproject.toml
+++ b/tests/data/test_wallet_google_plugins/pyproject.toml
@@ -5,4 +5,4 @@ version = "1.0"
 [project.entry-points.'edutap.wallet_google.plugins']
 ImageProvider = 'plugins:TestImageProvider'
 CallbackHandler = 'plugins:TestCallbackHandler'
-CredentialProvider = 'plugins:TestCredentialProvider'
+CredentialsProvider = 'plugins:TestCredentialsProvider'

--- a/tests/data/test_wallet_google_plugins/pyproject.toml
+++ b/tests/data/test_wallet_google_plugins/pyproject.toml
@@ -5,3 +5,4 @@ version = "1.0"
 [project.entry-points.'edutap.wallet_google.plugins']
 ImageProvider = 'plugins:TestImageProvider'
 CallbackHandler = 'plugins:TestCallbackHandler'
+CredentialProvider = 'plugins:TestCredentialProvider'

--- a/tests/test_api_save_link.py
+++ b/tests/test_api_save_link.py
@@ -71,12 +71,14 @@ def test_create_claims():
     assert expected == dumped
 
 
-def test_api_save_link(mock_settings):
+def test_api_save_link():
     from edutap.wallet_google.settings import ROOT_DIR
 
-    mock_settings.credentials_file = (
-        ROOT_DIR / "tests" / "data" / "credentials_fake.json"
-    )
+    import json
+
+    credentials_file = ROOT_DIR / "tests" / "data" / "credentials_fake.json"
+    with open(credentials_file) as fd:
+        credentials = json.load(fd)
 
     from edutap.wallet_google import api
 
@@ -98,6 +100,7 @@ def test_api_save_link(mock_settings):
             ),
         ],
         iat=datetime.datetime(2025, 1, 22, 10, 20, 0, 0, datetime.timezone.utc),
+        credentials=credentials,
     )
     expected = "https://pay.google.com/gp/v/save/eyJ0eXAiOiAiSldUIiwgImFsZyI6ICJSUzI1NiIsICJraWQiOiAiMTIzNDU2Nzg5MGFiY2RlZjEyMzQ1Njc4OTBhYmNkZWYxMjM0NTY3OCJ9.eyJpc3MiOiAiZWR1dGFwLXRlc3QtZXhhbXBsZUBzb2RpdW0tcmF5LTEyMzQ1Ni5pYW0uZ3NlcnZpY2VhY2NvdW50LmNvbSIsICJhdWQiOiAiZ29vZ2xlIiwgInR5cCI6ICJzYXZldG93YWxsZXQiLCAiaWF0IjogIjE3Mzc1NDEyMDAiLCAicGF5bG9hZCI6IHsib2ZmZXJPYmplY3RzIjogW3siaWQiOiAiMTIzNDU2Nzg5MDEyMzQ1Njc4OS50ZXN0LTIuZWR1dGFwLmV1IiwgImNsYXNzSWQiOiAiMTIzNDU2Nzg5MDEyMzQ1Njc4OS50ZXN0LWNsYXNzLTEuZWR1dGFwLmV1IiwgInN0YXRlIjogIlNUQVRFX1VOU1BFQ0lGSUVEIiwgImhhc0xpbmtlZERldmljZSI6IGZhbHNlLCAiZGlzYWJsZUV4cGlyYXRpb25Ob3RpZmljYXRpb24iOiBmYWxzZSwgIm5vdGlmeVByZWZlcmVuY2UiOiAiTk9USUZJQ0FUSU9OX1NFVFRJTkdTX0ZPUl9VUERBVEVTX1VOU1BFQ0lGSUVEIn1dLCAiZ2VuZXJpY09iamVjdHMiOiBbeyJpZCI6ICIxMjM0NTY3ODkwMTIzNDU2Nzg5LnRlc3QtMS5lZHV0YXAuZXUifV19LCAib3JpZ2lucyI6IFtdLCAiZXhwIjogIiJ9.M5rHck9hIZOCHyIb9waDHsVHIzIQD-Hle4EK-BJYaRnGWeAnG2Gq9jxG9anBWlujRoqwFBsKozaHagGB9AyzpVDbfPJPY7Zm2jRwhe76zzmkSruEr25H1hf_OMxZgpUoyatASikANPPBrayA9-D9nuNThbNCOuSmwFXv4iDdxHHfCzq0iEKiPvw_6fePF7bdPnkv1uE0GA5rseM2olJ830U7xB7wuw7SA84OPoRclMiCvl3RjisTE2PfrkZ0sJlbxM16-aMkAQ-FxlERLoxkeWgSA2yYXuqjEdH0TVbg_b4tGKgQkTXo2TxhaVam4ZqdjYzTkgu9oesPVVae8ZgEtQ"
     assert link == expected

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -21,13 +21,13 @@ def test_get_callback_handlers():
     assert isinstance(plugins[0], CallbackHandler)
 
 
-def test_get_credential_providers():
-    from edutap.wallet_google.plugins import get_credential_providers
-    from edutap.wallet_google.protocols import CredentialProvider
+def test_get_credentials_providers():
+    from edutap.wallet_google.plugins import get_credentials_providers
+    from edutap.wallet_google.protocols import CredentialsProvider
 
-    plugins = get_credential_providers()
+    plugins = get_credentials_providers()
     assert len(plugins) == 1
-    assert isinstance(plugins[0], CredentialProvider)
+    assert isinstance(plugins[0], CredentialsProvider)
 
 
 def test_get_callback_handlers_empty(monkeypatch):
@@ -103,8 +103,8 @@ class DummyCallbackHandler:
     ) -> None: ...
 
 
-class DummyCredentialProvider:
-    def credential_for_issuer(self, issuer_id: str) -> str:
+class DummyCredentialsProvider:
+    def credentials_for_issuer(self, issuer_id: str) -> str:
         raise NotImplementedError
 
 
@@ -114,16 +114,16 @@ def test_add_plugin():
     """
     from edutap.wallet_google.plugins import add_plugin
     from edutap.wallet_google.plugins import get_callback_handlers
-    from edutap.wallet_google.plugins import get_credential_providers
+    from edutap.wallet_google.plugins import get_credentials_providers
     from edutap.wallet_google.plugins import get_image_providers
 
     count_image_providers = len(get_image_providers())
     count_callback_handlers = len(get_callback_handlers())
-    count_credential_providers = len(get_credential_providers())
+    count_credentials_providers = len(get_credentials_providers())
 
     add_plugin("ImageProvider", DummyImageProvider)
     add_plugin("CallbackHandler", DummyCallbackHandler)
-    add_plugin("CredentialProvider", DummyCredentialProvider)
+    add_plugin("CredentialsProvider", DummyCredentialsProvider)
 
     with pytest.raises(TypeError):
         add_plugin("CallbackHandler", DummyImageProvider)
@@ -136,6 +136,6 @@ def test_add_plugin():
     assert len(plugins) == 1 + count_callback_handlers
     assert isinstance(plugins[-1], DummyCallbackHandler)
 
-    plugins = get_credential_providers()
-    assert len(plugins) == 1 + count_credential_providers
-    assert isinstance(plugins[-1], DummyCredentialProvider)
+    plugins = get_credentials_providers()
+    assert len(plugins) == 1 + count_credentials_providers
+    assert isinstance(plugins[-1], DummyCredentialsProvider)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -21,6 +21,15 @@ def test_get_callback_handlers():
     assert isinstance(plugins[0], CallbackHandler)
 
 
+def test_get_credential_providers():
+    from edutap.wallet_google.plugins import get_credential_providers
+    from edutap.wallet_google.protocols import CredentialProvider
+
+    plugins = get_credential_providers()
+    assert len(plugins) == 1
+    assert isinstance(plugins[0], CredentialProvider)
+
+
 def test_get_callback_handlers_empty(monkeypatch):
     from edutap.wallet_google.plugins import get_callback_handlers
 
@@ -94,19 +103,27 @@ class DummyCallbackHandler:
     ) -> None: ...
 
 
-def test_add_plugin(monkeypatch):
+class DummyCredentialProvider:
+    def credential_for_issuer(self, issuer_id: str) -> str:
+        raise NotImplementedError
+
+
+def test_add_plugin():
     """
     test adding plugins at runtime
     """
     from edutap.wallet_google.plugins import add_plugin
     from edutap.wallet_google.plugins import get_callback_handlers
+    from edutap.wallet_google.plugins import get_credential_providers
     from edutap.wallet_google.plugins import get_image_providers
 
     count_image_providers = len(get_image_providers())
     count_callback_handlers = len(get_callback_handlers())
+    count_credential_providers = len(get_credential_providers())
 
     add_plugin("ImageProvider", DummyImageProvider)
     add_plugin("CallbackHandler", DummyCallbackHandler)
+    add_plugin("CredentialProvider", DummyCredentialProvider)
 
     with pytest.raises(TypeError):
         add_plugin("CallbackHandler", DummyImageProvider)
@@ -118,3 +135,7 @@ def test_add_plugin(monkeypatch):
     plugins = get_callback_handlers()
     assert len(plugins) == 1 + count_callback_handlers
     assert isinstance(plugins[-1], DummyCallbackHandler)
+
+    plugins = get_credential_providers()
+    assert len(plugins) == 1 + count_credential_providers
+    assert isinstance(plugins[-1], DummyCredentialProvider)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -42,12 +42,12 @@ def test_session_manager_url(
 def test_session_creation(monkeypatch, clean_session_threadlocals):
     from edutap.wallet_google.session import SessionManager
 
-    def mock_get_credential_providers():
+    def mock_get_credentials_providers():
         raise NotImplementedError()
 
     monkeypatch.setattr(
-        "edutap.wallet_google.session.get_credential_providers",
-        mock_get_credential_providers,
+        "edutap.wallet_google.session.get_credentials_providers",
+        mock_get_credentials_providers,
     )
 
     monkeypatch.setenv(
@@ -86,24 +86,28 @@ def test_session_creation(monkeypatch, clean_session_threadlocals):
 def test_session_creation_with_provider(monkeypatch, clean_session_threadlocals):
     from edutap.wallet_google.session import SessionManager
 
-    class MockCredentialProvider:
+    class MockCredentialsProvider:
 
-        def credential_for_issuer(self, issuer_id: str) -> str:
+        def credentials_for_issuer(self, issuer_id: str) -> str:
             with (ROOT_DIR / "tests" / "data" / "credentials_fake.json").open(
                 "r"
             ) as fd:
                 return fd.read()
 
-    def mock_get_credential_providers():
-        return [MockCredentialProvider()]
+    def mock_get_credentials_providers():
+        return [MockCredentialsProvider()]
 
     monkeypatch.setattr(
-        "edutap.wallet_google.session.get_credential_providers",
-        mock_get_credential_providers,
+        "edutap.wallet_google.session.get_credentials_providers",
+        mock_get_credentials_providers,
     )
 
     manager = SessionManager()
-    session = manager.session("dummy-issuer")
+    session = manager.session(credentials={
+        "private_key_id": "dummy-key-id",
+        'client_email': "dummy@tld.net",
+        'token_uri': "http://token-uri",
+    })
     assert session is not None
 
 
@@ -112,17 +116,17 @@ def test_session_creation_with_provider_none_found(
 ):
     from edutap.wallet_google.session import SessionManager
 
-    class MockCredentialProvider:
+    class MockCredentialsProvider:
 
-        def credential_for_issuer(self, issuer_id: str) -> str:
+        def credentials_for_issuer(self, issuer_id: str) -> str:
             raise LookupError()
 
-    def mock_get_credential_providers():
-        return [MockCredentialProvider()]
+    def mock_get_credentials_providers():
+        return [MockCredentialsProvider()]
 
     monkeypatch.setattr(
-        "edutap.wallet_google.session.get_credential_providers",
-        mock_get_credential_providers,
+        "edutap.wallet_google.session.get_credentials_providers",
+        mock_get_credentials_providers,
     )
 
     manager = SessionManager()
@@ -134,12 +138,12 @@ def test_session_with_HTTPRecorder(tmp_path, monkeypatch):
     from edutap.wallet_google.session import _THREADLOCAL
     from edutap.wallet_google.session import SessionManager
 
-    def mock_get_credential_providers():
+    def mock_get_credentials_providers():
         raise NotImplementedError()
 
     monkeypatch.setattr(
-        "edutap.wallet_google.session.get_credential_providers",
-        mock_get_credential_providers,
+        "edutap.wallet_google.session.get_credentials_providers",
+        mock_get_credentials_providers,
     )
 
     delattr(_THREADLOCAL, "sessions")


### PR DESCRIPTION
The session credentials file (IAM authentication file for the Google Service Account) was static. Thus we were not able to serve multiple clients within one usage of this library. For security reason one should use for each environment a different Service Account.

To get dynamic credential-data a new protocol CredentialProvider was introduced using the same plugin mechanism as already known from the image handler and pass data provider.  Any integration now can provide such an provider and lookup a credential file by issuer_id.

If there is no provider configured, fall back to fetch credentials from settings.

Additional we provide a method to directly pass the credentials (as parsed dictionary) to the API methods (`api.py`). If passed in, provider an fallback are bypassed.

The session was refactored to reflect this. Since we use AuthorizedSession each issuer now gets its own session  per thread. Integrators need to take care to not explode the number of sessions. 