### PR TITLE
delegate the max-age of a specific image to the image plugin

### DIFF
--- a/src/edutap/wallet_google/handlers/fastapi.py
+++ b/src/edutap/wallet_google/handlers/fastapi.py
@@ -135,10 +135,13 @@ async def handle_image(request: Request, encrypted_image_id: str):
         raise HTTPException(
             status_code=500, detail="Error while handling the image (exception)."
         )
+    cache_control = session_manager.settings.handler_image_cache_control.format(
+        max_age=result.max_age
+    )
     return Response(
         content=result.data,
         media_type=result.mimetype,
-        headers={"Cache-Control": session_manager.settings.handler_image_cache_control},
+        headers={"Cache-Control": cache_control},
     )
 
 

--- a/src/edutap/wallet_google/models/handlers.py
+++ b/src/edutap/wallet_google/models/handlers.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 class ImageData(BaseModel):
     mimetype: str
     data: bytes
+    max_age: int = 86400  # in seconds, default 24h
 
 
 #  Callback

--- a/src/edutap/wallet_google/settings.py
+++ b/src/edutap/wallet_google/settings.py
@@ -40,7 +40,9 @@ class Settings(BaseSettings):
     handler_prefix_callback: str = ""
     handler_prefix_images: str = ""
     handler_callback_verify_signature: str = "1"
-    handler_image_cache_control: str = "no-cache"
+    handler_image_cache_control: str = (
+        "no-cache"  # "no-cache", "public, immutable, max-age={max_age}", etc.
+    )
     handlers_callback_timeout: float = 5.0
     handlers_image_timeout: float = 5.0
 


### PR DESCRIPTION
Caching images needs primary control over the max-age from the plugin implementation. This i.e. depends if the image is from the template, more static one or if it is a portrait, how often passes are updated and so on.

With this change the  `ImageData` contains a field `max_age` which is applied as a format parameter to the cache header string provided by the settings `handler_image_cache_control`.