### PR TITLE
chore: migrate save_link JWT signing from authlib.jose to joserfc

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,10 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "authlib",
+    "authlib>=1.7.2",
     "cryptography",
     "httpx",
+    "joserfc",
     "pydantic-settings",
     "pydantic[email]>=2.0",
   ]

--- a/src/edutap/wallet_google/api.py
+++ b/src/edutap/wallet_google/api.py
@@ -52,7 +52,8 @@ from .utils import handle_response_errors
 from .utils import parse_response_json
 from .utils import validate_data
 from .utils import validate_data_and_convert_to_json
-from authlib.jose import jwt
+from joserfc import jwt
+from joserfc.jwk import RSAKey
 from collections.abc import AsyncGenerator
 from collections.abc import Generator
 
@@ -226,9 +227,9 @@ def save_link(
         exclude_none=True,
     )
 
-    # authlib's jwt.encode returns bytes
-    jwt_bytes = jwt.encode(header, payload, credentials["private_key"])
-    jwt_string = jwt_bytes.decode("utf-8")
+    # joserfc.jwt.encode requires a typed Key and returns a str
+    private_key = RSAKey.import_key(credentials["private_key"])
+    jwt_string = jwt.encode(header, payload, private_key)
 
     logger.debug(jwt_string)
     if (jwt_len := len(jwt_string)) >= 1800:

--- a/src/edutap/wallet_google/api.py
+++ b/src/edutap/wallet_google/api.py
@@ -52,10 +52,10 @@ from .utils import handle_response_errors
 from .utils import parse_response_json
 from .utils import validate_data
 from .utils import validate_data_and_convert_to_json
-from joserfc import jwt
-from joserfc.jwk import RSAKey
 from collections.abc import AsyncGenerator
 from collections.abc import Generator
+from joserfc import jwt
+from joserfc.jwk import RSAKey
 
 import datetime
 import json


### PR DESCRIPTION
## Summary

- Swap `authlib.jose.jwt` for `joserfc.jwt` in `save_link` (the only user of `authlib.jose` in this package). joserfc is the successor library authlib itself delegates to as of 1.7.
- Add `joserfc` to `dependencies`; bump the `authlib` floor to `>=1.7.2` so its `_joserfc_helpers` module stops top-level-importing `authlib.jose` (and stops emitting its own deprecation warning).
- Keep `authlib` in dependencies — `clientpool.py` still uses `authlib.integrations.httpx_client`.

## Notes for reviewers

`joserfc.jwt.encode` differs from `authlib.jose.jwt.encode` in two small ways:

- it wants a typed key (`RSAKey.import_key(pem)` here) instead of a raw PEM string
- it returns `str` rather than `bytes`, so the surrounding `.decode("utf-8")` is removed

`tests/test_api_jwt.py::test_api_save_link` exercises the full path with the fake-credentials fixture and verifies the resulting header/payload/signature structure; that test passes unchanged.

## Test plan

- [x] `pytest tests/test_api_jwt.py` — all 7 tests pass
- [ ] CI green on the PR