### PR TITLE
fix(ci): split release concurrency group by event_name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,8 +10,13 @@
           - published
       workflow_dispatch:
 
+    # Without ``github.event_name`` in the group, the ``push`` event fired
+    # by tagging a release and the ``release`` event fired by publishing
+    # it land in the same group. ``cancel-in-progress: true`` then kills
+    # whichever arrived second — typically the ``release`` run that
+    # uploads to pypi.org, leaving the tag unpublished.
     concurrency:
-      group: release-${{ github.ref }}
+      group: release-${{ github.ref }}-${{ github.event_name }}
       cancel-in-progress: true
 
     jobs:


### PR DESCRIPTION
## Summary

Tagging and publishing a GitHub release fires two workflow runs against the same `github.ref`:

- `push` event from the tag itself
- `release` event from the published release

With the previous concurrency group keyed solely on `github.ref`, `cancel-in-progress: true` cancelled whichever of the two arrived second. On the `v3.0.0b2` release this killed the `release` run that uploads to pypi.org, so the tag is published on GitHub but the package never reached PyPI.

Include `github.event_name` in the group so the two runs sit in independent slots and both can complete.

## Test plan

- [ ] Next published release uploads to PyPI without the parallel push run cancelling it
- [ ] Existing push-on-main → test.pypi.org path keeps working

## Notes

`v3.0.0b2` still needs to be re-published manually after this lands, since the original run that would have uploaded it was cancelled.