### PR TITLE
chore: modernise packaging, tooling and linter configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,32 @@ exclude: ^worktrees/
 ci:
     autofix_prs: false
     autoupdate_schedule: monthly
-    skip: [check-manifest, pyroma]
+    # ty is skipped here for a measured reason, not out of caution — please do
+    # not quietly drop it from this list.
+    #
+    # The ty-pre-commit hook's entry is
+    #   uv check --quiet --preview-features=check-command --ty-version=0.0.66
+    # and `uv check` builds the project, which resolves `build-system.requires`
+    # against PyPI. pre-commit.ci disables network access while hooks run, so
+    # the build cannot resolve and the hook fails before ty ever type-checks
+    # anything. Observed on PR #96, where it was tested deliberately:
+    #
+    #   × Failed to build `edutap-wallet-google @ file:///code`
+    #     ├─▶ Failed to resolve requirements from `build-system.requires`
+    #     ├─▶ No solution found when resolving: `hatchling>=1.27.0`, `hatch-vcs>=0.5.0`
+    #     ╰─▶ dns error: Temporary failure in name resolution
+    #
+    # Every other hook passed in that run. This is architectural, not a timeout
+    # and not a version problem: no pin or rev bump fixes it, because the runner
+    # has no network by design.
+    #
+    # ty is NOT unchecked as a result. It runs in the GitHub Actions `lint` job
+    # via `tox -e lint` (verified passing at v0.0.66 on PR #96) and locally via
+    # `make lint` and `prek run -a`. Only the pre-commit.ci execution is skipped,
+    # while `rev:` on the hook below stays inside pre-commit.ci's monthly
+    # autoupdate — which is the reason it became a remote hook in the first
+    # place.
+    skip: [check-manifest, pyroma, ty]
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: ^worktrees/
 ci:
     autofix_prs: false
     autoupdate_schedule: monthly
-    skip: [check-manifest, pyroma, ty]
+    skip: [check-manifest, pyroma]
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -21,14 +21,10 @@ repos:
     -   id: ruff
         args: [--fix]
     -   id: ruff-format
--   repo: local
+-   repo: https://github.com/astral-sh/ty-pre-commit
+    rev: v0.0.66
     hooks:
     -   id: ty
-        name: ty type check
-        entry: uvx ty@0.0.17 check
-        language: system
-        types: [python]
-        pass_filenames: false
 -   repo: https://github.com/codespell-project/codespell
     rev: v2.4.3
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,12 +41,18 @@ repos:
     - id: end-of-file-fixer
     - id: trailing-whitespace
 -   repo: https://github.com/astral-sh/ruff-pre-commit
+    # Cross-referenced with the ruff floor/ceiling in pyproject.toml's
+    # dependency-groups.lint, and checked against it by
+    # tests/test_tool_version_pins.py — update both together.
     rev: v0.16.1
     hooks:
     -   id: ruff
         args: [--fix]
     -   id: ruff-format
 -   repo: https://github.com/astral-sh/ty-pre-commit
+    # Cross-referenced with the ty floor/ceiling in pyproject.toml's
+    # dependency-groups.typecheck, and checked against it by
+    # tests/test_tool_version_pins.py — update both together.
     rev: v0.0.66
     hooks:
     -   id: ty

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ pytest -k "not integration" --tb=short  # Skip integration tests
 
 ```bash
 # Run all pre-commit hooks (includes all checks below)
-uvx pre-commit run --all-files
+uvx prek run --all-files
 
 # Format code (tox environment)
 uvx tox -e format
@@ -233,10 +233,10 @@ The docs follow the [Diátaxis](https://diataxis.fr/) framework.
 ## Development Workflow
 
 1. **Local setup**: `uv venv && source .venv/bin/activate && uv pip install -U -e ".[callback]" --group dev` (or `make venv`)
-2. **Install pre-commit**: `uvx pre-commit install` (runs checks on every commit)
+2. **Install prek**: `uvx prek install` (runs checks on every commit)
 3. **Make changes**: Edit code, add tests
 4. **Run tests**: `pytest tests/ -k "not integration"` (fast iteration)
-5. **Run checks**: `uvx pre-commit run --all-files` (before committing)
+5. **Run checks**: `uvx prek run --all-files` (before committing)
 6. **Integration test**: Set environment variables and run `pytest tests/integration/ --run-integration`
 
 ## Code Quality Tools

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,9 +18,7 @@ The package provides:
 Install with uv (preferred):
 - `uv pip install edutap.wallet_google` - Base package with both sync and async APIs (authlib + httpx)
 - `uv pip install edutap.wallet_google[callback]` - Adds FastAPI for callback endpoints
-- `uv pip install edutap.wallet_google[test]` - Adds pytest, respx, and testing tools
-- `uv pip install edutap.wallet_google[typecheck]` - Adds ty type checker
-- `uv pip install edutap.wallet_google[develop]` - Adds pdbp debugger for development
+- For development, use the `dev` dependency group instead of extras: `uv pip install -U -e ".[callback]" --group dev` (or `make venv`) adds pytest, respx, ty and pdbp. The `[test]`, `[typecheck]` and `[develop]` extras no longer exist.
 
 ## Development Commands
 
@@ -43,7 +41,7 @@ uvx tox -e py313 -- --cov=src/edutap/wallet_google --cov-report=term-missing
 uvx tox -e py313 -- tests/integration/ -v --run-integration
 
 # Fast iteration: Run tests directly (no tox overhead)
-# First: uv venv && source .venv/bin/activate && uv pip install -e .[test,develop]
+# First: uv venv && source .venv/bin/activate && uv pip install -U -e ".[callback]" --group dev
 pytest tests/test_api_sync.py -v
 pytest tests/test_api_async.py::test_acreate -v --tb=short
 pytest -k "not integration" --tb=short  # Skip integration tests
@@ -234,7 +232,7 @@ The docs follow the [Diátaxis](https://diataxis.fr/) framework.
 
 ## Development Workflow
 
-1. **Local setup**: `uv venv && source .venv/bin/activate && uv pip install -e .[test,develop,typecheck]`
+1. **Local setup**: `uv venv && source .venv/bin/activate && uv pip install -U -e ".[callback]" --group dev` (or `make venv`)
 2. **Install pre-commit**: `uvx pre-commit install` (runs checks on every commit)
 3. **Make changes**: Edit code, add tests
 4. **Run tests**: `pytest tests/ -k "not integration"` (fast iteration)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,19 @@ This approach minimizes duplicates, streamlines issue management, and saves time
 
 Use the issue template addressing your problem.
 
+## Common tasks
+
+    make help              # list every target
+    make venv              # create .venv and install the package for development
+    make lint              # ruff check, ruff format --check, ty check
+    make reformat          # ruff format and ruff check --fix
+    make test-local        # the unit suite
+    make test-matrix       # the full tox matrix, py310 through py314
+
+`make test-integration` runs against the real Google Wallet API. It needs
+credentials and it creates objects that cannot be deleted; read
+`tests/integration/` before running it.
+
 ## Pull Requests
 
 First check if someone else already created a pull request solving your problem.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,0 @@
-recursive-include tests *.json *.py
-recursive-exclude docs *
-recursive-exclude .claude *
-exclude .git

--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,9 @@ lint: venv ## Run ruff checks and the type checker
 	$(PYTHON) -m ruff format --check src tests
 	# Runs the ty pinned in the typecheck dependency group, installed into
 	# .venv by the venv target above — not an unpinned `uvx ty check`, which
-	# would resolve to whatever the latest release happens to be. The local
-	# pre-commit hook currently pins a different, older ty
-	# (.pre-commit-config.yaml: ty@0.0.17); bringing the two into agreement
-	# is Task 3's job, not this target's.
+	# would resolve to whatever the latest release happens to be. Keep the
+	# pin in sync with rev: on the ty hook in .pre-commit-config.yaml, so
+	# this target and CI report the same thing.
 	$(PYTHON) -m ty check
 
 reformat: venv ## Autoformat and autofix

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+# Tools run from .venv, not through `uv run`: this package declares an entry point
+# group that uv resolves against the whole environment, and a bare `uv run` can fail
+# in a checkout where sibling eduTAP packages are not installed.
+PYTHON := .venv/bin/python
+VENV   := .venv
+
+.DEFAULT_GOAL := help
+.PHONY: help venv lint reformat test-local test-integration test-matrix
+
+help: ## Show available targets
+	@grep -hE '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) \
+		| awk -F':.*?## ' '{printf "  %-18s %s\n", $$1, $$2}'
+
+venv: ## Create .venv and install the package with the callback extra and dev group
+	test -d $(VENV) || uv venv
+	uv pip install -U -e ".[callback]" --group dev
+
+lint: venv ## Run ruff checks and the type checker
+	$(PYTHON) -m ruff check src tests
+	$(PYTHON) -m ruff format --check src tests
+	uvx ty check
+
+reformat: venv ## Autoformat and autofix
+	$(PYTHON) -m ruff format src tests
+	$(PYTHON) -m ruff check --fix src tests
+
+test-local: venv ## Unit tests, no Google credentials needed
+	$(PYTHON) -m pytest
+
+test-integration: venv ## Tests against the real Google Wallet API, needs credentials
+	$(PYTHON) -m pytest --run-integration
+
+test-matrix: venv ## The full tox matrix, py310 through py314
+	uvx --with "tox-uv,tox-gh" tox

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,13 @@ venv: ## Create .venv and install the package with the callback extra and dev gr
 lint: venv ## Run ruff checks and the type checker
 	$(PYTHON) -m ruff check src tests
 	$(PYTHON) -m ruff format --check src tests
-	uvx ty check
+	# Runs the ty pinned in the typecheck dependency group, installed into
+	# .venv by the venv target above — not an unpinned `uvx ty check`, which
+	# would resolve to whatever the latest release happens to be. The local
+	# pre-commit hook currently pins a different, older ty
+	# (.pre-commit-config.yaml: ty@0.0.17); bringing the two into agreement
+	# is Task 3's job, not this target's.
+	$(PYTHON) -m ty check
 
 reformat: venv ## Autoformat and autofix
 	$(PYTHON) -m ruff format src tests

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,19 @@ venv: ## Create .venv and install the package with the callback extra and dev gr
 	uv pip install -U -e ".[callback]" --group dev
 
 lint: venv ## Run ruff checks and the type checker
-	$(PYTHON) -m ruff check src tests
+	# Whole repository, matching `prek run -a` and the CI lint job (both run
+	# every hook over every tracked file) — commit 59620c2 is proof this and
+	# CI already diverged once on examples/, which `src tests` does not cover.
+	$(PYTHON) -m ruff check .
+	# Deliberately still scoped to src tests, NOT widened to match the check
+	# above. `ruff format .` also formats Python code blocks embedded in
+	# Markdown (CLAUDE.md, README.md, docs/tutorials.md all have some) as of
+	# ruff 0.16, but the ruff-format pre-commit hook only ever receives
+	# python/pyi/jupyter files (its `types_or`), so CI never format-checks
+	# those three files and would not fail if they drifted. Widening this to
+	# `.` would make `make lint` stricter than CI, not equal to it, and would
+	# need those three docs reformatted as a one-off side effect unrelated to
+	# any code change. Revisit deliberately, in its own commit, if wanted.
 	$(PYTHON) -m ruff format --check src tests
 	# Runs the ty pinned in the typecheck dependency group, installed into
 	# .venv by the venv target above — not an unpinned `uvx ty check`, which

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,14 +12,18 @@ The version is automatically derived from Git tags using `hatch-vcs`:
 
 ## Creating a Release
 
-1. Ensure all changes are merged to `main` and CI is green
-2. Go to [GitHub Releases](https://github.com/edutap-eu/edutap.wallet_google/releases)
-3. Click "Draft a new release"
-4. Click "Choose a tag" and **type a new tag** (e.g., `v0.5.0`, `v1.0.0a1`)
-5. Select "Create new tag on publish"
-6. Target: `main` branch
-7. Generate release notes or write them manually
-8. Click "Publish release"
+1. Check whether any supported Python version has reached end of life
+   (<https://endoflife.date/python>). Dropping one narrows `requires-python`
+   and is a breaking change: it needs its own release and a note in the
+   release description, not a quiet ride along with other work.
+2. Ensure all changes are merged to `main` and CI is green
+3. Go to [GitHub Releases](https://github.com/edutap-eu/edutap.wallet_google/releases)
+4. Click "Draft a new release"
+5. Click "Choose a tag" and **type a new tag** (e.g., `v0.5.0`, `v1.0.0a1`)
+6. Select "Create new tag on publish"
+7. Target: `main` branch
+8. Generate release notes or write them manually
+9. Click "Publish release"
 
 The release workflow will automatically:
 - Run all tests

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -69,7 +69,7 @@ with environment `release-test-pypi`.
 The `_version.py` file is not generated. Run:
 
 ```bash
-uv sync  # or uv pip install -e .
+uv pip install -e .
 ```
 
 ### Package not uploading

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,7 +2,7 @@
 
 ## Preconditions
 
-Python 3.10+, currently up to 3.13 is tested.
+Python 3.10+, currently up to 3.14 is tested.
 Version 3.13 is recommended.
 
 ## Installation
@@ -196,6 +196,27 @@ Google API URLs, normally not subject of change:
 
 ## Development
 
+In a clone of the repository, create the development environment with `make venv`, which
+runs `uv venv` followed by `uv pip install -U -e ".[callback]" --group dev` — the extra
+this package's consumers install, plus the `dev` dependency group (tests, linting, type
+checking):
+
+```bash
+make venv
+```
+
+The common tasks are all `make` targets:
+
+```text
+make help              # list every target
+make venv              # create .venv and install the package for development
+make lint              # ruff check, ruff format --check, ty check
+make reformat          # ruff format and ruff check --fix
+make test-local        # the unit suite
+make test-integration  # against the real Google Wallet API, needs credentials
+make test-matrix       # the full tox matrix, py310 through py314
+```
+
 ### Running the tests
 
 Copy the value of the above remembered Issuer Id and point the environment variable `EDUTAP_WALLET_GOOGLE_TEST_ISSUER_ID` to it. Example:
@@ -204,24 +225,30 @@ Copy the value of the above remembered Issuer Id and point the environment varia
 export EDUTAP_WALLET_GOOGLE_TEST_ISSUER_ID=1234567890123456789
 ```
 
-In a clone of the repository:
-
 Run unit tests:
 
 ```bash
-uvx --with tox-uv tox -e test
+make test-local
 ```
 
 Run integration tests:
 
 ```bash
-uvx --with tox-uv tox -e test -- --run-integration
+make test-integration
 ```
 
 Format code and run checks:
 
 ```bash
-uvx --with tox-uv tox -e lint
+make reformat
+make lint
+```
+
+To run the suite against every supported Python version instead of just the one `.venv`
+uses, run the full tox matrix:
+
+```bash
+make test-matrix
 ```
 
 ### Debugging

--- a/examples/edutap_wallet_google_example_callback/edutap_wallet_google_example_callback.py
+++ b/examples/edutap_wallet_google_example_callback/edutap_wallet_google_example_callback.py
@@ -11,9 +11,7 @@ app.include_router(router_callback)
 
 
 class LoggingCallbackHandler:
-    """
-    Implementation of edutap.wallet_google.protocols.CallbackHandler
-    """
+    """Implementation of edutap.wallet_google.protocols.CallbackHandler."""
 
     async def handle(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,9 +169,41 @@ exclude = ["worktrees/"]
 python-version = "3.10"
 extra-paths = ["src", "tests"]
 
+[tool.ty.terminal]
+# ty exits 1 on warning-level diagnostics by default. Every rule set to "warn"
+# below is one this project has deliberately decided not to block on yet, and a
+# non-zero exit for them makes "warn" mean exactly the same thing as "error" —
+# at which point the downgrades say nothing. The diagnostics are still printed;
+# only the exit code changes, and error-level ones still fail. Configured here
+# rather than as a --exit-zero-on-warning flag, so a bare `ty check` in a
+# terminal, `make lint` and the pre-commit hook all behave the same way.
+error-on-warning = false
+
 [tool.ty.rules]
 unresolved-import = "warn"
-# the following rules are stricter than mypy; downgrade to warnings for now
+# The following rules are stricter than mypy. As of ty 0.0.66 they report
+# nothing at all in src/ — every remaining instance is in tests/ — so this is
+# about how much type discipline the test suite is held to, not the library.
+#
+# unresolved-attribute (71x, all in tests/): the CRUD functions in api.py select
+#   the model class from a runtime registry lookup by string name, so they are
+#   annotated `-> Model` and cannot be narrower. Every test that reads a pass
+#   back and touches a concrete field — `read("EventTicketObject", ...).state` —
+#   is therefore an attribute access on the base class. Narrowing this needs a
+#   different public API shape (Literal overloads, or a model-class-first
+#   variant of read()), which is a design change and not a lint fix.
+# invalid-argument-type (31x, all in tests/): two causes, both test-local.
+#   Fixtures such as `@register_model("Foo", ...) class Foo: pass` in
+#   test_clientpool.py register a plain class that is not a Model subclass — the
+#   registry only stores it, so the tests pass, but the annotation is honest
+#   that this is not what the decorator is for. And test_handler_fastapi.py
+#   feeds hand-written JSON-ish dicts straight into models, so the declared
+#   field types do not match what a `dict[str, str | list[str]]` literal infers.
+#
+# unknown-argument and not-iterable currently report nothing, and unresolved-import
+# only fires where the optional `callback` extra is absent. Left downgraded on
+# purpose: promoting a rule back to error because today's checkout happens to be
+# clean is how a green build turns red on someone else's machine.
 unresolved-attribute = "warn"
 invalid-argument-type = "warn"
 unknown-argument = "warn"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,11 +68,21 @@ Documentation = "https://docs.edutap.eu/packages/edutap_wallet_google/index.html
 [project.optional-dependencies]
 # The only extra a consumer of this library installs. Everything else that used
 # to live here is a dependency group below: groups are not published in the
-# wheel metadata, which is the right place for tooling nobody downstream needs
-# — and, per the spec's Part 5, the right place to give Renovate a version
-# constraint to act on, which none of these had before.
+# wheel metadata, which is the right place for tooling nobody downstream needs.
+#
+# `callback` is different from those groups precisely because it *is*
+# published: every consumer of `edutap.wallet-google[callback]` resolves this
+# entry against their own environment, exactly like the six entries in
+# `[project.dependencies]` (spec's Part 5). It therefore follows that part's
+# rule, not the dependency-groups' rule: a floor only when a real code
+# requirement backs it, no ceiling, and no Renovate `rangeStrategy: "bump"` —
+# bumping this floor on every FastAPI release would force lockstep upgrades on
+# every application that depends on this extra. handlers/fastapi.py imports
+# only APIRouter, Request, Response, HTTPException, JSONResponse and logger,
+# all present since FastAPI's earliest 0.x releases, so no floor is justified
+# here yet. Add one if and when the code actually needs it.
 callback = [
-    "fastapi>=0.141.1",
+    "fastapi",
 ]
 
 [dependency-groups]
@@ -89,10 +99,10 @@ lint = [
     # Ceiling as well as floor: a ruff minor release changes what it reports
     # and reformats files that were correct under the previous one — matches
     # edutap.data_provider's own ruff>=0.16,<0.17, and matches the version
-    # already pinned in .pre-commit-config.yaml (v0.16.1) so the hook and
-    # this group cannot silently disagree. ruff was never a project
-    # dependency before this; it only ran inside pre-commit/prek's own
-    # isolated environment.
+    # already pinned in .pre-commit-config.yaml (v0.16.1) — cross-referenced
+    # there too, and kept honest by tests/test_tool_version_pins.py rather
+    # than by the comment alone. ruff was never a project dependency before
+    # this; it only ran inside pre-commit/prek's own isolated environment.
     "ruff>=0.16.1,<0.17",
 ]
 typecheck = [
@@ -100,7 +110,9 @@ typecheck = [
     # and moves fast enough that Task 3 jumps it 49 releases in one commit.
     # Its releases are all 0.0.x, so there is no separate minor line to float
     # within — the ceiling pins the current release exactly and asks for a
-    # deliberate bump, and a look at what changed, every single time.
+    # deliberate bump, and a look at what changed, every single time. Matches
+    # .pre-commit-config.yaml (v0.0.66), enforced by
+    # tests/test_tool_version_pins.py, not just claimed in this comment.
     "ty>=0.0.66,<0.0.67",
 ]
 dev = [
@@ -118,7 +130,8 @@ generate-fernet-key = "edutap.wallet_google.utils:generate_fernet_key"
 requires = [
     # 1.27.0 is the first hatchling release that builds a PEP 639 license
     # expression as Metadata-Version 2.4 with License-Expression/License-File
-    # fields (Step 2 above). 1.26.x accepts the license-files array syntax
+    # fields, which `license = "EUPL-1.2"` and `license-files` above rely on.
+    # 1.26.x accepts the license-files array syntax
     # without erroring but silently builds Metadata-Version 2.3 with no
     # license fields at all; 1.24.0 and 1.25.0 reject the syntax outright.
     # Verified by building a throwaway package against all four.
@@ -141,8 +154,13 @@ packages = ["src/edutap"]
 # hatchling does not read MANIFEST.in — that is a setuptools file, and an sdist
 # built with it in place still contained docs/ and .claude/, both of which it
 # claimed to exclude. These are the contents on purpose:
-#   tests/ and the Makefile stay, so a distribution packager can run the
-#     suite with `make test-local`.
+#   tests/ and the Makefile stay together: `make test-local` itself needs
+#     network (its `venv` prerequisite runs `uv venv` plus an install), which
+#     a distro packager's sandboxed build usually does not have — but the
+#     Makefile is still the authoritative, minimal reference for which
+#     command runs the suite (`pytest`, see the `test-local` target), so a
+#     packager who already has a populated environment can read it and run
+#     that command directly instead of guessing.
 #   superpowers/, .claude/, CLAUDE.md are internal working documents.
 #   .github/, docs/ and examples/ are not needed to build or test the package.
 include = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,14 +223,14 @@ dependency_groups = ["dev"]
 [tool.tox.env.format]
 description = "automatically reformats code"
 skip_install = true
-deps = ["pre-commit"]
+deps = ["prek"]
 commands = [
-    ["pre-commit", "run", "-a", "ruff"],
-    ["pre-commit", "run", "-a", "ruff-format"],
+    ["prek", "run", "-a", "ruff"],
+    ["prek", "run", "-a", "ruff-format"],
 ]
 
 [tool.tox.env.lint]
 description = "run linters that will help improve the code style"
 skip_install = true
-deps = ["pre-commit"]
-commands = [["pre-commit", "run", "-a"]]
+deps = ["prek"]
+commands = [["prek", "run", "-a"]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,7 +162,8 @@ packages = ["src/edutap"]
 #     packager who already has a populated environment can read it and run
 #     that command directly instead of guessing.
 #   superpowers/, .claude/, CLAUDE.md are internal working documents.
-#   .github/, docs/ and examples/ are not needed to build or test the package.
+#   .github/, docs/, examples/ and renovate.json5 are not needed to build or
+#     test the package.
 include = [
     "/src",
     "/tests",
@@ -305,6 +306,9 @@ ignore = [
     "docs/**",
     "examples/**",
     "superpowers/**",
+    # CI/tooling configuration, same category as .github/: not needed to
+    # build or test the package.
+    "renovate.json5",
 ]
 
 [tool.tox]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,12 +118,14 @@ packages = ["src/edutap"]
 # hatchling does not read MANIFEST.in — that is a setuptools file, and an sdist
 # built with it in place still contained docs/ and .claude/, both of which it
 # claimed to exclude. These are the contents on purpose:
-#   tests/ stays, so a distribution packager can run the suite.
+#   tests/ and the Makefile stay, so a distribution packager can run the
+#     suite with `make test-local`.
 #   superpowers/, .claude/, CLAUDE.md are internal working documents.
 #   .github/, docs/ and examples/ are not needed to build or test the package.
 include = [
     "/src",
     "/tests",
+    "/Makefile",
     "/README.md",
     "/CONTRIBUTING.md",
     "/LICENSE",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,12 @@ authors = [
     {name = "Jens Klein", email = "jk@kleinundpartner.at"},
     {name = "Robert Niederreiter", email = "office@squarewave.at"},
 ]
+# Python 3.10 reaches end of life on 2026-10-31. Dropping it narrows this
+# field, which is a breaking change for consumers, so it gets its own release
+# rather than riding along with something else. Everything that changes with
+# it: requires-python below, the 3.10 classifier, [tool.ruff] target-version,
+# [tool.ty.environment] python-version, [tool.tox] env_list,
+# [tool.tox.gh.python], and the matrix in .github/workflows/tests.yaml.
 requires-python = ">=3.10"
 license = "EUPL-1.2"
 license-files = ["LICENSE"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,12 +174,29 @@ target-version = "py310"
 src = ["src", "tests"]
 
 [tool.ruff.lint]
-select = ["B", "E", "F", "I", "S", "UP", "W"]
-ignore = ["E501"]
+select = ["B", "D", "E", "F", "I", "S", "UP", "W"]
+ignore = [
+    "E501",
+    # The "undocumented public …" rules. 144 findings, every one of which needs
+    # a docstring written rather than a fix applied. Enabling them now would buy
+    # 144 hasty docstrings or a permanent blanket ignore. Write the docstrings,
+    # then delete these lines — not the other way round.
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D104",
+    "D107",
+]
 
 [tool.ruff.lint.per-file-ignores]
 # assert *is* the test framework here; S101 in tests is not a finding.
 "tests/**" = ["S101"]
+
+[tool.ruff.lint.pydocstyle]
+# Also settles the D203/D211 and D212/D213 incompatibilities, which ruff
+# otherwise warns about on every single run.
+convention = "pep257"
 
 [tool.ruff.lint.isort]
 force-single-line = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,13 +11,8 @@ authors = [
     {name = "Robert Niederreiter", email = "office@squarewave.at"},
 ]
 requires-python = ">=3.10"
-license = { text = "EUPL 1.2" }
-# TODO for PEP 639 https://peps.python.org/pep-0639
-# -> when implemented in PyPI, twine, pyroma, etc.
-# add license-expression = EUPL-1.2
-# add license-file = LICENSE
-# remove license field
-# remove License classifier
+license = "EUPL-1.2"
+license-files = ["LICENSE"]
 
 classifiers = [
     "Programming Language :: Python :: 3.10",
@@ -25,7 +20,6 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
-    "License :: OSI Approved :: European Union Public Licence 1.2 (EUPL 1.2)",
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries",
@@ -49,24 +43,48 @@ Issues = "https://github.com/edutap-eu/edutap.wallet_google/issues"
 Documentation = "https://docs.edutap.eu/packages/edutap_wallet_google/index.html"
 
 [project.optional-dependencies]
+# The only extra a consumer of this library installs. Everything else that used
+# to live here is a dependency group below: groups are not published in the
+# wheel metadata, which is the right place for tooling nobody downstream needs
+# — and, per the spec's Part 5, the right place to give Renovate a version
+# constraint to act on, which none of these had before.
 callback = [
-    "fastapi",
+    "fastapi>=0.141.1",
 ]
+
+[dependency-groups]
 test = [
-    "edutap.wallet-google[callback]",
-    "freezegun",
-    "pytest-asyncio",
-    "pytest-cov",
-    "pytest-explicit",
-    "pytest",
-    "respx",
-    "tox",
+    "freezegun>=1.5.5",
+    "pytest-asyncio>=1.4.0",
+    "pytest-cov>=7.1.0",
+    "pytest-explicit>=1.0.1",
+    "pytest>=9.1.1",
+    "respx>=0.23.1",
+    "tox>=4.58.0",
 ]
-typecheck  = [
-    "ty",
+lint = [
+    # Ceiling as well as floor: a ruff minor release changes what it reports
+    # and reformats files that were correct under the previous one — matches
+    # edutap.data_provider's own ruff>=0.16,<0.17, and matches the version
+    # already pinned in .pre-commit-config.yaml (v0.16.1) so the hook and
+    # this group cannot silently disagree. ruff was never a project
+    # dependency before this; it only ran inside pre-commit/prek's own
+    # isolated environment.
+    "ruff>=0.16.1,<0.17",
 ]
-develop = [
-    "pdbp>=1.7.1", # the maintained successor to pdbpp
+typecheck = [
+    # Ceiling as well as floor, for the same reason as ruff: ty is pre-1.0
+    # and moves fast enough that Task 3 jumps it 49 releases in one commit.
+    # Its releases are all 0.0.x, so there is no separate minor line to float
+    # within — the ceiling pins the current release exactly and asks for a
+    # deliberate bump, and a look at what changed, every single time.
+    "ty>=0.0.66,<0.0.67",
+]
+dev = [
+    {include-group = "test"},
+    {include-group = "lint"},
+    {include-group = "typecheck"},
+    "pdbp>=1.7.1", # the maintained successor to pdbpp; already floored, unchanged
     # "ipython",  not recommended with pdpb, better use ipdb then
 ]
 
@@ -74,7 +92,16 @@ develop = [
 generate-fernet-key = "edutap.wallet_google.utils:generate_fernet_key"
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = [
+    # 1.27.0 is the first hatchling release that builds a PEP 639 license
+    # expression as Metadata-Version 2.4 with License-Expression/License-File
+    # fields (Step 2 above). 1.26.x accepts the license-files array syntax
+    # without erroring but silently builds Metadata-Version 2.3 with no
+    # license fields at all; 1.24.0 and 1.25.0 reject the syntax outright.
+    # Verified by building a throwaway package against all four.
+    "hatchling>=1.27.0",
+    "hatch-vcs>=0.5.0",  # the version currently resolving; no feature drives this floor
+]
 build-backend = "hatchling.build"
 
 [tool.hatch.version]
@@ -86,6 +113,22 @@ version-file = "src/edutap/wallet_google/_version.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/edutap"]
+
+[tool.hatch.build.targets.sdist]
+# hatchling does not read MANIFEST.in — that is a setuptools file, and an sdist
+# built with it in place still contained docs/ and .claude/, both of which it
+# claimed to exclude. These are the contents on purpose:
+#   tests/ stays, so a distribution packager can run the suite.
+#   superpowers/, .claude/, CLAUDE.md are internal working documents.
+#   .github/, docs/ and examples/ are not needed to build or test the package.
+include = [
+    "/src",
+    "/tests",
+    "/README.md",
+    "/CONTRIBUTING.md",
+    "/LICENSE",
+    "/pyproject.toml",
+]
 
 [tool.pytest.ini_options]
 minversion = "6.0"
@@ -160,7 +203,8 @@ use_develop = true
 skip_install = false
 deps = ["-e tests/data/test_wallet_google_plugins"]
 commands = [["pytest", { replace = "posargs", extend = true }]]
-extras = ["test", "develop"]
+extras = ["callback"]
+dependency_groups = ["dev"]
 
 [tool.tox.env.format]
 description = "automatically reformats code"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ authors = [
 # it goes stale:
 #   README.md "Built with httpx, Pydantic v2, and Python 3.10+"
 #   README.md "Python 3.10 or later (3.13 recommended)"
-#   docs/installation.md "Python 3.10+, currently up to 3.13 is tested"
+#   docs/installation.md "Python 3.10+, currently up to 3.14 is tested"
 #   Makefile, the test-matrix help text "py310 through py314"
 #   CONTRIBUTING.md, the same sentence as the Makefile
 # The two README lines are the user-facing statement of the supported floor; if

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,11 +179,25 @@ not-iterable = "warn"
 ignore-words-list = "discreet,"
 
 [tool.check-manifest]
+# Mirror image of [tool.hatch.build.targets.sdist].include: everything that
+# section deliberately leaves out of the sdist has to be named here too, or
+# check-manifest reports it as "missing" on every run. Edit the two together.
+# One pattern per excluded top-level area, not per file, so a new file added
+# inside docs/, examples/, superpowers/ or .claude/ does not reopen this —
+# but nothing broader than that: a new top-level file or directory nobody
+# accounted for should still make this hook complain.
 ignore = [
     ".editorconfig",
     ".pre-commit-config.yaml",
     "worktrees/**",
     "src/edutap/wallet_google/_version.py",
+    ".claude/**",
+    ".dockerignore",
+    "CLAUDE.md",
+    "RELEASING.md",
+    "docs/**",
+    "examples/**",
+    "superpowers/**",
 ]
 
 [tool.tox]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,23 @@ authors = [
 ]
 # Python 3.10 reaches end of life on 2026-10-31. Dropping it narrows this
 # field, which is a breaking change for consumers, so it gets its own release
-# rather than riding along with something else. Everything that changes with
-# it: requires-python below, the 3.10 classifier, [tool.ruff] target-version,
-# [tool.ty.environment] python-version, [tool.tox] env_list,
-# [tool.tox.gh.python], and the matrix in .github/workflows/tests.yaml.
+# rather than riding along with something else.
+#
+# Everything that changes with it — configuration:
+#   requires-python below, and the 3.10 entry in classifiers
+#   [tool.ruff] target-version
+#   [tool.ty.environment] python-version
+#   [tool.tox] env_list, and [tool.tox.gh.python]
+#   .github/workflows/tests.yaml, the python-version matrix
+# and prose, which is the half that gets forgotten, because nothing fails when
+# it goes stale:
+#   README.md "Built with httpx, Pydantic v2, and Python 3.10+"
+#   README.md "Python 3.10 or later (3.13 recommended)"
+#   docs/installation.md "Python 3.10+, currently up to 3.13 is tested"
+#   Makefile, the test-matrix help text "py310 through py314"
+#   CONTRIBUTING.md, the same sentence as the Makefile
+# The two README lines are the user-facing statement of the supported floor; if
+# only one thing on this list gets updated, make it those.
 requires-python = ">=3.10"
 license = "EUPL-1.2"
 license-files = ["LICENSE"]
@@ -37,7 +50,11 @@ dependencies = [
     # resolve the actual version against their own environment.
     "authlib>=1.7.2",
     "cryptography>=48.0.1",  # <48.0.1: vulnerable OpenSSL bundled in wheels (high)
-    "httpx",
+    # A feature floor, not a security one and not a statement about what is
+    # tested: api.py sends request bodies with `content=`, added in httpx 0.15.0
+    # ("Added Request(content=...) for byte content, instead of overloading
+    # Request(data=...)"). Below that the calls would raise TypeError.
+    "httpx>=0.15",
     "joserfc",
     "pydantic-settings>=2.14.2",  # 2.12.0..2.14.1: symlink escape in secrets source
     "pydantic[email]>=2.0",
@@ -186,6 +203,11 @@ extra-paths = ["src", "tests"]
 error-on-warning = false
 
 [tool.ty.rules]
+# Environment-dependent, and the only rule here that genuinely is: it reports
+# nothing in a checkout that installed the optional `callback` extra, because
+# handlers/fastapi.py imports fastapi unconditionally while fastapi lives in
+# [project.optional-dependencies]. Held at "warn" so a checkout without the
+# extra is not a failing checkout.
 unresolved-import = "warn"
 # The following rules are stricter than mypy. As of ty 0.0.66 they report
 # nothing at all in src/ — every remaining instance is in tests/ — so this is
@@ -206,14 +228,20 @@ unresolved-import = "warn"
 #   feeds hand-written JSON-ish dicts straight into models, so the declared
 #   field types do not match what a `dict[str, str | list[str]]` literal infers.
 #
-# unknown-argument and not-iterable currently report nothing, and unresolved-import
-# only fires where the optional `callback` extra is absent. Left downgraded on
-# purpose: promoting a rule back to error because today's checkout happens to be
-# clean is how a green build turns red on someone else's machine.
+# unknown-argument reports nothing as of this commit, but only because fixing
+#   register_model's annotation cleared all 34 instances at once. Kept at "warn"
+#   rather than promoted on the strength of one clean checkout: it was grouped
+#   with the two above as "stricter than mypy" by whoever wrote this section,
+#   and there are no instances left to judge that call from.
 unresolved-attribute = "warn"
 invalid-argument-type = "warn"
 unknown-argument = "warn"
-not-iterable = "warn"
+# not-iterable is an error, unlike its neighbours above. Its single instance was
+# a test unpacking the result of dict.get() without checking for None, fixed in
+# the same commit as this line. It does not depend on which extras are installed
+# and it does not depend on the api.py `-> Model` annotations, so neither reason
+# for downgrading the others applies to it.
+not-iterable = "error"
 
 [tool.codespell]
 ignore-words-list = "discreet,"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,8 +174,12 @@ target-version = "py310"
 src = ["src", "tests"]
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "UP"]
+select = ["B", "E", "F", "I", "S", "UP", "W"]
 ignore = ["E501"]
+
+[tool.ruff.lint.per-file-ignores]
+# assert *is* the test framework here; S101 in tests is not a finding.
+"tests/**" = ["S101"]
 
 [tool.ruff.lint.isort]
 force-single-line = true

--- a/renovate.json5
+++ b/renovate.json5
@@ -44,12 +44,14 @@
   // No automerge anywhere. Green CI proves the suite still passes, not that the
   // update is one we want.
   //
-  // The two rules below cover project.dependencies and
-  // project.optional-dependencies, not the whole pep621 surface: build-system.requires
-  // (hatchling, hatch-vcs) and requires-python are also extracted by the pep621
-  // manager and match neither rule, so an update to either would arrive ungrouped
-  // under config:recommended's defaults. Nobody pins either today, so this is
-  // acknowledged rather than given a third rule.
+  // The two rules below cover project.dependencies and, since
+  // chore/package-modernisation folded it in, dependency-groups plus
+  // build-system.requires — not the whole pep621 surface: requires-python is also
+  // extracted by the pep621 manager and matches neither rule, so an update to it
+  // would arrive ungrouped under config:recommended's defaults. Nobody proposes
+  // updating it via Renovate today (Python floor bumps are a deliberate,
+  // reviewed decision, not a routine dependency update), so this is acknowledged
+  // rather than given a third rule.
   packageRules: [
     {
       // `.github/dependabot.yml` watches this same ecosystem, on purpose, for a
@@ -62,19 +64,83 @@
       groupName: "GitHub Actions",
     },
     {
-      // Everything under [project.optional-dependencies] — the callback, test,
-      // typecheck and develop extras. None of it is installed by a consumer of the
-      // library, so one pull request for the batch would be proportionate — if this
-      // rule ever matched anything. It currently does not: all eleven entries
-      // (`fastapi`, `freezegun`, `pytest`, `pytest-asyncio`, `pytest-cov`,
-      // `pytest-explicit`, `respx`, `tox`, `ty`, and the `edutap.wallet-google[callback]`
-      // self-reference) are bare names with skipReason: "unspecified-version", except
-      // `pdbp>=1.7.1`, whose open floor `rangeStrategy: "replace"` leaves unchanged.
-      // Same mechanism, same nil result, as the runtime-dependency rule below — see
-      // there for the detail.
-      matchManagers: ["pep621"],
-      matchDepTypes: ["project.optional-dependencies"],
+      // Everything now in [dependency-groups] (test, lint, typecheck, dev) and in
+      // build-system.requires (hatchling, hatch-vcs): none of it is installed by
+      // a consumer of the library, and none of it is published in the wheel or
+      // sdist metadata a consumer resolves. Every entry here carries a version
+      // constraint as of chore/package-modernisation (Task 1) — but a floor alone
+      // is not sufficient. pdbp>=1.7.1 was already floored before that work, and
+      // a dry run against this repository (--dry-run=full, v44.11.6) still
+      // produced nothing for it: the default rangeStrategy for pep621 is "replace",
+      // which leaves an open floor unchanged whenever the newest release already
+      // satisfies it — which it always does. rangeStrategy: "bump" instead raises
+      // the floor itself to each new release. That is safe here specifically
+      // because nothing downstream resolves these ranges — unlike the
+      // runtime-dependency rule below, where the same setting would force every
+      // consumer to upgrade in lockstep.
+      //
+      // project.optional-dependencies is deliberately NOT in matchDepTypes below,
+      // even though it matched the "before" rule above. After Task 1 it holds only
+      // the callback extra, and callback is published wheel metadata that a
+      // consumer of this library actually resolves — unlike everything else this
+      // rule groups. bump would ratchet callback's fastapi floor to each new
+      // FastAPI release and force every application using this extra to upgrade
+      // in lockstep, which is exactly the harm the runtime-dependency rule below
+      // exists to avoid. callback currently carries no floor at all (Task 1 found
+      // no code reason for one), so this rule has nothing to match there today
+      // regardless; if callback ever gets a real floor, it belongs with the
+      // runtime-dependency rule's reasoning, not this one.
+      //
+      // matchManagers is ["pep621", "poetry"], not just ["pep621"] as this rule
+      // originally shipped: measured, not assumed, by a --dry-run=full against
+      // this repository (v44.13.2). With matchManagers: ["pep621"] alone, pdbp —
+      // the control case above — still showed "updates": [] despite bump being
+      // configured, identical to before this rule existed. Renovate's "poetry"
+      // manager declares `supersedesManagers: ["pep621"]`
+      // (modules/manager/poetry/index.js) and, per
+      // workers/repository/extract/supersedes.ts, discards pep621's extraction of
+      // any packageFile poetry also claims. Poetry's manager matches pyproject.toml
+      // whether or not a [tool.poetry] table exists — it now understands PEP 621
+      // syntax directly (modules/manager/poetry/schema.js) — so it wins here even
+      // though this project has no [tool.poetry] section, and every dep Renovate
+      // sees for this file is tagged manager: "poetry", which matchManagers:
+      // ["pep621"] never matches. Adding "poetry" to matchManagers is what made the
+      // dry run change pdbp's proposal to "newValue": ">=1.8.2" — confirmed by
+      // re-running with only that one line changed.
+      //
+      // Two things that fix does NOT reach, both measured the same way:
+      // build-system.requires (hatchling, hatch-vcs) still produces zero deps —
+      // Renovate's poetry manager only populates build-system.requires when
+      // build-backend is Poetry's own ("poetry.masonry.api" or
+      // "poetry.core.masonry.api"; see the z.string().refine(...) in
+      // modules/manager/poetry/schema.js) and silently drops it to `undefined`
+      // otherwise via `.catch(void 0)` — this project's build-backend is
+      // "hatchling.build". Because poetry supersedes pep621 for this file, pep621's
+      // own build-system.requires extraction (which has no such restriction) never
+      // survives to be seen. This is a Renovate limitation in the manager it picked
+      // for this file, not something this config can route around; build-system.requires
+      // stays in matchDepTypes below so this rule is already correct the day
+      // Renovate's poetry manager stops dropping it. requires-python is unaffected
+      // either way — no rule here claims it (see the top-level comment above).
+      //
+      // The ceiling question this rule's design left unverified — whether bump
+      // respects an explicit upper bound rather than proposing to jump past it —
+      // is answered by the same dry run, now that bump is confirmed to actually
+      // run: ty>=0.0.66,<0.0.67 had a same-day release, 0.0.67, sitting exactly on
+      // the ceiling (excluded by the old range's `<0.0.67`). bump's proposal was
+      // "newValue": ">=0.0.67,<0.0.68" — it slid the whole one-patch window
+      // forward, floor and ceiling together, rather than emitting an unbounded
+      // ">=0.0.67" or leaving the stale "<0.0.67" in place (which would have
+      // rejected the very release it just proposed). ruff>=0.16.1,<0.17 had no
+      // release past its own ceiling on the day this ran, so it stayed silent —
+      // consistent, not a second data point.
+      matchManagers: ["pep621", "poetry"],
+      matchDepTypes: [
+        "dependency-groups",
+        "build-system.requires",
+      ],
       groupName: "development dependencies",
+      rangeStrategy: "bump",
     },
     {
       // The runtime dependencies, which every consumer of this library resolves
@@ -96,6 +162,16 @@
       // them visible to Renovate at all, is `chore/package-modernisation`'s job, not
       // this branch's.
       //
+      // matchManagers gained "poetry" for the identical reason as the
+      // development-dependencies rule above — see there for the full finding.
+      // Renovate's poetry manager, not pep621, is what actually extracts this
+      // file's deps (supersedesManagers: ["pep621"]), so matchManagers: ["pep621"]
+      // alone matched nothing here either. Fixing it changes no dependency's
+      // proposed update today — rangeStrategy is untouched (still the "replace"
+      // default) and config:recommended's own default already produces one PR per
+      // dep — but it is what actually makes `groupName: null` this rule's own
+      // decision rather than an accident of the default applying anyway.
+      //
       // Until that lands, the only thing that reaches a Python dependency here is a
       // security advisory, which bypasses all of the above. vulnerabilityAlerts
       // defaults to rangeStrategy: "update-lockfile", which with no lockfile here
@@ -113,7 +189,7 @@
       // there being no lockfile: track uv.lock again and advisories go back to editing
       // the lockfile instead of raising the floors here, which removes the only
       // mechanism this paragraph describes.
-      matchManagers: ["pep621"],
+      matchManagers: ["pep621", "poetry"],
       matchDepTypes: ["project.dependencies"],
       groupName: null,
     },

--- a/src/edutap/wallet_google/api.py
+++ b/src/edutap/wallet_google/api.py
@@ -458,7 +458,7 @@ def create(
     client = client_pool.client(credentials=credentials)
     response = client.post(
         url=url,
-        data=verified_json.encode("utf-8"),
+        content=verified_json.encode("utf-8"),
         headers=headers,
         params=params,
     )
@@ -534,13 +534,13 @@ def update(
     if partial:
         response = session.patch(
             url=client_pool.url(name, f"/{resource_id}"),
-            data=verified_json.encode("utf-8"),
+            content=verified_json.encode("utf-8"),
             params=params,
         )
     else:
         response = session.put(
             url=client_pool.url(name, f"/{resource_id}"),
-            data=verified_json.encode("utf-8"),
+            content=verified_json.encode("utf-8"),
             params=params,
         )
 
@@ -579,7 +579,9 @@ def message(
             params = {"fields": ",".join(fields)}
 
     client = client_pool.client(credentials=credentials)
-    response = client.post(url=url, data=verified_json.encode("utf-8"), params=params)
+    response = client.post(
+        url=url, content=verified_json.encode("utf-8"), params=params
+    )
 
     handle_response_errors(response, "send message to", name, resource_id)
     logger.debug(f"RAW-Response: {response.content!r}")
@@ -705,7 +707,7 @@ async def acreate(
     client = client_pool.async_client(credentials=credentials)
     response = await client.post(
         url=url,
-        data=verified_json.encode("utf-8"),
+        content=verified_json.encode("utf-8"),
         headers=headers,
         params=params,
     )
@@ -781,13 +783,13 @@ async def aupdate(
     if partial:
         response = await session.patch(
             url=client_pool.url(name, f"/{resource_id}"),
-            data=verified_json.encode("utf-8"),
+            content=verified_json.encode("utf-8"),
             params=params,
         )
     else:
         response = await session.put(
             url=client_pool.url(name, f"/{resource_id}"),
-            data=verified_json.encode("utf-8"),
+            content=verified_json.encode("utf-8"),
             params=params,
         )
 
@@ -827,7 +829,7 @@ async def amessage(
 
     client = client_pool.async_client(credentials=credentials)
     response = await client.post(
-        url=url, data=verified_json.encode("utf-8"), params=params
+        url=url, content=verified_json.encode("utf-8"), params=params
     )
 
     handle_response_errors(response, "send message to", name, resource_id)

--- a/src/edutap/wallet_google/api.py
+++ b/src/edutap/wallet_google/api.py
@@ -123,7 +123,7 @@ def _create_payload(models: list[ClassModel | ObjectModel | Reference]) -> JWTPa
 
 
 def _convert_str_or_datetime_to_str(value: str | datetime.datetime) -> str:
-    """convert and check the value to be a valid string for the JWT claim timestamps"""
+    """Convert and check the value to be a valid string for the JWT claim timestamps."""
     if isinstance(value, datetime.datetime):
         return str(int(value.timestamp()))
     if value == "":

--- a/src/edutap/wallet_google/api.py
+++ b/src/edutap/wallet_google/api.py
@@ -313,7 +313,16 @@ def _prepare_update(
     resource_id, verified_json = validate_data_and_convert_to_json(
         model, data, existing=True, resource_id_key=model_metadata["resource_id"]
     )
-    assert resource_id is not None, "resource_id is required for update"
+    if resource_id is None:
+        # A caller can pass a model instance whose resource-id field was never
+        # set; validate_data_and_convert_to_json() then legitimately returns
+        # None (see its `skip_resource_id` branch for the other case that
+        # yields None). That is a caller mistake, not an internal invariant,
+        # so it must survive python -O as a real, actionable error.
+        raise ValueError(
+            f"resource_id (field '{model_metadata['resource_id']}') must be "
+            f"set on the model instance for an update"
+        )
     return name, resource_id, verified_json, model
 
 

--- a/src/edutap/wallet_google/api.py
+++ b/src/edutap/wallet_google/api.py
@@ -105,7 +105,7 @@ def new(
 
 
 def _create_payload(models: list[ClassModel | ObjectModel | Reference]) -> JWTPayload:
-    """Creates a payload for the JWT."""
+    """Create a payload for the JWT."""
     payload = JWTPayload()
 
     for model in models:
@@ -144,7 +144,7 @@ def _create_claims(
     iat: str | datetime.datetime,
     exp: str | datetime.datetime,
 ) -> JWTClaims:
-    """Creates a JWTClaims instance based on the given issuer, origins and models."""
+    """Create a JWTClaims instance based on the given issuer, origins and models."""
     return JWTClaims(
         iss=issuer,
         iat=_convert_str_or_datetime_to_str(iat),
@@ -163,7 +163,7 @@ def save_link(
     credentials: dict | None = None,
 ) -> str:
     """
-    Creates a link to save a Google Wallet Object to the wallet on the device.
+    Create a link to save a Google Wallet Object to the wallet on the device.
 
     Besides the capability to save an object to the wallet, it is also able create classes on-the-fly.
 
@@ -420,7 +420,7 @@ def _setup_pagination_params(
     result_per_page: int,
     next_page_token: str | None,
 ) -> dict:
-    """Setup pagination parameters for listing operations.
+    """Set up pagination parameters for listing operations.
 
     Returns: params dict with pagination settings
     """
@@ -445,7 +445,7 @@ def create(
     fields: list[str] | None = None,
 ) -> Model:
     """
-    Creates a Google Wallet items. `C` in CRUD.
+    Create a Google Wallet item. `C` in CRUD.
 
     :param data:                          Data to pass to the Google RESTful API.
                                           A model instance, has to be a registered model.
@@ -486,7 +486,7 @@ def read(
     fields: list[str] | None = None,
 ) -> Model:
     """
-    Reads a Google Wallet Class or Object. `R` in CRUD.
+    Read a Google Wallet Class or Object. `R` in CRUD.
 
     :param name:             Registered name of the model to use
     :param resource_id:      Identifier of the resource to read from the Google RESTful API
@@ -521,7 +521,7 @@ def update(
     partial: bool = True,
 ) -> Model:
     """
-    Updates a Google Wallet Class or Object. `U` in CRUD.
+    Update a Google Wallet Class or Object. `U` in CRUD.
 
     :param data:                    Data to pass to the Google RESTful API.
                                     A model instance, has to be a registered model.
@@ -568,7 +568,7 @@ def message(
     credentials: dict | None = None,
     fields: list[str] | None = None,
 ) -> Model:
-    """Sends a message to a Google Wallet Class or Object.
+    """Send a message to a Google Wallet Class or Object.
 
     :param name:                      Registered name of the model to use
     :param resource_id:               Identifier of the resource to send to
@@ -611,7 +611,7 @@ def listing(
     credentials: dict | None = None,
     fields: list[str] | None = None,
 ) -> Generator[Model | str, None, None]:
-    """Lists wallet related resources.
+    """List wallet related resources.
 
     It is possible to list all classes of an issuer. Parameter 'name' has to end with 'Class',
     all objects of a registered object type by it's classes resource id,
@@ -695,7 +695,7 @@ async def acreate(
     fields: list[str] | None = None,
 ) -> Model:
     """
-    Creates a Google Wallet item asynchronously. `C` in CRUD.
+    Create a Google Wallet item asynchronously. `C` in CRUD.
 
     :param data:                          Data to pass to the Google RESTful API.
                                           A model instance, has to be a registered model.
@@ -735,7 +735,7 @@ async def aread(
     fields: list[str] | None = None,
 ) -> Model:
     """
-    Reads a Google Wallet Class or Object asynchronously. `R` in CRUD.
+    Read a Google Wallet Class or Object asynchronously. `R` in CRUD.
 
     :param name:             Registered name of the model to use
     :param resource_id:      Identifier of the resource to read from the Google RESTful API
@@ -770,7 +770,7 @@ async def aupdate(
     partial: bool = True,
 ) -> Model:
     """
-    Updates a Google Wallet Class or Object asynchronously. `U` in CRUD.
+    Update a Google Wallet Class or Object asynchronously. `U` in CRUD.
 
     :param data:                    Data to pass to the Google RESTful API.
                                     A model instance, has to be a registered model.
@@ -817,7 +817,7 @@ async def amessage(
     credentials: dict | None = None,
     fields: list[str] | None = None,
 ) -> Model:
-    """Sends a message to a Google Wallet Class or Object asynchronously.
+    """Send a message to a Google Wallet Class or Object asynchronously.
 
     :param name:                      Registered name of the model to use
     :param resource_id:               Identifier of the resource to send to
@@ -860,7 +860,7 @@ async def alisting(
     credentials: dict | None = None,
     fields: list[str] | None = None,
 ) -> AsyncGenerator[Model | str, None]:
-    """Lists wallet related resources asynchronously.
+    """List wallet related resources asynchronously.
 
     It is possible to list all classes of an issuer. Parameter 'name' has to end with 'Class',
     all objects of a registered object type by it's classes resource id,

--- a/src/edutap/wallet_google/clientpool.py
+++ b/src/edutap/wallet_google/clientpool.py
@@ -56,7 +56,7 @@ class ClientPoolManager:
         :param credentials: Service account credentials dict.
         :return:            Configuration dict for AssertionClient/AsyncAssertionClient.
         """
-        token_endpoint = "https://oauth2.googleapis.com/token"
+        token_endpoint = "https://oauth2.googleapis.com/token"  # noqa: S105  # a URL, not a secret
         return {
             "token_endpoint": token_endpoint,
             "issuer": credentials["client_email"],

--- a/src/edutap/wallet_google/credentials.py
+++ b/src/edutap/wallet_google/credentials.py
@@ -18,7 +18,15 @@ class CredentialsManager:
             self._settings = Settings()
         return self._settings
 
-    @functools.cache
+    # functools.cache on a method normally risks a memory leak: it keeps
+    # every `self` that ever called the method alive for the process
+    # lifetime. Here there is exactly one `self` — the `credentials_manager`
+    # singleton below, the only instance this class is ever constructed
+    # into (see api.py and clientpool.py, which both import that singleton
+    # rather than instantiating CredentialsManager themselves). That
+    # instance is already kept alive for the whole process by the module
+    # binding, so caching on it does not extend anything's lifetime further.
+    @functools.cache  # noqa: B019
     def credentials_from_file(self) -> dict:
         """Load credentials from file defined in settings.
 

--- a/src/edutap/wallet_google/handlers/fastapi.py
+++ b/src/edutap/wallet_google/handlers/fastapi.py
@@ -35,10 +35,14 @@ async def handle_callback(request: Request, callback_data: CallbackData):
     # get the registered callback handlers
     try:
         handlers = get_callback_handlers()
-    except NotImplementedError:
+    except NotImplementedError as error:
+        # NotImplementedError carries no more than a static "no plug-in
+        # found" message (see plugins.get_plugins()); chaining it keeps the
+        # traceback pointing at the failed entry_points lookup, which helps
+        # diagnosing a deployment/registration problem.
         raise HTTPException(
             status_code=500, detail="No callback handlers were registered."
-        )
+        ) from error
 
     # extract and verify message (given verification is not disabled)
     callback_message = await verified_signed_message(callback_data)
@@ -67,13 +71,13 @@ async def handle_callback(request: Request, callback_data: CallbackData):
                 timeout=client_pool.settings.handlers_callback_timeout,
             )
         )
-    except asyncio.TimeoutError:
+    except asyncio.TimeoutError as error:
         logger.exception(
             f"Timeout after {client_pool.settings.handlers_callback_timeout}s while handling the callbacks.",
         )
         raise HTTPException(
             status_code=500, detail="Error while handling the callbacks (timeout)."
-        )
+        ) from error
     # results is a list of exceptions or None
     if any(results):
         logger.error("Error while handling a callbacks.")
@@ -92,10 +96,13 @@ async def handle_image(request: Request, encrypted_image_id: str):
     # get the registered image providers
     try:
         handlers = get_image_providers()
-    except NotImplementedError:
+    except NotImplementedError as error:
+        # Same reasoning as the callback handler lookup above: the original
+        # carries only a static message and chaining it keeps the traceback
+        # pointing at the failed entry_points lookup.
         raise HTTPException(
             status_code=500, detail="No image providers were registered."
-        )
+        ) from error
     if len(handlers) > 1:
         logger.error("Multiple image providers found, abort.")
         raise HTTPException(
@@ -112,29 +119,41 @@ async def handle_image(request: Request, encrypted_image_id: str):
             handler.image_by_id(image_id),
             timeout=client_pool.settings.handlers_image_timeout,
         )
-    except asyncio.TimeoutError:
+    except asyncio.TimeoutError as error:
         logger.exception(
             f"Timeout after {client_pool.settings.handlers_image_timeout}s while handling the image.",
         )
         raise HTTPException(
             status_code=500, detail="Error while handling the image (timeout)."
-        )
-    except asyncio.CancelledError:
+        ) from error
+    except asyncio.CancelledError as error:
         logger.exception(
             "Cancelled while handling the image.",
         )
         raise HTTPException(
             status_code=500, detail="Error while handling the image (cancel)."
-        )
+        ) from error
     except LookupError:
-        raise HTTPException(status_code=404, detail="Image not found.")
+        # image_by_id() is provided by a pluggable ImageProvider and its
+        # LookupError may embed the lookup key (e.g. a storage path or
+        # object id derived from the decrypted image id) in its message.
+        # That is exactly the kind of detail the caller must not see, and
+        # it is not needed server-side either — nothing here logs it, unlike
+        # the other except-branches, precisely to keep it out of chains that
+        # might get exported to less trusted sinks.
+        raise HTTPException(status_code=404, detail="Image not found.") from None
     except Exception:
         logger.exception(
             "Error while handling a image.",
         )
+        # A catch-all around a third-party ImageProvider plugin: the
+        # original could be anything the plugin author's code raises, with
+        # unknown content. It is already fully captured by logger.exception
+        # above; not chaining it keeps the HTTPException from also carrying
+        # arbitrary plugin-internal details.
         raise HTTPException(
             status_code=500, detail="Error while handling the image (exception)."
-        )
+        ) from None
     cache_control = client_pool.settings.handler_image_cache_control.format(
         max_age=result.max_age
     )

--- a/src/edutap/wallet_google/handlers/validate.py
+++ b/src/edutap/wallet_google/handlers/validate.py
@@ -1,5 +1,6 @@
 """
-Parts of this module are rewrites and borrows from from https://github.com/yoyowallet/google-pay-token-decryption
+Parts of this module are rewrites and borrows from from https://github.com/yoyowallet/google-pay-token-decryption.
+
 The above packages does not fulfill the needs we have here, but was a great starting point.
 Copyright is by its original authors at Yoyo Wallet <dev@yoyowallet.com>
 This file is under the MIT License, as found here https://github.com/yoyowallet/google-pay-token-decryption/blob/5cd006da9687171c1e35b55507b671c6e4eb513d/pyproject.toml#L8.
@@ -92,10 +93,7 @@ def _calculate_cache_expiration(keys: RootSigningPublicKeys) -> float:
 
 
 def _construct_signed_data(*args: str) -> bytes:
-    """
-    Construct the signed message from the list of its components by concatenating the
-    byte length of each component in 4 bytes little-endian format plus the UTF-8 encoded
-    component.
+    """Construct the signed message from the list of its components by concatenating the byte length of each component in 4 bytes little-endian format plus the UTF-8 encoded component.
 
     See https://developers.google.com/pay/api/android/guides/resources/payment-data-cryptography#verify-signature
     or  https://developers.google.com/pay/api/android/guides/resources/payment-data-cryptography#how-to-construct-the-byte-string-for-intermediate-signing-key-signature
@@ -243,9 +241,7 @@ async def google_root_signing_public_keys(
 
 
 async def verified_signed_message(data: CallbackData) -> SignedMessage:
-    """
-    Verifies the signature of the callback data asynchronously.
-    and returns the parsed SignedMessage.
+    """Verify the signature of the callback data and return the parsed SignedMessage, asynchronously.
 
     Async version using httpx.AsyncClient for fetching Google root signing keys.
     """

--- a/src/edutap/wallet_google/handlers/validate.py
+++ b/src/edutap/wallet_google/handlers/validate.py
@@ -2,7 +2,7 @@
 Parts of this module are rewrites and borrows from from https://github.com/yoyowallet/google-pay-token-decryption
 The above packages does not fulfill the needs we have here, but was a great starting point.
 Copyright is by its original authors at Yoyo Wallet <dev@yoyowallet.com>
-This file is under the MIT License, as found here https://github.com/yoyowallet/google-pay-token-decryption/blob/5cd006da9687171c1e35b55507b671c6e4eb513d/pyproject.toml#L8
+This file is under the MIT License, as found here https://github.com/yoyowallet/google-pay-token-decryption/blob/5cd006da9687171c1e35b55507b671c6e4eb513d/pyproject.toml#L8.
 
 The google-pay-token-decryption uses ECv2 for verification and decryption of payment tokens.
 
@@ -245,7 +245,7 @@ async def google_root_signing_public_keys(
 async def verified_signed_message(data: CallbackData) -> SignedMessage:
     """
     Verifies the signature of the callback data asynchronously.
-    and returns the parsed SignedMessage
+    and returns the parsed SignedMessage.
 
     Async version using httpx.AsyncClient for fetching Google root signing keys.
     """

--- a/src/edutap/wallet_google/handlers/validate.py
+++ b/src/edutap/wallet_google/handlers/validate.py
@@ -1,5 +1,5 @@
 """
-Parts of this module are rewrites and borrows from from https://github.com/yoyowallet/google-pay-token-decryption.
+Parts of this module are rewrites and borrows from https://github.com/yoyowallet/google-pay-token-decryption.
 
 The above packages does not fulfill the needs we have here, but was a great starting point.
 Copyright is by its original authors at Yoyo Wallet <dev@yoyowallet.com>
@@ -93,7 +93,10 @@ def _calculate_cache_expiration(keys: RootSigningPublicKeys) -> float:
 
 
 def _construct_signed_data(*args: str) -> bytes:
-    """Construct the signed message from the list of its components by concatenating the byte length of each component in 4 bytes little-endian format plus the UTF-8 encoded component.
+    """Construct the signed message from its components.
+
+    Concatenates, for each component, its byte length in 4-byte
+    little-endian format followed by the UTF-8 encoded component.
 
     See https://developers.google.com/pay/api/android/guides/resources/payment-data-cryptography#verify-signature
     or  https://developers.google.com/pay/api/android/guides/resources/payment-data-cryptography#how-to-construct-the-byte-string-for-intermediate-signing-key-signature

--- a/src/edutap/wallet_google/handlers/validate.py
+++ b/src/edutap/wallet_google/handlers/validate.py
@@ -331,9 +331,15 @@ async def verified_signed_message(data: CallbackData) -> SignedMessage:
         logger.error(
             f"Message signature verification failed: {e.__class__.__name__}: {e}"
         )
+        # This is cryptographic signature verification on an inbound
+        # webhook callback: the class name and message are already logged
+        # above for server-side debugging. Not chaining keeps whatever the
+        # `cryptography` library put into its exception (which is not
+        # documented to avoid leaking key- or padding-related detail) out
+        # of any downstream trace of this security-sensitive failure.
         raise ValueError(
             "Invalid message signature: verification failed with intermediate signing key"
-        )
+        ) from None
 
     logger.info(
         f"Successfully verified callback for {message.classId}/{message.objectId} "

--- a/src/edutap/wallet_google/models/bases.py
+++ b/src/edutap/wallet_google/models/bases.py
@@ -42,7 +42,14 @@ def make_partial_model(model: type[Model]) -> type[Model]:
             field_overrides[name] = (field_info.annotation | None, None)
     if not field_overrides:
         return model
-    return create_model(
+    # ty 0.0.66 cannot select an overload for a call that passes **kwargs from a
+    # dict: it has no way to prove which keyword-only parameters the unpacking
+    # fills, so every overload of create_model is rejected. Reproducible without
+    # pydantic on any overloaded function with keyword-only parameters, and the
+    # same call against the non-overloaded implementation signature checks
+    # cleanly. Suppressed on this line rather than by downgrading the rule
+    # project-wide, because no-matching-overload does catch real errors.
+    return create_model(  # ty: ignore[no-matching-overload]
         f"Partial{model.__name__}",
         __base__=model,
         **field_overrides,

--- a/src/edutap/wallet_google/models/bases.py
+++ b/src/edutap/wallet_google/models/bases.py
@@ -42,13 +42,21 @@ def make_partial_model(model: type[Model]) -> type[Model]:
             field_overrides[name] = (field_info.annotation | None, None)
     if not field_overrides:
         return model
-    # ty 0.0.66 cannot select an overload for a call that passes **kwargs from a
-    # dict: it has no way to prove which keyword-only parameters the unpacking
-    # fills, so every overload of create_model is rejected. Reproducible without
-    # pydantic on any overloaded function with keyword-only parameters, and the
-    # same call against the non-overloaded implementation signature checks
-    # cleanly. Suppressed on this line rather than by downgrading the rule
-    # project-wide, because no-matching-overload does catch real errors.
+    # This call cannot be overload-checked by any conforming type checker, and
+    # that is not going to change. A **kwargs unpacking has statically unknown
+    # keys, so a checker cannot tell whether it supplies create_model's
+    # keyword-only parameters (__base__, __config__, ...) or its arbitrary field
+    # definitions — and therefore cannot pick an overload. Confirmed on a
+    # reduced case with no pydantic involved: ty 0.0.66 and mypy 1.18.2 both
+    # reject the same call against an overloaded signature and both accept it
+    # against a non-overloaded one.
+    #
+    # So do not read this as a bug to re-test on a newer ty. If it ever needs to
+    # go away, the fix is at this call site — building the model without a
+    # dict unpacking — not upstream.
+    #
+    # Suppressed on the line rather than by downgrading no-matching-overload in
+    # [tool.ty.rules], because the rule does catch real errors elsewhere.
     return create_model(  # ty: ignore[no-matching-overload]
         f"Partial{model.__name__}",
         __base__=model,

--- a/src/edutap/wallet_google/models/bases.py
+++ b/src/edutap/wallet_google/models/bases.py
@@ -22,9 +22,7 @@ class Model(BaseModel):
 
 
 class WithIdModel(Model):
-    """
-    Model for Google Wallet models with an identifier.
-    """
+    """Model for Google Wallet models with an identifier."""
 
     id: str
 
@@ -104,7 +102,7 @@ class CamelCaseAliasEnum(Enum):
 
     def __eq__(self, other: typing.Any | Enum) -> bool:
         """Allow comparison with the camelcase value.
-        Take into account that UPPER_CASE and camelCase are equal
+        Take into account that UPPER_CASE and camelCase are equal.
         """
         if not isinstance(other, Enum):
             other = self.__class__(other)

--- a/src/edutap/wallet_google/models/bases.py
+++ b/src/edutap/wallet_google/models/bases.py
@@ -70,8 +70,7 @@ def _snake_to_camel(snake_str: str) -> str:
 
 
 class CamelCaseAliasEnum(Enum):
-    """Add an value alias in camelcase to the enum,
-    given the value in snake-case.
+    """Add a value alias in camelcase to the enum, given the value in snake-case.
 
     example: a enum like
 
@@ -102,6 +101,7 @@ class CamelCaseAliasEnum(Enum):
 
     def __eq__(self, other: typing.Any | Enum) -> bool:
         """Allow comparison with the camelcase value.
+
         Take into account that UPPER_CASE and camelCase are equal.
         """
         if not isinstance(other, Enum):

--- a/src/edutap/wallet_google/models/datatypes/barcode.py
+++ b/src/edutap/wallet_google/models/datatypes/barcode.py
@@ -11,9 +11,7 @@ from .localized_string import LocalizedString
 
 
 class Barcode(DeprecatedKindFieldMixin, Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/Barcode
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/Barcode."""
 
     # inherits kind (deprecated)
     type: BarcodeType = BarcodeType.BARCODE_TYPE_UNSPECIFIED
@@ -26,18 +24,14 @@ class Barcode(DeprecatedKindFieldMixin, Model):
 
 
 class TotpParameters(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/RotatingBarcode#totpparameters
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/RotatingBarcode#totpparameters."""
 
     key: str
     valueLength: int
 
 
 class TotpDetails(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/RotatingBarcode#totpdetails
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/RotatingBarcode#totpdetails."""
 
     periodMillis: str
     algorithm: TotpAlgorithm = TotpAlgorithm.TOTP_ALGORITHM_UNSPECIFIED
@@ -45,9 +39,7 @@ class TotpDetails(Model):
 
 
 class RotatingBarcodeValues(Model):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/RotatingBarcode#rotatingbarcodevalues
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/RotatingBarcode#rotatingbarcodevalues."""
 
     startDateTime: str | None = None
     values: list[str] | None = None
@@ -55,9 +47,7 @@ class RotatingBarcodeValues(Model):
 
 
 class RotatingBarcode(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/RotatingBarcode
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/RotatingBarcode."""
 
     type: BarcodeType = BarcodeType.BARCODE_TYPE_UNSPECIFIED
     renderEncoding: BarcodeRenderEncoding = (

--- a/src/edutap/wallet_google/models/datatypes/class_template_info.py
+++ b/src/edutap/wallet_google/models/datatypes/class_template_info.py
@@ -12,26 +12,20 @@ from typing_extensions import deprecated
 
 
 class FieldReference(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/ClassTemplateInfo#fieldreference
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/ClassTemplateInfo#fieldreference."""
 
     fieldPath: str
     dateFormat: DateFormat | None = None
 
 
 class FieldSelector(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/ClassTemplateInfo#fieldselector
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/ClassTemplateInfo#fieldselector."""
 
     fields: list[FieldReference]
 
 
 class TemplateItem(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/ClassTemplateInfo#templateitem
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/ClassTemplateInfo#templateitem."""
 
     firstValue: FieldSelector | None = None
     secondValue: FieldSelector | None = None
@@ -39,17 +33,13 @@ class TemplateItem(Model):
 
 
 class BarcodeSectionDetail(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/ClassTemplateInfo#barcodesectiondetail
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/ClassTemplateInfo#barcodesectiondetail."""
 
     fieldSelector: FieldSelector
 
 
 class CardBarcodeSectionDetails(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/ClassTemplateInfo#cardbarcodesectiondetails
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/ClassTemplateInfo#cardbarcodesectiondetails."""
 
     firstTopDetail: BarcodeSectionDetail | None = None
     firstBottomDetail: BarcodeSectionDetail | None = None
@@ -57,26 +47,20 @@ class CardBarcodeSectionDetails(Model):
 
 
 class CardRowOneItem(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/ClassTemplateInfo#cardrowoneitem
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/ClassTemplateInfo#cardrowoneitem."""
 
     item: TemplateItem | None = None
 
 
 class CardRowTwoItems(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/ClassTemplateInfo#cardrowtwoitems
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/ClassTemplateInfo#cardrowtwoitems."""
 
     startItem: TemplateItem | None = None
     endItem: TemplateItem | None = None
 
 
 class CardRowThreeItems(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/ClassTemplateInfo#cardrowthreeitems
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/ClassTemplateInfo#cardrowthreeitems."""
 
     startItem: TemplateItem | None = None
     middleItem: TemplateItem | None = None
@@ -84,9 +68,7 @@ class CardRowThreeItems(Model):
 
 
 class CardRowTemplateInfo(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/ClassTemplateInfo#cardrowtemplateinfo
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/ClassTemplateInfo#cardrowtemplateinfo."""
 
     oneItem: CardRowOneItem | None = None
     twoItems: CardRowTwoItems | None = None
@@ -94,42 +76,32 @@ class CardRowTemplateInfo(Model):
 
 
 class CardTemplateOverride(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/ClassTemplateInfo#cardtemplateoverride
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/ClassTemplateInfo#cardtemplateoverride."""
 
     cardRowTemplateInfos: list[CardRowTemplateInfo] | None = None
 
 
 class DetailsItemInfo(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/ClassTemplateInfo#detailsiteminfo
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/ClassTemplateInfo#detailsiteminfo."""
 
     item: TemplateItem | None = None
 
 
 class DetailsTemplateOverride(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/ClassTemplateInfo#detailstemplateoverride
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/ClassTemplateInfo#detailstemplateoverride."""
 
     detailsItemInfos: list[DetailsItemInfo] | None = None
 
 
 class FirstRowOption(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/ClassTemplateInfo#firstrowoption
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/ClassTemplateInfo#firstrowoption."""
 
     transitOption: TransitOption | None = None
     fieldOption: FieldSelector | None = None
 
 
 class ListTemplateOverride(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/ClassTemplateInfo#listtemplateoverride
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/ClassTemplateInfo#listtemplateoverride."""
 
     firstRowOption: FirstRowOption | None = None
     secondRowOption: FieldSelector | None = None
@@ -146,9 +118,7 @@ class ListTemplateOverride(Model):
 
 
 class ClassTemplateInfo(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/ClassTemplateInfo
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/ClassTemplateInfo."""
 
     cardBarcodeSectionDetails: CardBarcodeSectionDetails | None = None
     cardTemplateOverride: CardTemplateOverride | None = None

--- a/src/edutap/wallet_google/models/datatypes/data.py
+++ b/src/edutap/wallet_google/models/datatypes/data.py
@@ -13,7 +13,7 @@ from typing_extensions import deprecated
 
 class TextModuleData(Model):
     """
-    see: https://developers.google.com/wallet/generic/rest/v1/TextModuleData
+    see: https://developers.google.com/wallet/generic/rest/v1/TextModuleData.
 
     Google accepts both header and localizedHeader, body and localizedBody
     but if localizedHeader and localizedBody are present, header and body are ignored and set to None.
@@ -29,35 +29,27 @@ class TextModuleData(Model):
 
 
 class LinksModuleData(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/LinksModuleData
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/LinksModuleData."""
 
     uris: list[Uri] | None = None
 
 
 class ImageModuleData(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/ImageModuleData
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/ImageModuleData."""
 
     mainImage: Image | None = None
     id: str | None = None
 
 
 class AppTarget(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/AppLinkData#apptarget
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/AppLinkData#apptarget."""
 
     targetUri: Uri | None = None
     packageName: str | None = None
 
 
 class AppLinkInfo(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/AppLinkData#applinkinfo
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/AppLinkData#applinkinfo."""
 
     appLogoImage: Annotated[
         Image | None,
@@ -93,9 +85,7 @@ class AppLinkInfo(Model):
 
 
 class AppLinkData(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/AppLinkData
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/AppLinkData."""
 
     androidAppLinkInfo: AppLinkInfo | None = None
     iosAppLinkInfo: Annotated[

--- a/src/edutap/wallet_google/models/datatypes/datetime.py
+++ b/src/edutap/wallet_google/models/datatypes/datetime.py
@@ -10,17 +10,13 @@ import datetime
 
 
 class DateTime(Model):
-    """
-    see: https://developers.google.com/wallet/tickets/events/rest/v1/DateTime
-    """
+    """see: https://developers.google.com/wallet/tickets/events/rest/v1/DateTime."""
 
     date: datetime.datetime
 
 
 class TimeInterval(DeprecatedKindFieldMixin, Model):
-    """
-    see: https://developers.google.com/wallet/tickets/events/rest/v1/TimeInterval
-    """
+    """see: https://developers.google.com/wallet/tickets/events/rest/v1/TimeInterval."""
 
     # inherits kind (deprecated)
     start: DateTime | None = None

--- a/src/edutap/wallet_google/models/datatypes/enums.py
+++ b/src/edutap/wallet_google/models/datatypes/enums.py
@@ -172,9 +172,9 @@ class GenericType(CamelCaseAliasEnum):
     """
 
     GENERIC_TYPE_UNSPECIFIED = "GENERIC_TYPE_UNSPECIFIED"  # Unspecified generic type.
-    GENERIC_SEASON_PASS = "GENERIC_SEASON_PASS"  # Season pass
+    GENERIC_SEASON_PASS = "GENERIC_SEASON_PASS"  # noqa: S105  # an enum member, not a secret  # Season pass
     GENERIC_UTILITY_BILLS = "GENERIC_UTILITY_BILLS"  # Utility bills
-    GENERIC_PARKING_PASS = "GENERIC_PARKING_PASS"  # Parking pass
+    GENERIC_PARKING_PASS = "GENERIC_PARKING_PASS"  # noqa: S105  # an enum member, not a secret  # Parking pass
     GENERIC_VOUCHER = "GENERIC_VOUCHER"  # Voucher
     GENERIC_GYM_MEMBERSHIP = "GENERIC_GYM_MEMBERSHIP"  # Gym membership cards
     GENERIC_LIBRARY_MEMBERSHIP = (

--- a/src/edutap/wallet_google/models/datatypes/enums.py
+++ b/src/edutap/wallet_google/models/datatypes/enums.py
@@ -299,9 +299,7 @@ class SharedDataType(CamelCaseAliasEnum):
 
 
 class State(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/State
-         https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/State.
+    """see: https://developers.google.com/wallet/generic/rest/v1/State and https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/State.
 
     The official reference page does not spell out the semantic difference
     between COMPLETED, EXPIRED, and INACTIVE — in the Wallet app they all

--- a/src/edutap/wallet_google/models/datatypes/enums.py
+++ b/src/edutap/wallet_google/models/datatypes/enums.py
@@ -6,9 +6,7 @@ from ..bases import CamelCaseAliasEnum
 
 
 class Action(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/smarttap#action
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/smarttap#action."""
 
     ACTION_UNSPECIFIED = "ACTION_UNSPECIFIED"
     S2AP = "S2AP"
@@ -16,9 +14,7 @@ class Action(CamelCaseAliasEnum):
 
 
 class ActivationState(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/transitobject#state
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/transitobject#state."""
 
     UNKNOWN_STATE = "UNKNOWN_STATE"
     NOT_ACTIVATED = "NOT_ACTIVATED"
@@ -26,27 +22,21 @@ class ActivationState(CamelCaseAliasEnum):
 
 
 class AnimationType(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/SecurityAnimation#animationtype
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/SecurityAnimation#animationtype."""
 
     ANIMATION_UNSPECIFIED = "ANIMATION_UNSPECIFIED"
     FOIL_SHIMMER = "FOIL_SHIMMER"
 
 
 class BarcodeRenderEncoding(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/BarcodeRenderEncoding
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/BarcodeRenderEncoding."""
 
     RENDER_ENCODING_UNSPECIFIED = "RENDER_ENCODING_UNSPECIFIED"
     UTF_8 = "UTF_8"
 
 
 class BarcodeType(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/BarcodeType
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/BarcodeType."""
 
     BARCODE_TYPE_UNSPECIFIED = "BARCODE_TYPE_UNSPECIFIED"
     AZTEC = "AZTEC"
@@ -64,9 +54,7 @@ class BarcodeType(CamelCaseAliasEnum):
 
 
 class BoardingDoor(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/flightobject#BoardingDoor
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/flightobject#BoardingDoor."""
 
     BOARDING_DOOR_UNSPECIFIED = "BOARDING_DOOR_UNSPECIFIED"
     FRONT = "FRONT"
@@ -74,9 +62,7 @@ class BoardingDoor(CamelCaseAliasEnum):
 
 
 class BoardingPolicy(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/flightclass#boardingpolicy
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/flightclass#boardingpolicy."""
 
     BOARDING_POLICY_UNSPECIFIED = "BOARDING_POLICY_UNSPECIFIED"
     ZONE_BASED = "ZONE_BASED"
@@ -85,9 +71,7 @@ class BoardingPolicy(CamelCaseAliasEnum):
 
 
 class ConcessionCategory(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/transitobject#concessioncategory
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/transitobject#concessioncategory."""
 
     CONCESSION_CATEGORY_UNSPECIFIED = "CONCESSION_CATEGORY_UNSPECIFIED"
     ADULT = "ADULT"
@@ -96,9 +80,7 @@ class ConcessionCategory(CamelCaseAliasEnum):
 
 
 class ConfirmationCodeLabel(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/tickets/events/rest/v1/eventticketclass#confirmationcodelabel
-    """
+    """see: https://developers.google.com/wallet/tickets/events/rest/v1/eventticketclass#confirmationcodelabel."""
 
     CONFIRMATION_CODE_LABEL_UNSPECIFIED = "CONFIRMATION_CODE_LABEL_UNSPECIFIED"
     CONFIRMATION_CODE = "CONFIRMATION_CODE"
@@ -108,9 +90,7 @@ class ConfirmationCodeLabel(CamelCaseAliasEnum):
 
 
 class DateFormat(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/ClassTemplateInfo#dateformat
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/ClassTemplateInfo#dateformat."""
 
     DATE_FORMAT_UNSPECIFIED = "DATE_FORMAT_UNSPECIFIED"
     DATE_TIME = "DATE_TIME"
@@ -121,9 +101,7 @@ class DateFormat(CamelCaseAliasEnum):
 
 
 class DoorsOpenLabel(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/tickets/events/rest/v1/eventticketclass#doorsopenlabel
-    """
+    """see: https://developers.google.com/wallet/tickets/events/rest/v1/eventticketclass#doorsopenlabel."""
 
     DOORS_OPEN_LABEL_UNSPECIFIED = "DOORS_OPEN_LABEL_UNSPECIFIED"
     DOORS_OPEN = "DOORS_OPEN"
@@ -131,9 +109,7 @@ class DoorsOpenLabel(CamelCaseAliasEnum):
 
 
 class FareClass(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/transitobject#fareclass
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/transitobject#fareclass."""
 
     FARE_CLASS_UNSPECIFIED = "FARE_CLASS_UNSPECIFIED"
     ECONOMY = "ECONOMY"
@@ -142,9 +118,7 @@ class FareClass(CamelCaseAliasEnum):
 
 
 class FlightStatus(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/flightclass#flightstatus
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/flightclass#flightstatus."""
 
     FLIGHT_STATUS_UNSPECIFIED = "FLIGHT_STATUS_UNSPECIFIED"
     SCHEDULED = "SCHEDULED"
@@ -156,9 +130,7 @@ class FlightStatus(CamelCaseAliasEnum):
 
 
 class GateLabel(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/tickets/events/rest/v1/eventticketclass#gatelabel
-    """
+    """see: https://developers.google.com/wallet/tickets/events/rest/v1/eventticketclass#gatelabel."""
 
     GATE_LABEL_UNSPECIFIED = "GATE_LABEL_UNSPECIFIED"
     GATE = "GATE"
@@ -167,9 +139,7 @@ class GateLabel(CamelCaseAliasEnum):
 
 
 class GenericType(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/genericobject#generictype
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/genericobject#generictype."""
 
     GENERIC_TYPE_UNSPECIFIED = "GENERIC_TYPE_UNSPECIFIED"  # Unspecified generic type.
     GENERIC_SEASON_PASS = "GENERIC_SEASON_PASS"  # noqa: S105  # an enum member, not a secret  # Season pass
@@ -189,9 +159,7 @@ class GenericType(CamelCaseAliasEnum):
 
 
 class MessageType(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/tickets/events/rest/v1/Message#messagetype
-    """
+    """see: https://developers.google.com/wallet/tickets/events/rest/v1/Message#messagetype."""
 
     MESSAGE_TYPE_UNSPECIFIED = "MESSAGE_TYPE_UNSPECIFIED"
     TEXT = "TEXT"
@@ -200,9 +168,7 @@ class MessageType(CamelCaseAliasEnum):
 
 
 class MultipleDevicesAndHoldersAllowedStatus(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/MultipleDevicesAndHoldersAllowedStatus
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/MultipleDevicesAndHoldersAllowedStatus."""
 
     STATUS_UNSPECIFIED = "STATUS_UNSPECIFIED"
     MULTIPLE_HOLDERS = "MULTIPLE_HOLDERS"
@@ -211,9 +177,7 @@ class MultipleDevicesAndHoldersAllowedStatus(CamelCaseAliasEnum):
 
 
 class NfcConstraint(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/PassConstraints#NfcConstraint
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/PassConstraints#NfcConstraint."""
 
     NFC_CONSTRAINT_UNSPECIFIED = "NFC_CONSTRAINT_UNSPECIFIED"
     BLOCK_PAYMENT = "BLOCK_PAYMENT"
@@ -221,9 +185,7 @@ class NfcConstraint(CamelCaseAliasEnum):
 
 
 class NotificationSettingsForUpdates(CamelCaseAliasEnum):
-    """
-    see https://developers.google.com/wallet/reference/rest/v1/NotificationSettingsForUpdates
-    """
+    """see https://developers.google.com/wallet/reference/rest/v1/NotificationSettingsForUpdates."""
 
     NOTIFICATION_SETTINGS_FOR_UPDATES_UNSPECIFIED = (
         "NOTIFICATION_SETTINGS_FOR_UPDATES_UNSPECIFIED"
@@ -232,9 +194,7 @@ class NotificationSettingsForUpdates(CamelCaseAliasEnum):
 
 
 class PassengerType(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/transitobject#passengertype
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/transitobject#passengertype."""
 
     PASSENGER_TYPE_UNSPECIFIED = "PASSENGER_TYPE_UNSPECIFIED"
     SINGLE_PASSENGER = "SINGLE_PASSENGER"
@@ -242,9 +202,7 @@ class PassengerType(CamelCaseAliasEnum):
 
 
 class PredefinedItem(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/retail/offers/rest/v1/ClassTemplateInfo#predefineditem
-    """
+    """see: https://developers.google.com/wallet/retail/offers/rest/v1/ClassTemplateInfo#predefineditem."""
 
     PREDEFINED_ITEM_UNSPECIFIED = "PREDEFINED_ITEM_UNSPECIFIED"
     FREQUENT_FLYER_PROGRAM_NAME_AND_NUMBER = "FREQUENT_FLYER_PROGRAM_NAME_AND_NUMBER"
@@ -254,9 +212,7 @@ class PredefinedItem(CamelCaseAliasEnum):
 
 
 class RedemptionChannel(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/retail/offers/rest/v1/offerclass#OfferClass.RedemptionChannel
-    """
+    """see: https://developers.google.com/wallet/retail/offers/rest/v1/offerclass#OfferClass.RedemptionChannel."""
 
     REDEMPTION_CHANNEL_UNSPECIFIED = "REDEMPTION_CHANNEL_UNSPECIFIED"
     INSTORE = "INSTORE"
@@ -266,9 +222,7 @@ class RedemptionChannel(CamelCaseAliasEnum):
 
 
 class ReviewStatus(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/ReviewStatus
-    """
+    """see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/ReviewStatus."""
 
     REVIEW_STATUS_UNSPECIFIED = "REVIEW_STATUS_UNSPECIFIED"
     UNDER_REVIEW = "UNDER_REVIEW"
@@ -278,9 +232,7 @@ class ReviewStatus(CamelCaseAliasEnum):
 
 
 class Role(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/permissions#role
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/permissions#role."""
 
     ROLE_UNSPECIFIED = "ROLE_UNSPECIFIED"
     OWNER = "OWNER"
@@ -289,18 +241,14 @@ class Role(CamelCaseAliasEnum):
 
 
 class RowLabel(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/tickets/events/rest/v1/eventticketclass#rowlabel
-    """
+    """see: https://developers.google.com/wallet/tickets/events/rest/v1/eventticketclass#rowlabel."""
 
     ROW_LABEL_UNSPECIFIED = "ROW_LABEL_UNSPECIFIED"
     ROW = "ROW"
 
 
 class ScreenshotEligibility(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/PassConstraints#screenshoteligibility
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/PassConstraints#screenshoteligibility."""
 
     SCREENSHOT_ELIGIBILITY_UNSPECIFIED = "SCREENSHOT_ELIGIBILITY_UNSPECIFIED"
     ELIGIBLE = "ELIGIBLE"
@@ -308,9 +256,7 @@ class ScreenshotEligibility(CamelCaseAliasEnum):
 
 
 class SeatClassPolicy(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/flightclass#seatclasspolicy
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/flightclass#seatclasspolicy."""
 
     SEAT_CLASS_POLICY_UNSPECIFIED = "SEAT_CLASS_POLICY_UNSPECIFIED"
     CABIN_BASED = "CABIN_BASED"
@@ -320,18 +266,14 @@ class SeatClassPolicy(CamelCaseAliasEnum):
 
 
 class SeatLabel(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/tickets/events/rest/v1/eventticketclass#seatlabel
-    """
+    """see: https://developers.google.com/wallet/tickets/events/rest/v1/eventticketclass#seatlabel."""
 
     SEAT_LABEL_UNSPECIFIED = "SEAT_LABEL_UNSPECIFIED"
     SEAT = "SEAT"
 
 
 class SectionLabel(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/tickets/events/rest/v1/eventticketclass#sectionlabel
-    """
+    """see: https://developers.google.com/wallet/tickets/events/rest/v1/eventticketclass#sectionlabel."""
 
     SECTION_LABEL_UNSPECIFIED = "SECTION_LABEL_UNSPECIFIED"
     SECTION = "SECTION"
@@ -339,9 +281,7 @@ class SectionLabel(CamelCaseAliasEnum):
 
 
 class SharedDataType(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/loyaltyclass#shareddatatype
-    """
+    """see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/loyaltyclass#shareddatatype."""
 
     SHARED_DATA_TYPE_UNSPECIFIED = "SHARED_DATA_TYPE_UNSPECIFIED"
     FIRST_NAME = "FIRST_NAME"
@@ -361,7 +301,7 @@ class SharedDataType(CamelCaseAliasEnum):
 class State(CamelCaseAliasEnum):
     """
     see: https://developers.google.com/wallet/generic/rest/v1/State
-         https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/State
+         https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/State.
 
     The official reference page does not spell out the semantic difference
     between COMPLETED, EXPIRED, and INACTIVE — in the Wallet app they all
@@ -393,9 +333,7 @@ class State(CamelCaseAliasEnum):
 
 
 class RetailState(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/loyaltyclass#state
-    """
+    """see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/loyaltyclass#state."""
 
     STATE_UNSPECIFIED = "STATE_UNSPECIFIED"
     TRUSTED_TESTERS = "TRUSTED_TESTERS"
@@ -404,9 +342,7 @@ class RetailState(CamelCaseAliasEnum):
 
 
 class TicketStatus(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/transitobject#ticketstatus
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/transitobject#ticketstatus."""
 
     TICKET_STATUS_UNSPECIFIED = "TICKET_STATUS_UNSPECIFIED"
     USED = "USED"
@@ -415,18 +351,14 @@ class TicketStatus(CamelCaseAliasEnum):
 
 
 class TotpAlgorithm(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/RotatingBarcode#totpalgorithm
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/RotatingBarcode#totpalgorithm."""
 
     TOTP_ALGORITHM_UNSPECIFIED = "TOTP_ALGORITHM_UNSPECIFIED"
     TOTP_SHA1 = "TOTP_SHA1"
 
 
 class TransitType(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/transitclass#transittype
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/transitclass#transittype."""
 
     TRANSIT_TYPE_UNSPECIFIED = "TRANSIT_TYPE_UNSPECIFIED"
     BUS = "BUS"
@@ -437,9 +369,7 @@ class TransitType(CamelCaseAliasEnum):
 
 
 class TransitOption(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/ClassTemplateInfo#transitoption
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/ClassTemplateInfo#transitoption."""
 
     TRANSIT_OPTION_UNSPECIFIED = "TRANSIT_OPTION_UNSPECIFIED"
     ORIGIN_AND_DESTINATION_NAMES = "ORIGIN_AND_DESTINATION_NAMES"
@@ -448,9 +378,7 @@ class TransitOption(CamelCaseAliasEnum):
 
 
 class TripType(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/transitobject#triptype
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/transitobject#triptype."""
 
     TRIP_TYPE_UNSPECIFIED = "TRIP_TYPE_UNSPECIFIED"
     ROUND_TRIP = "ROUND_TRIP"
@@ -458,9 +386,7 @@ class TripType(CamelCaseAliasEnum):
 
 
 class ViewUnlockRequirement(CamelCaseAliasEnum):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/ViewUnlockRequirement
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/ViewUnlockRequirement."""
 
     VIEW_UNLOCK_REQUIREMENT_UNSPECIFIED = "VIEW_UNLOCK_REQUIREMENT_UNSPECIFIED"
     UNLOCK_NOT_REQUIRED = "UNLOCK_NOT_REQUIRED"

--- a/src/edutap/wallet_google/models/datatypes/event.py
+++ b/src/edutap/wallet_google/models/datatypes/event.py
@@ -11,9 +11,7 @@ import datetime
 
 
 class EventVenue(DeprecatedKindFieldMixin, Model):
-    """
-    see: https://developers.google.com/wallet/tickets/events/rest/v1/eventticketclass#eventvenue
-    """
+    """see: https://developers.google.com/wallet/tickets/events/rest/v1/eventticketclass#eventvenue."""
 
     # inherits kind (deprecated)
     name: LocalizedString | None = None
@@ -21,9 +19,7 @@ class EventVenue(DeprecatedKindFieldMixin, Model):
 
 
 class EventDateTime(DeprecatedKindFieldMixin, Model):
-    """
-    see: https://developers.google.com/wallet/tickets/events/rest/v1/eventticketclass#eventdatetime
-    """
+    """see: https://developers.google.com/wallet/tickets/events/rest/v1/eventticketclass#eventdatetime."""
 
     # inherits kind (deprecated)
     # TODO: can't be properly resolved because we have a custom module named datetime, i.e. global datetime is shadowed
@@ -35,9 +31,7 @@ class EventDateTime(DeprecatedKindFieldMixin, Model):
 
 
 class EventSeat(DeprecatedKindFieldMixin, Model):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/eventticketobject#eventseat
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/eventticketobject#eventseat."""
 
     # inherits kind (deprecated)
     seat: LocalizedString | None = None
@@ -47,9 +41,7 @@ class EventSeat(DeprecatedKindFieldMixin, Model):
 
 
 class EventReservationInfo(DeprecatedKindFieldMixin, Model):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/eventticketobject#eventreservationinfo
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/eventticketobject#eventreservationinfo."""
 
     # inherits kind (deprecated)
     confirmationCode: str | None = None

--- a/src/edutap/wallet_google/models/datatypes/flight.py
+++ b/src/edutap/wallet_google/models/datatypes/flight.py
@@ -13,9 +13,7 @@ from pydantic import Field
 
 
 class BoardingAndSeatingInfo(DeprecatedKindFieldMixin, Model):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/flightobject#BoardingAndSeatingInfo
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/flightobject#BoardingAndSeatingInfo."""
 
     # inherits kind (deprecated)
     boardingGroup: str | None = None
@@ -29,9 +27,7 @@ class BoardingAndSeatingInfo(DeprecatedKindFieldMixin, Model):
 
 
 class FrequentFlyerInfo(DeprecatedKindFieldMixin, Model):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/flightobject#FrequentFlyerInfo
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/flightobject#FrequentFlyerInfo."""
 
     # inherits kind (deprecated)
     frequentFlyerProgramName: LocalizedString
@@ -39,9 +35,7 @@ class FrequentFlyerInfo(DeprecatedKindFieldMixin, Model):
 
 
 class ReservationInfo(DeprecatedKindFieldMixin, Model):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/flightobject#ReservationInfo
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/flightobject#ReservationInfo."""
 
     # inherits kind (deprecated)
     confirmationCode: str | None = None
@@ -50,9 +44,7 @@ class ReservationInfo(DeprecatedKindFieldMixin, Model):
 
 
 class FlightCarrier(DeprecatedKindFieldMixin, Model):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/flightclass#flightcarrier
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/flightclass#flightcarrier."""
 
     # inherits kind (deprecated)
     carrierIataCode: str | None = Field(
@@ -70,9 +62,7 @@ class FlightCarrier(DeprecatedKindFieldMixin, Model):
 
 
 class FlightHeader(DeprecatedKindFieldMixin, Model):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/flightclass#flightheader
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/flightclass#flightheader."""
 
     # inherits kind (deprecated)
     carrier: FlightCarrier | None = None
@@ -83,9 +73,7 @@ class FlightHeader(DeprecatedKindFieldMixin, Model):
 
 
 class AirportInfo(DeprecatedKindFieldMixin, Model):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/flightclass#airportinfo
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/flightclass#airportinfo."""
 
     # inherits kind (deprecated)
     airportIataCode: str | None = Field(max_length=3, default=None)
@@ -95,9 +83,7 @@ class AirportInfo(DeprecatedKindFieldMixin, Model):
 
 
 class BoardingAndSeatingPolicy(DeprecatedKindFieldMixin, Model):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/flightclass#boardingandseatingpolicy
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/flightclass#boardingandseatingpolicy."""
 
     # inherits kind (deprecated)
     boardingPolicy: BoardingPolicy = BoardingPolicy.BOARDING_POLICY_UNSPECIFIED

--- a/src/edutap/wallet_google/models/datatypes/general.py
+++ b/src/edutap/wallet_google/models/datatypes/general.py
@@ -16,9 +16,7 @@ from typing_extensions import deprecated
 
 
 class Uri(DeprecatedKindFieldMixin, Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/Uri
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/Uri."""
 
     # inherits kind (deprecated)
     uri: AnyUrl | str | None = None
@@ -28,9 +26,7 @@ class Uri(DeprecatedKindFieldMixin, Model):
 
 
 class ImageUri(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/Image#imageuri
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/Image#imageuri."""
 
     uri: AnyUrl
     description: Annotated[
@@ -56,9 +52,7 @@ class ImageUri(Model):
 
 
 class Image(DeprecatedKindFieldMixin, Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/Image
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/Image."""
 
     # inherits kind (deprecated)
     sourceUri: ImageUri | None = None
@@ -67,9 +61,7 @@ class Image(DeprecatedKindFieldMixin, Model):
 
 
 class PassConstraints(Model):
-    """
-    see https://developers.google.com/wallet/generic/rest/v1/PassConstraints
-    """
+    """see https://developers.google.com/wallet/generic/rest/v1/PassConstraints."""
 
     screenshotEligibility: ScreenshotEligibility = (
         ScreenshotEligibility.SCREENSHOT_ELIGIBILITY_UNSPECIFIED
@@ -82,26 +74,20 @@ class PassConstraints(Model):
 
 
 class SecurityAnimation(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/SecurityAnimation
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/SecurityAnimation."""
 
     animationType: AnimationType = AnimationType.ANIMATION_UNSPECIFIED
 
 
 class GroupingInfo(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/GroupingInfo
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/GroupingInfo."""
 
     sortIndex: int | None = None
     groupingId: str | None = None
 
 
 class Pagination(DeprecatedKindFieldMixin, Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/Pagination
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/Pagination."""
 
     # inherits kind (deprecated)
     resultsPerPage: int
@@ -116,7 +102,7 @@ class PaginatedResponse(Model):
          https://developers.google.com/wallet/reference/rest/v1/offerobject/list
          https://developers.google.com/wallet/reference/rest/v1/eventticketclass/list
          https://developers.google.com/wallet/reference/rest/v1/eventticketobject/list
-         ... and many more
+         ... and many more.
 
     The List Response for Issuer is not paginated (see: https://developers.google.com/wallet/reference/rest/v1/issuer/list),
     therefore the pagination attribute is optional.
@@ -127,9 +113,7 @@ class PaginatedResponse(Model):
 
 
 class CallbackOptions(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/CallbackOptions
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/CallbackOptions."""
 
     url: AnyHttpUrl | None = None
     updateRequestUrl: Annotated[
@@ -145,8 +129,6 @@ class CallbackOptions(Model):
 
 
 class SaveRestrictions(Model):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/SaveRestrictions
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/SaveRestrictions."""
 
     restrictToEmailSha256: str | None = None

--- a/src/edutap/wallet_google/models/datatypes/general.py
+++ b/src/edutap/wallet_google/models/datatypes/general.py
@@ -96,6 +96,7 @@ class Pagination(DeprecatedKindFieldMixin, Model):
 
 class PaginatedResponse(Model):
     """All Class and Object List Responses are paginated.
+
     see: https://developers.google.com/wallet/reference/rest/v1/loyaltyclass/list
          https://developers.google.com/wallet/reference/rest/v1/loyaltyobject/list
          https://developers.google.com/wallet/reference/rest/v1/offerclass/list

--- a/src/edutap/wallet_google/models/datatypes/jwt.py
+++ b/src/edutap/wallet_google/models/datatypes/jwt.py
@@ -1,6 +1,4 @@
-"""
-Models to be used to assemble the JWT for the save link (add to wallet link).
-"""
+"""Models to be used to assemble the JWT for the save link (add to wallet link)."""
 
 from ..bases import Model
 from ..passes import generic
@@ -37,7 +35,7 @@ class JWTPayload(Model):
 
 class JWTClaims(Model):
     """
-    see: https://developers.google.com/wallet/reference/rest/v1/Jwt
+    see: https://developers.google.com/wallet/reference/rest/v1/Jwt.
 
     Note: `exp` is added to the model as standard field of the JWT specification,
     see https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4,

--- a/src/edutap/wallet_google/models/datatypes/localized_string.py
+++ b/src/edutap/wallet_google/models/datatypes/localized_string.py
@@ -8,9 +8,7 @@ from pydantic import Field
 
 
 class TranslatedString(DeprecatedKindFieldMixin, Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/LocalizedString#translatedstring
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/LocalizedString#translatedstring."""
 
     # inherits kind (deprecated)
     language: str | None = Field(default=None)
@@ -18,9 +16,7 @@ class TranslatedString(DeprecatedKindFieldMixin, Model):
 
 
 class LocalizedString(DeprecatedKindFieldMixin, Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/LocalizedString
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/LocalizedString."""
 
     # inherits kind (deprecated)
     translatedValues: list[TranslatedString] = Field(default_factory=list)

--- a/src/edutap/wallet_google/models/datatypes/location.py
+++ b/src/edutap/wallet_google/models/datatypes/location.py
@@ -8,9 +8,7 @@ from pydantic import Field
 
 
 class LatLongPoint(DeprecatedKindFieldMixin, Model):
-    """
-    see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/LatLongPoint
-    """
+    """see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/LatLongPoint."""
 
     # inherits kind (deprecated)
     latitude: float = Field(ge=-90.0, le=90.0)
@@ -18,9 +16,7 @@ class LatLongPoint(DeprecatedKindFieldMixin, Model):
 
 
 class MerchantLocation(Model):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/MerchantLocation
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/MerchantLocation."""
 
     latitude: float = Field(ge=-90.0, le=90.0)
     longitude: float = Field(ge=-180.0, le=180.0)

--- a/src/edutap/wallet_google/models/datatypes/loyalty.py
+++ b/src/edutap/wallet_google/models/datatypes/loyalty.py
@@ -10,10 +10,7 @@ from pydantic import model_validator
 
 
 class LoyaltyPointsBalance(Model):
-    """
-    data-type,
-    see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/loyaltyobject#LoyaltyPointsBalance.
-    """
+    """data-type, see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/loyaltyobject#LoyaltyPointsBalance."""
 
     string: str | None = None
     int_: int | None = Field(alias="int", serialization_alias="int", default=None)
@@ -35,10 +32,7 @@ class LoyaltyPointsBalance(Model):
 
 
 class LoyaltyPoints(Model):
-    """
-    data-type,
-    see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/loyaltyobject#LoyaltyPoints.
-    """
+    """data-type, see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/loyaltyobject#LoyaltyPoints."""
 
     label: str | None = None
     balance: LoyaltyPointsBalance | None = None

--- a/src/edutap/wallet_google/models/datatypes/loyalty.py
+++ b/src/edutap/wallet_google/models/datatypes/loyalty.py
@@ -12,7 +12,7 @@ from pydantic import model_validator
 class LoyaltyPointsBalance(Model):
     """
     data-type,
-    see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/loyaltyobject#LoyaltyPointsBalance
+    see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/loyaltyobject#LoyaltyPointsBalance.
     """
 
     string: str | None = None
@@ -37,7 +37,7 @@ class LoyaltyPointsBalance(Model):
 class LoyaltyPoints(Model):
     """
     data-type,
-    see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/loyaltyobject#LoyaltyPoints
+    see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/loyaltyobject#LoyaltyPoints.
     """
 
     label: str | None = None

--- a/src/edutap/wallet_google/models/datatypes/message.py
+++ b/src/edutap/wallet_google/models/datatypes/message.py
@@ -10,9 +10,7 @@ from .localized_string import LocalizedString
 
 
 class Message(DeprecatedKindFieldMixin, Model):
-    """
-    see: https://developers.google.com/wallet/tickets/events/rest/v1/Message
-    """
+    """see: https://developers.google.com/wallet/tickets/events/rest/v1/Message."""
 
     # inherits kind (deprecated)
     header: str | None = None

--- a/src/edutap/wallet_google/models/datatypes/moduledata.py
+++ b/src/edutap/wallet_google/models/datatypes/moduledata.py
@@ -9,17 +9,13 @@ from .localized_string import LocalizedString
 
 
 class ModuleViewConstraints(Model):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/ValueAddedModuleData
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/ValueAddedModuleData."""
 
     displayInterval: TimeInterval | None = None
 
 
 class ValueAddedModuleData(Model):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/ValueAddedModuleData
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/ValueAddedModuleData."""
 
     header: LocalizedString | None = None
     body: LocalizedString | None = None

--- a/src/edutap/wallet_google/models/datatypes/money.py
+++ b/src/edutap/wallet_google/models/datatypes/money.py
@@ -7,9 +7,7 @@ from ..deprecated import DeprecatedKindFieldMixin
 
 
 class Money(DeprecatedKindFieldMixin, Model):
-    """
-    see: https://developers.google.com/wallet/tickets/events/rest/v1/Money
-    """
+    """see: https://developers.google.com/wallet/tickets/events/rest/v1/Money."""
 
     # inherits kind (deprecated)
     micros: str | None = None

--- a/src/edutap/wallet_google/models/datatypes/notification.py
+++ b/src/edutap/wallet_google/models/datatypes/notification.py
@@ -6,25 +6,19 @@ from ..bases import Model
 
 
 class ExpiryNotification(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/genericobject#expirynotification
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/genericobject#expirynotification."""
 
     enableNotification: bool = False
 
 
 class UpcomingNotification(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/genericobject#upcomingnotification
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/genericobject#upcomingnotification."""
 
     enableNotification: bool = False
 
 
 class Notifications(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/genericobject#notifications
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/genericobject#notifications."""
 
     expiryNotification: ExpiryNotification | None = None
     upcomingNotification: UpcomingNotification | None = None

--- a/src/edutap/wallet_google/models/datatypes/retail.py
+++ b/src/edutap/wallet_google/models/datatypes/retail.py
@@ -9,26 +9,20 @@ from .general import Uri
 
 
 class DiscoverableProgramMerchantSignupInfo(Model):
-    """
-    see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/loyaltyclass#discoverableprogrammerchantsignupinfo
-    """
+    """see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/loyaltyclass#discoverableprogrammerchantsignupinfo."""
 
     signupWebsite: Uri
     signupSharedDatas: list[SharedDataType]
 
 
 class DiscoverableProgramMerchantSigninInfo(Model):
-    """
-    see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/loyaltyclass#discoverableprogrammerchantsignininfo
-    """
+    """see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/loyaltyclass#discoverableprogrammerchantsignininfo."""
 
     signinWebsite: Uri
 
 
 class DiscoverableProgram(Model):
-    """
-    see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/loyaltyclass#discoverableprogram
-    """
+    """see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/loyaltyclass#discoverableprogram."""
 
     merchantSignupInfo: DiscoverableProgramMerchantSignupInfo | None = None
     merchantSigninInfo: DiscoverableProgramMerchantSigninInfo | None = None

--- a/src/edutap/wallet_google/models/datatypes/review.py
+++ b/src/edutap/wallet_google/models/datatypes/review.py
@@ -6,8 +6,6 @@ from ..bases import Model
 
 
 class Review(Model):
-    """
-    see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/Review
-    """
+    """see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/Review."""
 
     comments: str | None = None

--- a/src/edutap/wallet_google/models/datatypes/smarttap.py
+++ b/src/edutap/wallet_google/models/datatypes/smarttap.py
@@ -11,35 +11,27 @@ from pydantic import Field
 
 
 class Permission(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/permissions#permission
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/permissions#permission."""
 
     emailAddress: EmailStr | None
     role: Role | None
 
 
 class AuthenticationKey(Model):
-    """
-    see: https://developers.google.com/wallet/tickets/events/rest/v1/issuer#authenticationkey
-    """
+    """see: https://developers.google.com/wallet/tickets/events/rest/v1/issuer#authenticationkey."""
 
     id: int
     publicKeyPem: str
 
 
 class SignUpInfo(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/smarttap#signupinfo
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/smarttap#signupinfo."""
 
     classId: str
 
 
 class IssuerToUserInfo(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/smarttap#issuertouserinfo
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/smarttap#issuertouserinfo."""
 
     action: Action = Action.ACTION_UNSPECIFIED
     url: AnyHttpUrl | None = Field(
@@ -50,9 +42,7 @@ class IssuerToUserInfo(Model):
 
 
 class IssuerContactInfo(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/issuer#issuercontactinfo
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/issuer#issuercontactinfo."""
 
     name: str | None = None
     phone: str | None = None
@@ -61,9 +51,7 @@ class IssuerContactInfo(Model):
 
 
 class SmartTapMerchantData(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/issuer#smarttapmerchantdata
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/issuer#smarttapmerchantdata."""
 
     smartTapMerchantId: str | None = None
     authenticationKeys: list[AuthenticationKey] | None = None

--- a/src/edutap/wallet_google/models/datatypes/transit.py
+++ b/src/edutap/wallet_google/models/datatypes/transit.py
@@ -12,26 +12,20 @@ from pydantic import model_validator
 
 
 class ActivationOptions(Model):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/transitclass#activationoptions
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/transitclass#activationoptions."""
 
     activationUrl: AnyHttpUrl | None = None
     allowReactivation: bool = False
 
 
 class ActivationStatus(Model):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/transitobject#activationstatus
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/transitobject#activationstatus."""
 
     state: ActivationState = ActivationState.UNKNOWN_STATE
 
 
 class TicketRestrictions(Model):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/transitobject#ticketrestrictions
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/transitobject#ticketrestrictions."""
 
     routeRestrictions: LocalizedString | None = None
     routeRestrictionsDetails: LocalizedString | None = None
@@ -40,9 +34,7 @@ class TicketRestrictions(Model):
 
 
 class TicketCost(Model):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/transitobject#ticketcost
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/transitobject#ticketcost."""
 
     faceValue: Money | None = None
     purchasePrice: Money | None = None
@@ -50,9 +42,7 @@ class TicketCost(Model):
 
 
 class TicketSeat(Model):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/transitobject#ticketseat
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/transitobject#ticketseat."""
 
     fareClass: FareClass = FareClass.FARE_CLASS_UNSPECIFIED
     customFareClass: LocalizedString | None = None
@@ -62,9 +52,7 @@ class TicketSeat(Model):
 
 
 class TicketLeg(Model):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/transitobject#ticketleg
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/transitobject#ticketleg."""
 
     originStationCode: str | None = None
     originName: LocalizedString | None = None
@@ -99,9 +87,7 @@ class TicketLeg(Model):
 
 
 class PurchaseDetails(Model):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/transitobject#purchasedetails
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/transitobject#purchasedetails."""
 
     purchaseReceiptNumber: str | None = None
     purchaseDateTime: str | None = None
@@ -111,8 +97,6 @@ class PurchaseDetails(Model):
 
 
 class DeviceContext(Model):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/transitobject#devicecontext
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/transitobject#devicecontext."""
 
     deviceToken: str | None = None

--- a/src/edutap/wallet_google/models/deprecated.py
+++ b/src/edutap/wallet_google/models/deprecated.py
@@ -1,5 +1,6 @@
 """
 Many Google wallet models or datatypes have deprecated attributes.
+
 Those must not be serialized again, nor repeated in the special models.
 To handle this, we create mixins which can be added to the models which still have the deprecated fields.
 """
@@ -12,10 +13,7 @@ from typing_extensions import deprecated
 
 
 class DeprecatedKindFieldMixin:
-    """
-    Mixin to add the deprecated kind field to a model.
-    May be removed in the future.
-    """
+    """Mixin to add the deprecated kind field to a model. May be removed in the future."""
 
     kind: Annotated[
         str,
@@ -30,10 +28,7 @@ class DeprecatedKindFieldMixin:
 
 
 class DeprecatedAllowMultipleUsersPerObjectMixin:
-    """
-    Mixin to add the deprecated allowMultipleUsersPerObject field to a model.
-    May be removed in the future.
-    """
+    """Mixin to add the deprecated allowMultipleUsersPerObject field to a model. May be removed in the future."""
 
     allowMultipleUsersPerObject: Annotated[
         bool,
@@ -48,10 +43,7 @@ class DeprecatedAllowMultipleUsersPerObjectMixin:
 
 
 class DeprecatedVersionFieldMixin:
-    """
-    Mixin to add the deprecated version field to a model.
-    May be removed in the future.
-    """
+    """Mixin to add the deprecated version field to a model. May be removed in the future."""
 
     version: Annotated[
         str | None,
@@ -80,10 +72,7 @@ class LatLongPoint(DeprecatedKindFieldMixin, Model):
 
 
 class DeprecatedLocationsFieldMixin:
-    """
-    Mixin to add the deprecated locations field to a model.
-    May be removed in the future.
-    """
+    """Mixin to add the deprecated locations field to a model. May be removed in the future."""
 
     locations: Annotated[
         list[LatLongPoint] | None,
@@ -175,10 +164,7 @@ class InfoModuleData(Model):
 
 
 class DeprecatedInfoModuleDataFieldMixin:
-    """
-    Mixin to add the deprecated infoModuleData field to a model.
-    May be removed in the future.
-    """
+    """Mixin to add the deprecated infoModuleData field to a model. May be removed in the future."""
 
     infoModuleData: Annotated[
         InfoModuleData | None,
@@ -239,10 +225,7 @@ class Image(DeprecatedKindFieldMixin, Model):
 
 
 class DeprecatedWordMarkFieldMixin:
-    """
-    Mixin to add the deprecated wordMark field to a model.
-    May be removed in the future.
-    """
+    """Mixin to add the deprecated wordMark field to a model. May be removed in the future."""
 
     wordMark: Annotated[
         list[Image] | None,

--- a/src/edutap/wallet_google/models/deprecated.py
+++ b/src/edutap/wallet_google/models/deprecated.py
@@ -67,7 +67,7 @@ class DeprecatedVersionFieldMixin:
 
 class LatLongPoint(DeprecatedKindFieldMixin, Model):
     """
-    see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/LatLongPoint
+    see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/LatLongPoint.
 
     To avoid circular imports this model is a duplicate of the one in location.py
 
@@ -99,7 +99,7 @@ class DeprecatedLocationsFieldMixin:
 
 class TranslatedString(DeprecatedKindFieldMixin, Model):
     """
-    see: https://developers.google.com/wallet/generic/rest/v1/LocalizedString#translatedstring
+    see: https://developers.google.com/wallet/generic/rest/v1/LocalizedString#translatedstring.
 
     To avoid circular imports this model is a duplicate of the one in location.py
 
@@ -113,7 +113,7 @@ class TranslatedString(DeprecatedKindFieldMixin, Model):
 
 class LocalizedString(DeprecatedKindFieldMixin, Model):
     """
-    see: https://developers.google.com/wallet/generic/rest/v1/LocalizedString
+    see: https://developers.google.com/wallet/generic/rest/v1/LocalizedString.
 
     To avoid circular imports this model is a duplicate of the one in localized_string.py
 
@@ -127,7 +127,7 @@ class LocalizedString(DeprecatedKindFieldMixin, Model):
 
 class LabelValue(Model):
     """
-    see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/InfoModuleData#labelvalue
+    see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/InfoModuleData#labelvalue.
 
     To avoid circular imports this model is a duplicate of the one in data.py
 
@@ -142,7 +142,7 @@ class LabelValue(Model):
 
 class LabelValueRow(Model):
     """
-    see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/InfoModuleData#labelvaluerow
+    see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/InfoModuleData#labelvaluerow.
 
     To avoid circular imports this model is a duplicate of the one in data.py
 
@@ -154,7 +154,7 @@ class LabelValueRow(Model):
 
 class InfoModuleData(Model):
     """
-    see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/InfoModuleData
+    see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/InfoModuleData.
 
     To avoid circular imports this model is a duplicate of the one in data.py
 
@@ -194,7 +194,7 @@ class DeprecatedInfoModuleDataFieldMixin:
 
 class ImageUri(Model):
     """
-    see: https://developers.google.com/wallet/generic/rest/v1/Image#imageuri
+    see: https://developers.google.com/wallet/generic/rest/v1/Image#imageuri.
 
     To avoid circular imports this model is a duplicate of the one in general.py
 
@@ -226,7 +226,7 @@ class ImageUri(Model):
 
 class Image(DeprecatedKindFieldMixin, Model):
     """
-    see: https://developers.google.com/wallet/generic/rest/v1/Image
+    see: https://developers.google.com/wallet/generic/rest/v1/Image.
 
     To avoid circular imports this model is a duplicate of the one in general.py
 

--- a/src/edutap/wallet_google/models/handlers.py
+++ b/src/edutap/wallet_google/models/handlers.py
@@ -1,6 +1,4 @@
-"""
-see https://developers.google.com/wallet/generic/use-cases/use-callbacks-for-saves-and-deletions
-"""
+"""see https://developers.google.com/wallet/generic/use-cases/use-callbacks-for-saves-and-deletions."""
 
 from .datatypes.enums import CamelCaseAliasEnum
 from pydantic import BaseModel
@@ -53,9 +51,7 @@ class CallbackData(BaseModel):
 
 
 class RootSigningPublicKey(BaseModel):
-    """
-    see https://developers.google.com/pay/api/android/guides/resources/payment-data-cryptography#root-signing-keys
-    """
+    """see https://developers.google.com/pay/api/android/guides/resources/payment-data-cryptography#root-signing-keys."""
 
     keyValue: str
     protocolVersion: str
@@ -63,8 +59,6 @@ class RootSigningPublicKey(BaseModel):
 
 
 class RootSigningPublicKeys(BaseModel):
-    """
-    see https://developers.google.com/pay/api/android/guides/resources/payment-data-cryptography#root-signing-keys
-    """
+    """see https://developers.google.com/pay/api/android/guides/resources/payment-data-cryptography#root-signing-keys."""
 
     keys: list[RootSigningPublicKey]

--- a/src/edutap/wallet_google/models/misc.py
+++ b/src/edutap/wallet_google/models/misc.py
@@ -85,20 +85,13 @@ class AddMessageRequest(Model):
     can_message=False,
 )
 class JwtResource(Model):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/jwt
-         https://developers.google.com/wallet/tickets/events/rest/v1/jwt
-         https://developers.google.com/wallet/generic/web/javascript-button#google-pay-api-for-passes-jwt.
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/jwt, https://developers.google.com/wallet/tickets/events/rest/v1/jwt and https://developers.google.com/wallet/generic/web/javascript-button#google-pay-api-for-passes-jwt."""
 
     jwt: str
 
 
 class Resources(Model):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/jwt/insert#resources
-         https://developers.google.com/wallet/tickets/events/rest/v1/jwt/insert#resources.
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/jwt/insert#resources and https://developers.google.com/wallet/tickets/events/rest/v1/jwt/insert#resources."""
 
     eventTicketClasses: list[tickets_and_transit.EventTicketClass] | None = None
     eventTicketObjects: list[tickets_and_transit.EventTicketObject] | None = None

--- a/src/edutap/wallet_google/models/misc.py
+++ b/src/edutap/wallet_google/models/misc.py
@@ -1,6 +1,4 @@
-"""
-This module contains models that are not directly related to passes but to other Google Wallet APIs
-"""
+"""This module contains models that are not directly related to passes but to other Google Wallet APIs."""
 
 from ..registry import register_model
 from .bases import Model
@@ -32,9 +30,7 @@ from pydantic import Field
     can_message=False,
 )
 class SmartTap(DeprecatedKindFieldMixin, WithIdModel):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/smarttap#resource:-smarttap
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/smarttap#resource:-smarttap."""
 
     # inherits id
     merchantId: str
@@ -49,9 +45,7 @@ class SmartTap(DeprecatedKindFieldMixin, WithIdModel):
     can_message=False,
 )
 class Issuer(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/issuer
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/issuer."""
 
     issuerId: str | None = None
     name: str
@@ -70,18 +64,14 @@ class Issuer(Model):
     can_message=False,
 )
 class Permissions(Model):
-    """
-    see: https://developers.google.com/wallet/generic/rest/v1/permissions
-    """
+    """see: https://developers.google.com/wallet/generic/rest/v1/permissions."""
 
     issuerId: str | None = None
     permissions: list[Permission] = Field(default_factory=list)
 
 
 class AddMessageRequest(Model):
-    """
-    see: https://developers.google.com/wallet/tickets/events/rest/v1/AddMessageRequest
-    """
+    """see: https://developers.google.com/wallet/tickets/events/rest/v1/AddMessageRequest."""
 
     message: Message | None = None
 
@@ -98,7 +88,7 @@ class JwtResource(Model):
     """
     see: https://developers.google.com/wallet/reference/rest/v1/jwt
          https://developers.google.com/wallet/tickets/events/rest/v1/jwt
-         https://developers.google.com/wallet/generic/web/javascript-button#google-pay-api-for-passes-jwt
+         https://developers.google.com/wallet/generic/web/javascript-button#google-pay-api-for-passes-jwt.
     """
 
     jwt: str
@@ -107,7 +97,7 @@ class JwtResource(Model):
 class Resources(Model):
     """
     see: https://developers.google.com/wallet/reference/rest/v1/jwt/insert#resources
-         https://developers.google.com/wallet/tickets/events/rest/v1/jwt/insert#resources
+         https://developers.google.com/wallet/tickets/events/rest/v1/jwt/insert#resources.
     """
 
     eventTicketClasses: list[tickets_and_transit.EventTicketClass] | None = None
@@ -127,9 +117,7 @@ class Resources(Model):
 
 
 class JwtResponse(Model):
-    """
-    see: https://developers.google.com/wallet/tickets/events/rest/v1/jwt/insert
-    """
+    """see: https://developers.google.com/wallet/tickets/events/rest/v1/jwt/insert."""
 
     saveUri: AnyHttpUrl
     resources: Resources

--- a/src/edutap/wallet_google/models/passes/bases.py
+++ b/src/edutap/wallet_google/models/passes/bases.py
@@ -134,9 +134,7 @@ class ObjectModel(WithIdModel):
 
 
 class StyleableMixin:
-    """
-    Mixin for Google Wallet Classes/Objects that can be styled.
-    """
+    """Mixin for Google Wallet Classes/Objects that can be styled."""
 
     hexBackgroundColor: str | None = None
 
@@ -154,8 +152,6 @@ class CommonLogosMixin:
 
 
 class HeroImageMixin:
-    """
-    Mixin for Google Wallet Classes/Object with a hero image.
-    """
+    """Mixin for Google Wallet Classes/Object with a hero image."""
 
     heroImage: Image | None = None

--- a/src/edutap/wallet_google/models/passes/generic.py
+++ b/src/edutap/wallet_google/models/passes/generic.py
@@ -20,8 +20,8 @@ from .bases import StyleableMixin
     can_message=True,
 )
 class GenericClass(ClassModel):
-    """
-    The GenericClass is the implicitly the base class for all other Wallet Class models.
+    """The GenericClass is implicitly the base class for all other Wallet Class models.
+
     The Google documentation does not mention this fact.
     This might change in future updates, do not depend on this assumption!
 
@@ -51,7 +51,7 @@ class GenericClass(ClassModel):
 @register_model("GenericObject", url_part="genericObject", can_message=True)
 class GenericObject(StyleableMixin, CommonLogosMixin, ObjectModel):
     """
-    The GenericObject is a specific object and does not act as the base for other wallet objects!
+    The GenericObject is a specific object and does not act as the base for other wallet objects.
 
     see: https://developers.google.com/wallet/generic/rest/v1/genericobject
     """

--- a/src/edutap/wallet_google/models/passes/retail.py
+++ b/src/edutap/wallet_google/models/passes/retail.py
@@ -39,9 +39,7 @@ class GiftCardClass(
     StyleableMixin,
     ClassModel,
 ):
-    """
-    see: https://developers.google.com/wallet/retail/gift-cards/rest/v1/giftcardclass
-    """
+    """see: https://developers.google.com/wallet/retail/gift-cards/rest/v1/giftcardclass."""
 
     # inherits kind (deprecated)
     merchantName: str | None = None
@@ -96,9 +94,7 @@ class GiftCardObject(
     DeprecatedInfoModuleDataFieldMixin,
     ObjectModel,
 ):
-    """
-    see: https://developers.google.com/wallet/retail/gift-cards/rest/v1/giftcardobject
-    """
+    """see: https://developers.google.com/wallet/retail/gift-cards/rest/v1/giftcardobject."""
 
     # inherits kind (deprecated)
     classReference: GiftCardClass | None = None
@@ -148,9 +144,7 @@ class LoyaltyClass(
     StyleableMixin,
     ClassModel,
 ):
-    """
-    see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/loyaltyclass
-    """
+    """see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/loyaltyclass."""
 
     programName: str | None = None
     programLogo: Image | None = None
@@ -212,7 +206,7 @@ class LoyaltyObject(
 ):
     """
     data-type,
-    see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/loyaltyobject
+    see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/loyaltyobject.
     """
 
     # inherits kind (deprecated)
@@ -264,9 +258,7 @@ class OfferClass(
     StyleableMixin,
     ClassModel,
 ):
-    """
-    see: https://developers.google.com/wallet/retail/offers/rest/v1/offerclass
-    """
+    """see: https://developers.google.com/wallet/retail/offers/rest/v1/offerclass."""
 
     # inherits kind (deprecated)
     title: str | None = None
@@ -327,9 +319,7 @@ class OfferObject(
     # StyleableMixin,
     ObjectModel,
 ):
-    """
-    see: https://developers.google.com/wallet/retail/offers/rest/v1/offerobject
-    """
+    """see: https://developers.google.com/wallet/retail/offers/rest/v1/offerobject."""
 
     # inherits kind (deprecated)
     classReference: OfferClass | None = None

--- a/src/edutap/wallet_google/models/passes/retail.py
+++ b/src/edutap/wallet_google/models/passes/retail.py
@@ -204,10 +204,7 @@ class LoyaltyObject(
     DeprecatedInfoModuleDataFieldMixin,
     ObjectModel,
 ):
-    """
-    data-type,
-    see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/loyaltyobject.
-    """
+    """data-type, see: https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/loyaltyobject."""
 
     # inherits kind (deprecated)
     classReference: LoyaltyClass | None = None

--- a/src/edutap/wallet_google/models/passes/tickets_and_transit.py
+++ b/src/edutap/wallet_google/models/passes/tickets_and_transit.py
@@ -67,9 +67,7 @@ class EventTicketClass(
     CommonLogosMixin,
     ClassModel,
 ):
-    """
-    see: https://developers.google.com/wallet/tickets/events/rest/v1/eventticketclass
-    """
+    """see: https://developers.google.com/wallet/tickets/events/rest/v1/eventticketclass."""
 
     # inherits kind (deprecated)
     eventName: LocalizedString | None = None
@@ -132,9 +130,7 @@ class EventTicketObject(
     HeroImageMixin,
     ObjectModel,
 ):
-    """
-    see: https://developers.google.com/wallet/tickets/events/rest/v1/eventticketobject
-    """
+    """see: https://developers.google.com/wallet/tickets/events/rest/v1/eventticketobject."""
 
     # inherits kind (deprecated)
     classReference: EventTicketClass | None = None
@@ -186,9 +182,7 @@ class TransitClass(
     CommonLogosMixin,
     ClassModel,
 ):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/transitclass
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/transitclass."""
 
     transitOperatorName: LocalizedString | None = None
     # inherits logo
@@ -259,9 +253,7 @@ class TransitObject(
     HeroImageMixin,
     ObjectModel,
 ):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/transitobject
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/transitobject."""
 
     classReference: TransitClass | None = None
     ticketNumber: str | None = None
@@ -344,9 +336,7 @@ class FlightClass(
     HeroImageMixin,
     ClassModel,
 ):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/flightclass
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/flightclass."""
 
     # inherits kind (deprecated)
     localScheduledDepartureDateTime: str | None = Field(default=None)
@@ -403,9 +393,7 @@ class FlightObject(
     StyleableMixin,
     ObjectModel,
 ):
-    """
-    see: https://developers.google.com/wallet/reference/rest/v1/flightobject
-    """
+    """see: https://developers.google.com/wallet/reference/rest/v1/flightobject."""
 
     # inherits kind (deprecated)
     classReference: FlightClass | None = None

--- a/src/edutap/wallet_google/protocols.py
+++ b/src/edutap/wallet_google/protocols.py
@@ -6,7 +6,8 @@ from typing import runtime_checkable
 @runtime_checkable
 class ImageProvider(Protocol):
     async def image_by_id(self, image_id: str) -> ImageData:
-        """
+        """Fetch the image data for the given image identifier.
+
         :param image_id: Unique image identifier as string.
         :return: ImageData instance.
 
@@ -25,7 +26,8 @@ class CallbackHandler(Protocol):
         count: int,
         nonce: str,
     ) -> None:
-        """
+        """Handle a Google Wallet callback event.
+
         :param class_id: ClassId
         :param object_id: ObjectId
         :param event_type: EventType

--- a/src/edutap/wallet_google/registry.py
+++ b/src/edutap/wallet_google/registry.py
@@ -264,7 +264,7 @@ def _find_enums() -> list[str]:
         "edutap.wallet_google.models.datatypes.enums"
     )
     enums: list[str] = []
-    for enum_name, enum in inspect.getmembers(enums_module, inspect.isclass):
+    for enum_name, _enum in inspect.getmembers(enums_module, inspect.isclass):
         enums.append(enum_name)
     return enums
 

--- a/src/edutap/wallet_google/registry.py
+++ b/src/edutap/wallet_google/registry.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 from typing import TypedDict
+from typing import TypeVar
 
 import functools
 import importlib
@@ -11,6 +12,16 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from .models.bases import Model
+
+
+# The decorated class flows through `register_model.__call__` unchanged at
+# runtime, so the annotation has to carry its concrete type through as well.
+# Annotating the parameter and the return value both as `type[Model]` erased
+# every decorated class down to that base: `EventTicketClass` stopped being a
+# class for a type checker and became a variable holding some `type[Model]`,
+# which then cannot be used in a type expression at all. TypeVar and not PEP
+# 695 syntax because this package still supports Python 3.10.
+ModelT = TypeVar("ModelT", bound="Model")
 
 
 class RegistryMetadataDict(TypedDict, total=False):
@@ -86,8 +97,8 @@ class register_model:
 
     def __call__(
         self,
-        cls: "type[Model]",
-    ) -> "type[Model]":
+        cls: type[ModelT],
+    ) -> type[ModelT]:
         """
         Registers the given class in the registry.
         """
@@ -201,9 +212,16 @@ def _find_models() -> dict[str, "type[Model]"]:
     from .models.bases import Model
 
     models: dict[str, type[Model]] = {}
-    pkg = importlib.import_module("edutap.wallet_google")
-    datatypes_module = pkg.models.datatypes
-    deprecated_module = pkg.models.deprecated
+    # Import the two modules by name instead of reaching for them as attributes
+    # of the imported package. `edutap.wallet_google.models.datatypes` is a
+    # namespace package and `.deprecated` is not imported by
+    # `models/__init__.py`; both only happen to be set as attributes because
+    # other modules imported them first. That is a load-order coincidence, and
+    # a coincidence this function's whole result depends on.
+    datatypes_module = importlib.import_module("edutap.wallet_google.models.datatypes")
+    deprecated_module = importlib.import_module(
+        "edutap.wallet_google.models.deprecated"
+    )
 
     def _collect_classes(mod):
         for cls_name, cls in inspect.getmembers(mod, inspect.isclass):
@@ -232,8 +250,10 @@ def _find_enums() -> list[str]:
     """
     Returns a list of all enum class names.
     """
-    pkg = importlib.import_module("edutap.wallet_google")
-    enums_module = pkg.models.datatypes.enums
+    # Imported by name for the same reason as in _find_models() above.
+    enums_module = importlib.import_module(
+        "edutap.wallet_google.models.datatypes.enums"
+    )
     enums: list[str] = []
     for enum_name, enum in inspect.getmembers(enums_module, inspect.isclass):
         enums.append(enum_name)

--- a/src/edutap/wallet_google/registry.py
+++ b/src/edutap/wallet_google/registry.py
@@ -46,8 +46,8 @@ _MODEL_REGISTRY_BY_MODEL: "dict[type[Model], RegistryMetadataDict]" = {}
 
 
 class register_model:
-    """
-    Registers a Pydantic model based on Model in a registry.
+    """Register a Pydantic model based on Model in a registry.
+
     To be used as a decorator.
     """
 
@@ -66,7 +66,7 @@ class register_model:
         can_message: bool = True,
     ):
         """
-        Prepares the registration of a Model or its subclasses.
+        Prepare the registration of a Model or its subclasses.
 
         :param name:        Name of the model. Usually the same as the class name.
         :param url_part:    Part of the URL to be used for the RESTful API endpoint.
@@ -100,7 +100,7 @@ class register_model:
         self,
         cls: type[ModelT],
     ) -> type[ModelT]:
-        """Registers the given class in the registry."""
+        """Register the given class in the registry."""
         name = self.metadata["name"]
         if name in _MODEL_REGISTRY_BY_NAME:
             raise ValueError(f"Duplicate registration of '{name}'")
@@ -111,12 +111,12 @@ class register_model:
 
 
 def lookup_model_by_name(name: str) -> "type[Model]":
-    """Returns the model with the given name."""
+    """Return the model with the given name."""
     return _MODEL_REGISTRY_BY_NAME[name]["model"]
 
 
 def lookup_model_by_plural_name(plural_name: str) -> "type[Model]":
-    """Returns the model with the given plural name."""
+    """Return the model with the given plural name."""
     for model in _MODEL_REGISTRY_BY_NAME.values():
         if model["plural"] == plural_name:
             return model["model"]
@@ -124,22 +124,22 @@ def lookup_model_by_plural_name(plural_name: str) -> "type[Model]":
 
 
 def lookup_metadata_by_name(name: str) -> RegistryMetadataDict:
-    """Returns the metadata of the model with the given name."""
+    """Return the metadata of the model with the given name."""
     return _MODEL_REGISTRY_BY_NAME[name]
 
 
 def lookup_metadata_by_model_instance(model: "Model") -> RegistryMetadataDict:
-    """Returns the registry metadata by a given instance of a model."""
+    """Return the registry metadata by a given instance of a model."""
     return _MODEL_REGISTRY_BY_MODEL[type(model)]
 
 
 def lookup_metadata_by_model_type(model_type: "type[Model]") -> RegistryMetadataDict:
-    """Returns the registry metadata by a given model type."""
+    """Return the registry metadata by a given model type."""
     return _MODEL_REGISTRY_BY_MODEL[model_type]
 
 
 def raise_when_operation_not_allowed(name: str, operation: str) -> None:
-    """Verifies that the given operation is allowed for the given registered name.
+    """Verify that the given operation is allowed for the given registered name.
 
     :raises: ValueError when the operation is not allowed.
     """
@@ -244,7 +244,7 @@ def _find_models() -> dict[str, "type[Model]"]:
 
 @functools.cache
 def _find_enums() -> list[str]:
-    """Returns a list of all enum class names."""
+    """Return a list of all enum class names."""
     # Imported by name for the same reason as in _find_models() above.
     enums_module = importlib.import_module(
         "edutap.wallet_google.models.datatypes.enums"
@@ -257,7 +257,7 @@ def _find_enums() -> list[str]:
 
 @functools.cache
 def _get_fields_for_model(model: "type[Model]") -> list[str]:
-    """Returns the list of valid fields for the given registered name."""
+    """Return the list of valid fields for the given model class."""
     from .models.bases import Model
 
     fields: set[str] = set()
@@ -274,7 +274,7 @@ def _get_fields_for_model(model: "type[Model]") -> list[str]:
 
 @functools.cache
 def _get_fields_for_name(name: str) -> list[str]:
-    """Returns the list of valid fields for the given registered name."""
+    """Return the list of valid fields for the given registered name."""
     from .models.bases import Model
 
     if "__" in name:
@@ -301,7 +301,7 @@ def _get_fields_for_name(name: str) -> list[str]:
 
 
 def _get_fields_from_definition(name, definition: dict) -> list[str]:
-    """Returns the list of valid fields for the given schema object."""
+    """Return the list of valid fields for the given schema object."""
     fields: set[str] = set()
     if definition in ("string", "boolean"):
         fields.add(name)

--- a/src/edutap/wallet_google/registry.py
+++ b/src/edutap/wallet_google/registry.py
@@ -100,9 +100,7 @@ class register_model:
         self,
         cls: type[ModelT],
     ) -> type[ModelT]:
-        """
-        Registers the given class in the registry.
-        """
+        """Registers the given class in the registry."""
         name = self.metadata["name"]
         if name in _MODEL_REGISTRY_BY_NAME:
             raise ValueError(f"Duplicate registration of '{name}'")
@@ -113,16 +111,12 @@ class register_model:
 
 
 def lookup_model_by_name(name: str) -> "type[Model]":
-    """
-    Returns the model with the given name.
-    """
+    """Returns the model with the given name."""
     return _MODEL_REGISTRY_BY_NAME[name]["model"]
 
 
 def lookup_model_by_plural_name(plural_name: str) -> "type[Model]":
-    """
-    Returns the model with the given plural name.
-    """
+    """Returns the model with the given plural name."""
     for model in _MODEL_REGISTRY_BY_NAME.values():
         if model["plural"] == plural_name:
             return model["model"]
@@ -130,23 +124,17 @@ def lookup_model_by_plural_name(plural_name: str) -> "type[Model]":
 
 
 def lookup_metadata_by_name(name: str) -> RegistryMetadataDict:
-    """
-    Returns the metadata of the model with the given name.
-    """
+    """Returns the metadata of the model with the given name."""
     return _MODEL_REGISTRY_BY_NAME[name]
 
 
 def lookup_metadata_by_model_instance(model: "Model") -> RegistryMetadataDict:
-    """
-    Returns the registry metadata by a given instance of a model
-    """
+    """Returns the registry metadata by a given instance of a model."""
     return _MODEL_REGISTRY_BY_MODEL[type(model)]
 
 
 def lookup_metadata_by_model_type(model_type: "type[Model]") -> RegistryMetadataDict:
-    """
-    Returns the registry metadata by a given model type
-    """
+    """Returns the registry metadata by a given model type."""
     return _MODEL_REGISTRY_BY_MODEL[model_type]
 
 
@@ -256,9 +244,7 @@ def _find_models() -> dict[str, "type[Model]"]:
 
 @functools.cache
 def _find_enums() -> list[str]:
-    """
-    Returns a list of all enum class names.
-    """
+    """Returns a list of all enum class names."""
     # Imported by name for the same reason as in _find_models() above.
     enums_module = importlib.import_module(
         "edutap.wallet_google.models.datatypes.enums"

--- a/src/edutap/wallet_google/registry.py
+++ b/src/edutap/wallet_google/registry.py
@@ -6,6 +6,7 @@ import functools
 import importlib
 import inspect
 import logging
+import pkgutil
 
 
 logger = logging.getLogger(__name__)
@@ -212,16 +213,14 @@ def _find_models() -> dict[str, "type[Model]"]:
     from .models.bases import Model
 
     models: dict[str, type[Model]] = {}
-    # Import the two modules by name instead of reaching for them as attributes
-    # of the imported package. `edutap.wallet_google.models.datatypes` is a
-    # namespace package and `.deprecated` is not imported by
-    # `models/__init__.py`; both only happen to be set as attributes because
-    # other modules imported them first. That is a load-order coincidence, and
-    # a coincidence this function's whole result depends on.
-    datatypes_module = importlib.import_module("edutap.wallet_google.models.datatypes")
+    # `models/__init__.py` does not import `.deprecated`; it is only ever set as
+    # an attribute of its parent because `misc.py` and `passes/retail.py` import
+    # from it. Importing it by name here does execute it, so this no longer
+    # depends on who else imported what first.
     deprecated_module = importlib.import_module(
         "edutap.wallet_google.models.deprecated"
     )
+    datatypes = importlib.import_module("edutap.wallet_google.models.datatypes")
 
     def _collect_classes(mod):
         for cls_name, cls in inspect.getmembers(mod, inspect.isclass):
@@ -237,10 +236,20 @@ def _find_models() -> dict[str, "type[Model]"]:
         ):
             models[cls_name] = cls
 
-    # datatypes/*
-    for name, module in inspect.getmembers(datatypes_module, inspect.ismodule):
-        if module.__name__.startswith("edutap.wallet_google.models.datatypes"):
-            _collect_classes(module)
+    # datatypes/* — enumerate the submodules from the package path and import
+    # each one, rather than asking the package object which submodules it has.
+    # `datatypes` is a namespace package: it has no `__init__.py`, so importing
+    # it executes no code and binds no submodule attributes. Anything reading
+    # the attributes therefore sees only the submodules some *other* module
+    # already imported, and a new datatypes module that nothing else imports
+    # would be silently skipped by model discovery. pkgutil.iter_modules reads
+    # the directory, so it sees every submodule whether or not it is loaded.
+    for module_info in pkgutil.iter_modules(datatypes.__path__):
+        _collect_classes(
+            importlib.import_module(
+                f"edutap.wallet_google.models.datatypes.{module_info.name}"
+            )
+        )
 
     return models
 

--- a/src/edutap/wallet_google/utils.py
+++ b/src/edutap/wallet_google/utils.py
@@ -47,7 +47,7 @@ def generate_fernet_key():
 
 
 def validate_data(model: type[Model], data: dict[str, typing.Any] | Model) -> Model:
-    """Takes a model and data, validates it and returns a model instance.
+    """Take a model and data, validate it, and return a model instance.
 
     :param model:      Pydantic model class to use for validation.
     :param data:       Data to pass to the Google RESTful API.
@@ -72,7 +72,7 @@ def validate_data_and_convert_to_json(
     resource_id_key: str = "id",
     skip_resource_id: bool = False,
 ) -> tuple[str | None, str]:
-    """Takes a model and data, validates it and convert to a json string.
+    """Take a model and data, validate it, and convert it to a JSON string.
 
     :param model:           Pydantic model class to use for validation.
     :param data:            Data to pass to the Google RESTful API.

--- a/superpowers/plans/2026-08-04-package-modernisation.md
+++ b/superpowers/plans/2026-08-04-package-modernisation.md
@@ -592,15 +592,21 @@ The point is not the version, it is where the version lives. `entry: uvx ty@0.0.
 
 The upstream hook is already `pass_filenames: false` and `always_run: true`, matching the local hook it replaces.
 
-- [ ] **Step 2: Take ty out of the pre-commit.ci skip list**
+- [ ] ~~**Step 2: Take ty out of the pre-commit.ci skip list**~~ — **SUPERSEDED, tested and reverted.**
 
-In the `ci:` block at the top of `.pre-commit-config.yaml`:
+This step said `ty` was skipped because a `local` hook shelling out to `uvx` cannot run in pre-commit.ci's sandbox, and that a remote hook can. **The second half is wrong.** It was tested rather than assumed: the branch was pushed as draft PR #96, and the ty hook was the only failure in the run.
 
-```yaml
-    skip: [check-manifest, pyroma]
+The upstream hook's entry is `uv check --quiet --preview-features=check-command --ty-version=0.0.66`. `uv check` builds the project, which resolves `build-system.requires` against PyPI, and pre-commit.ci disables network while hooks run:
+
+```
+× Failed to build `edutap-wallet-google @ file:///code`
+  ├─▶ Failed to resolve requirements from `build-system.requires`
+  ╰─▶ dns error: Temporary failure in name resolution
 ```
 
-`ty` was skipped because a `local` hook shelling out to `uvx` cannot run in pre-commit.ci's sandbox. A remote hook can.
+So the `ci:` block keeps `skip: [check-manifest, pyroma, ty]`, with that reasoning recorded as a comment in `.pre-commit-config.yaml` itself.
+
+Step 1 is unaffected and remains the point of the task: the version moved out of an `entry:` string that no tool could update — stuck at 0.0.17 for 49 releases — into a `rev:` that pre-commit.ci's monthly autoupdate maintains regardless of `skip:`. ty still runs in the GitHub Actions `lint` job via `tox -e lint` (verified passing at v0.0.66 on PR #96), and locally via `make lint`.
 
 - [ ] **Step 3: Run it and expect new diagnostics**
 

--- a/superpowers/plans/2026-08-04-package-modernisation.md
+++ b/superpowers/plans/2026-08-04-package-modernisation.md
@@ -278,7 +278,7 @@ print(len(names), 'files')
 diff sdist-before.txt sdist-after.txt
 ```
 
-Expected in the diff, as removals only: `.claude/*`, `.dockerignore`, `.editorconfig`, `.github/*`, `.gitignore`, `.pre-commit-config.yaml`, `CLAUDE.md`, `MANIFEST.in`, `RELEASING.md`, `docs/*`, `examples/*`, `superpowers/*`. `PKG-INFO` stays (hatchling generates it).
+Expected in the diff, as removals only: `.claude/*`, `.dockerignore`, `.editorconfig`, `.github/*`, `.pre-commit-config.yaml`, `CLAUDE.md`, `MANIFEST.in`, `RELEASING.md`, `docs/*`, `examples/*`, `superpowers/*`. `PKG-INFO` stays (hatchling generates it); `.gitignore` also stays — hatchling force-includes it in every sdist regardless of `include`.
 
 **Every `src/` and `tests/` path must be unchanged.** A removal under either is a mistake in the `include` list, not an improvement.
 

--- a/superpowers/plans/2026-08-04-package-modernisation.md
+++ b/superpowers/plans/2026-08-04-package-modernisation.md
@@ -4,7 +4,7 @@
 
 **Goal:** Bring `edutap.wallet_google` up to the project's tooling standard — a `Makefile` as the uniform entry point, PEP 639 and PEP 735 packaging metadata with version constraints Renovate can act on, an `sdist` that stops shipping internal documents, a `ty` pin that can actually be updated, and the full ruff rule selection.
 
-**Architecture:** Five independent changes on one branch, in an order that matters: the packaging metadata (Task 1) defines the `dev` dependency group — and gives every entry in it, in `[build-system.requires]`, and in the `callback` extra a real version constraint, which is what makes any of them visible to Renovate at all — that the `Makefile` (Task 2) then installs and depends on finding `ruff` and `ty` in. The linter rules go last so their large diffs do not sit underneath everything else during review. The six runtime dependencies in `[project.dependencies]` are out of scope for every task: their open floors stay open, by design — see the spec's Part 5.
+**Architecture:** Five independent changes on one branch, in an order that matters: the packaging metadata (Task 1) defines the `dev` dependency group — and gives every entry in it, in `[build-system.requires]`, and in the `callback` extra a real version constraint. A floor alone only stops Renovate from skipping an entry outright; making it actually actionable needs `rangeStrategy: "bump"` on the matching `renovate.json5` rule too — Task 1's final steps carry that, gated on the sibling `chore/renovate` PR (#95) merging first. The `Makefile` (Task 2) then installs from the same group and depends on finding `ruff` and `ty` in it. The linter rules go last so their large diffs do not sit underneath everything else during review. The six runtime dependencies in `[project.dependencies]` are out of scope for every task: their open floors stay open, by design — see the spec's Part 5.
 
 **Tech Stack:** hatchling, uv, prek, ruff, ty, tox, pytest.
 
@@ -17,6 +17,7 @@
 - **Do not drop Python 3.10 support in this branch.** Its end of life is 2026-10-31, which has not happened. Narrowing `requires-python` in a published library is a breaking change and belongs in its own release.
 - **Do not write the 144 missing docstrings.** The `D1xx` rules stay in `ignore`; see Task 5.
 - **Do not add upper bounds to the six runtime dependencies in `[project.dependencies]`.** Their open floors are deliberate — see the spec's Part 5 — even though Task 1 adds ceilings to `ruff` and `ty` in the dev tooling. Those are not the same kind of dependency and not the same decision.
+- **`renovate.json5` does not exist on this branch.** It lives on `chore/renovate` (PR #95), still open. Task 1's Steps 12-13 — pairing the new floors with `rangeStrategy: "bump"` — cannot run until #95 merges to `main` and `chore/package-modernisation` is rebased onto the result. Do not attempt them before then, and do not let that dependency block the rest of Task 1 or the branch: Steps 1-11 do not touch `renovate.json5` and have no reason to wait.
 - `tests/` stays in the sdist. A distribution packager wants to run the suite.
 - After Task 1 the install command everywhere is `uv pip install -U -e ".[callback]" --group dev`. `[test]`, `[typecheck]` and `[develop]` no longer exist as extras.
 - Each task ends with a green `pytest` before its commit. The suite is fast; run it.
@@ -37,6 +38,7 @@ uv pip install -e ".[test,develop]"   # the *old* extras; Task 1 replaces them
 | --- | --- | --- |
 | `pyproject.toml` | license expression, dependency groups and their version constraints, `build-system.requires` floors, sdist contents, ruff rules, dated 3.10 marker | 1, 3, 4, 5 |
 | `MANIFEST.in` | deleted — hatchling never read it | 1 |
+| `renovate.json5` (not on this branch yet — arrives with #95) | pair the new floors with `rangeStrategy: "bump"` so they are actionable, not just present | 1 (Steps 12-13, blocked on #95) |
 | `Makefile` | uniform entry point to the common workflows (create) | 2 |
 | `.pre-commit-config.yaml` | `ty` moves to the official hook repository | 3 |
 | `RELEASING.md` | the Python 3.10 removal checklist | 3 |
@@ -58,13 +60,30 @@ runs the other way: `make lint` (Task 2, Step 1) calls `$(PYTHON) -m ruff check`
 was never a project dependency before this task added it to the new `lint` group — without
 Step 4 below, Task 2's `Makefile` would have nothing installed to find.
 
+A floor alone is not the whole fix, and Steps 1-11 below only do half of it. Renovate was
+run against the repository directly (`--dry-run=full`, v44.11.6) rather than reasoned about
+from source, and `pdbp>=1.7.1` — already floored, already dependency-group-shaped, before
+any of Steps 1-11 run — is the proof: Renovate extracted it with no `skipReason` and still
+proposed nothing for it, because the pep621 manager's default `rangeStrategy` is `replace`,
+which leaves a satisfied floor untouched forever. The whole repository's dry run produced
+exactly two branches, both GitHub Actions, none for a Python dependency. Steps 12-13 are
+the other half: pairing every floor Step 4 writes with `rangeStrategy: "bump"` on the
+matching `renovate.json5` rule — but that file lives on the sibling `chore/renovate` branch
+(PR #95), still open, so those two steps are written down now and executed once #95 merges
+and this branch rebases, not before. See the spec's Part 5 for the full mechanism and the
+`ruff`/`ty` ceiling reasoning, which changes once `bump` is in the picture: a ceiling no
+longer makes an entry visible to Renovate (`bump` does that for the whole group regardless),
+so the ceilings on those two are kept for their own merits — a ruff minor release changes
+what it reports, `ty` is pre-1.0 and moving fast — not as part of the actionability fix.
+
 **Files:**
 - Modify: `pyproject.toml:13-33` (license, classifiers), `[build-system.requires]`, `:51-71` (extras → groups, with version constraints), `[tool.tox.env_run_base]`
 - Delete: `MANIFEST.in`
+- Modify (Steps 12-13 only, after PR #95 merges and this branch rebases): `renovate.json5`
 
 **Interfaces:**
-- Consumes: nothing.
-- Produces: the extra `callback` and the dependency groups `test`, `lint`, `typecheck`, `dev`, every entry version-constrained, plus a floored `[build-system.requires]`. Every later task and the `Makefile` install with `-e ".[callback]" --group dev`; Task 2's `make lint` additionally depends on `ruff` and `ty` resolving out of this group.
+- Consumes: nothing for Steps 1-11. Steps 12-13 consume `renovate.json5` from `chore/renovate` (PR #95), merged into `main` and rebased into this branch.
+- Produces: the extra `callback` and the dependency groups `test`, `lint`, `typecheck`, `dev`, every entry version-constrained, plus a floored `[build-system.requires]`. Every later task and the `Makefile` install with `-e ".[callback]" --group dev`; Task 2's `make lint` additionally depends on `ruff` and `ty` resolving out of this group. Steps 12-13 additionally produce a `renovate.json5` "development dependencies" rule with `rangeStrategy: "bump"`, which is what makes the floors above actionable rather than merely present.
 
 - [ ] **Step 1: Record what the sdist contains today**
 
@@ -319,6 +338,102 @@ floors are deliberate, and the reasoning is in the spec's Part 5.
 MANIFEST.in never did anything: hatchling does not read it, and the sdist it
 claimed to trim still contained docs/ and .claude/. An explicit sdist target
 replaces it and drops 40 files of CI configuration and internal notes."
+```
+
+- [ ] **Step 12: Pair the new floors with `rangeStrategy: "bump"` in `renovate.json5`**
+
+**Blocked until PR #95 (`chore/renovate`) merges to `main` and this branch is rebased onto
+the result.** `renovate.json5` does not exist in this checkout before that. Check first:
+
+```bash
+git fetch origin
+git log origin/main -- renovate.json5
+```
+
+If that shows nothing, stop — #95 has not merged yet, and this step is not doable. Once it
+has and this branch is rebased, `renovate.json5` will exist and carry a `packageRules` entry
+that currently reads (on `chore/renovate`, before this step):
+
+```json5
+{
+  // Everything under [project.optional-dependencies] — the callback, test,
+  // typecheck and develop extras. None of it is installed by a consumer of the
+  // library, so one pull request for the batch would be proportionate — if this
+  // rule ever matched anything. It currently does not: all eleven entries
+  // (...) are bare names with skipReason: "unspecified-version", except
+  // `pdbp>=1.7.1`, whose open floor `rangeStrategy: "replace"` leaves unchanged.
+  // Same mechanism, same nil result, as the runtime-dependency rule below — see
+  // there for the detail.
+  matchManagers: ["pep621"],
+  matchDepTypes: ["project.optional-dependencies"],
+  groupName: "development dependencies",
+},
+```
+
+Replace it with:
+
+```json5
+{
+  // The callback extra plus everything now in [dependency-groups] (test, lint,
+  // typecheck, dev) and in build-system.requires (hatchling, hatch-vcs): none of
+  // it is installed by a consumer of the library, and none of it is published in
+  // the wheel or sdist metadata a consumer resolves. Every entry here carries a
+  // version constraint as of chore/package-modernisation (Task 1) — but a floor
+  // alone is not sufficient. pdbp>=1.7.1 was already floored before that work,
+  // and a dry run against this repository (--dry-run=full, v44.11.6) still
+  // produced nothing for it: the default rangeStrategy for pep621 is "replace",
+  // which leaves an open floor unchanged whenever the newest release already
+  // satisfies it — which it always does. rangeStrategy: "bump" instead raises
+  // the floor itself to each new release. That is safe here specifically
+  // because nothing downstream resolves these ranges — unlike the
+  // runtime-dependency rule below, where the same setting would force every
+  // consumer to upgrade in lockstep.
+  matchManagers: ["pep621"],
+  matchDepTypes: [
+    "project.optional-dependencies",
+    "dependency-groups",
+    "build-system.requires",
+  ],
+  groupName: "development dependencies",
+  rangeStrategy: "bump",
+},
+```
+
+`build-system.requires` was previously unmatched by any rule — `chore/renovate`'s own
+comment on the runtime-dependency rule already flagged this as "acknowledged rather than
+given a third rule." Folding it into this rule rather than adding a fourth closes that gap
+at the same time, since it is exactly as unpublished as a dependency group.
+
+- [ ] **Step 13: Verify with a dry run, and commit**
+
+```bash
+npx --yes renovate --platform=local --dry-run=full .
+```
+
+(Or however this repository's Renovate access is configured to run locally — check
+`chore/renovate`'s own `CONTRIBUTING.md` notes on running it, added by that branch.)
+
+Expected: every entry that Step 4 floored is extracted with `rangeStrategy: "bump"` and no
+`skipReason`. If a newer release exists for any of them on the day this runs, that entry
+now produces an update — the concrete difference from the `pdbp` control case. If `ruff` or
+`ty` has a release available past its ceiling, read what Renovate proposes for it
+specifically: this is the first real test of whether `bump` respects an upper bound rather
+than jumping past it, flagged as unverified in the spec's Part 5.
+
+```bash
+git add renovate.json5
+git commit -m "build: pair dependency-group floors with rangeStrategy bump
+
+A floor alone does not make an entry actionable: pdbp>=1.7.1 was already
+floored and a dry run against this repository still proposed nothing for
+it, because pep621's default rangeStrategy (replace) leaves a satisfied
+floor unchanged. bump raises the floor itself on each release instead.
+
+Safe here because nothing downstream resolves a dependency group, the
+callback extra, or build-system.requires — unlike project.dependencies,
+where the same setting would force every consumer of this library to
+upgrade in lockstep. build-system.requires also moves into this rule,
+closing a gap the rule's own comment already flagged."
 ```
 
 ---
@@ -822,7 +937,7 @@ Structure it by the commits' subjects, and state:
 3. Python 3.10 support is deliberately **not** dropped, and why.
 4. The `D1xx` docstring rules are deliberately ignored, with the count (144) and where the comment explaining it lives.
 5. The ty jump from 0.0.17 to 0.0.66 and anything it made necessary in `[tool.ty.rules]`.
-6. Every `[dependency-groups]`, `callback` and `[build-system.requires]` entry now carries a version constraint Renovate can act on — the sibling `chore/renovate` PR (#95) found none of them actionable before this. The six runtime dependencies in `[project.dependencies]` deliberately keep their open floors; see the spec's Part 5.
+6. Every `[dependency-groups]`, `callback` and `[build-system.requires]` entry now carries a version constraint — necessary, per a `chore/renovate` (PR #95) dry run that found none of them actionable before this, but not sufficient on its own: `pdbp>=1.7.1` was already floored and still produced nothing. Actionability needs `rangeStrategy: "bump"` on the matching `renovate.json5` rule too (Task 1, Steps 12-13), which is blocked on #95 merging and may still be pending when this PR is opened — say so explicitly if it is. The six runtime dependencies in `[project.dependencies]` deliberately keep their open floors; see the spec's Part 5.
 
 - [ ] **Step 7: Stop**
 

--- a/superpowers/plans/2026-08-04-package-modernisation.md
+++ b/superpowers/plans/2026-08-04-package-modernisation.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Bring `edutap.wallet_google` up to the project's tooling standard — a `Makefile` as the uniform entry point, PEP 639 and PEP 735 packaging metadata, an `sdist` that stops shipping internal documents, a `ty` pin that can actually be updated, and the full ruff rule selection.
+**Goal:** Bring `edutap.wallet_google` up to the project's tooling standard — a `Makefile` as the uniform entry point, PEP 639 and PEP 735 packaging metadata with version constraints Renovate can act on, an `sdist` that stops shipping internal documents, a `ty` pin that can actually be updated, and the full ruff rule selection.
 
-**Architecture:** Five independent changes on one branch, in an order that matters: the packaging metadata defines the `dev` dependency group that the `Makefile` then installs, and the linter rules go last so their large diffs do not sit underneath everything else during review.
+**Architecture:** Five independent changes on one branch, in an order that matters: the packaging metadata (Task 1) defines the `dev` dependency group — and gives every entry in it, in `[build-system.requires]`, and in the `callback` extra a real version constraint, which is what makes any of them visible to Renovate at all — that the `Makefile` (Task 2) then installs and depends on finding `ruff` and `ty` in. The linter rules go last so their large diffs do not sit underneath everything else during review. The six runtime dependencies in `[project.dependencies]` are out of scope for every task: their open floors stay open, by design — see the spec's Part 5.
 
 **Tech Stack:** hatchling, uv, prek, ruff, ty, tox, pytest.
 
@@ -16,6 +16,7 @@
 - Conventional Commits. Commit messages, code, comments and identifiers in English.
 - **Do not drop Python 3.10 support in this branch.** Its end of life is 2026-10-31, which has not happened. Narrowing `requires-python` in a published library is a breaking change and belongs in its own release.
 - **Do not write the 144 missing docstrings.** The `D1xx` rules stay in `ignore`; see Task 5.
+- **Do not add upper bounds to the six runtime dependencies in `[project.dependencies]`.** Their open floors are deliberate — see the spec's Part 5 — even though Task 1 adds ceilings to `ruff` and `ty` in the dev tooling. Those are not the same kind of dependency and not the same decision.
 - `tests/` stays in the sdist. A distribution packager wants to run the suite.
 - After Task 1 the install command everywhere is `uv pip install -U -e ".[callback]" --group dev`. `[test]`, `[typecheck]` and `[develop]` no longer exist as extras.
 - Each task ends with a green `pytest` before its commit. The suite is fast; run it.
@@ -34,7 +35,7 @@ uv pip install -e ".[test,develop]"   # the *old* extras; Task 1 replaces them
 
 | File | Responsibility | Task |
 | --- | --- | --- |
-| `pyproject.toml` | license expression, dependency groups, sdist contents, ruff rules, dated 3.10 marker | 1, 3, 4, 5 |
+| `pyproject.toml` | license expression, dependency groups and their version constraints, `build-system.requires` floors, sdist contents, ruff rules, dated 3.10 marker | 1, 3, 4, 5 |
 | `MANIFEST.in` | deleted — hatchling never read it | 1 |
 | `Makefile` | uniform entry point to the common workflows (create) | 2 |
 | `.pre-commit-config.yaml` | `ty` moves to the official hook repository | 3 |
@@ -46,15 +47,24 @@ uv pip install -e ".[test,develop]"   # the *old* extras; Task 1 replaces them
 
 ---
 
-### Task 1: Packaging metadata
+### Task 1: Packaging metadata and dependency version constraints
+
+This task also carries the spec's Part 5: giving every entry in `[dependency-groups]`, the
+`callback` extra, and `[build-system.requires]` a real version constraint. It belongs here
+rather than in a new Task 7 because Step 4 below is the only place `[dependency-groups]` is
+written — adding the constraints later would mean re-editing the exact TOML block this task
+just wrote, for no benefit. Nothing about the constraints depends on Tasks 2-5, but Task 2
+runs the other way: `make lint` (Task 2, Step 1) calls `$(PYTHON) -m ruff check`, and `ruff`
+was never a project dependency before this task added it to the new `lint` group — without
+Step 4 below, Task 2's `Makefile` would have nothing installed to find.
 
 **Files:**
-- Modify: `pyproject.toml:13-33` (license, classifiers), `:51-71` (extras → groups), `[tool.tox.env_run_base]`
+- Modify: `pyproject.toml:13-33` (license, classifiers), `[build-system.requires]`, `:51-71` (extras → groups, with version constraints), `[tool.tox.env_run_base]`
 - Delete: `MANIFEST.in`
 
 **Interfaces:**
 - Consumes: nothing.
-- Produces: the extra `callback` and the dependency groups `test`, `typecheck`, `dev`. Every later task and the `Makefile` install with `-e ".[callback]" --group dev`.
+- Produces: the extra `callback` and the dependency groups `test`, `lint`, `typecheck`, `dev`, every entry version-constrained, plus a floored `[build-system.requires]`. Every later task and the `Makefile` install with `-e ".[callback]" --group dev`; Task 2's `make lint` additionally depends on `ruff` and `ty` resolving out of this group.
 
 - [ ] **Step 1: Record what the sdist contains today**
 
@@ -88,7 +98,39 @@ and delete this line from `classifiers`:
 
 PEP 639 forbids carrying both a license expression and a license classifier; leaving the classifier in makes the build fail rather than warn.
 
-- [ ] **Step 3: Move the development extras to dependency groups**
+- [ ] **Step 3: Floor `[build-system.requires]`**
+
+In `pyproject.toml`, replace:
+
+```toml
+[build-system]
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
+```
+
+with:
+
+```toml
+[build-system]
+requires = [
+    # 1.27.0 is the first hatchling release that builds a PEP 639 license
+    # expression as Metadata-Version 2.4 with License-Expression/License-File
+    # fields (Step 2 above). 1.26.x accepts the license-files array syntax
+    # without erroring but silently builds Metadata-Version 2.3 with no
+    # license fields at all; 1.24.0 and 1.25.0 reject the syntax outright.
+    # Verified by building a throwaway package against all four.
+    "hatchling>=1.27.0",
+    "hatch-vcs>=0.5.0",  # the version currently resolving; no feature drives this floor
+]
+build-backend = "hatchling.build"
+```
+
+Both were bare names before this, so Renovate skipped them outright
+(`skipReason: "unspecified-version"`); see the spec's Part 5 for the mechanism. Step 9
+below re-verifies the `Metadata-Version: 2.4` output, which doubles as confirmation that
+1.27.0 is actually sufficient.
+
+- [ ] **Step 4: Move the development extras to dependency groups, with version constraints**
 
 Replace the whole `[project.optional-dependencies]` block (lines 51-71) with:
 
@@ -96,35 +138,58 @@ Replace the whole `[project.optional-dependencies]` block (lines 51-71) with:
 [project.optional-dependencies]
 # The only extra a consumer of this library installs. Everything else that used
 # to live here is a dependency group below: groups are not published in the
-# wheel metadata, which is the right place for tooling nobody downstream needs.
+# wheel metadata, which is the right place for tooling nobody downstream needs
+# — and, per the spec's Part 5, the right place to give Renovate a version
+# constraint to act on, which none of these had before.
 callback = [
-    "fastapi",
+    "fastapi>=0.141.1",
 ]
 
 [dependency-groups]
 test = [
-    "freezegun",
-    "pytest-asyncio",
-    "pytest-cov",
-    "pytest-explicit",
-    "pytest",
-    "respx",
-    "tox",
+    "freezegun>=1.5.5",
+    "pytest-asyncio>=1.4.0",
+    "pytest-cov>=7.1.0",
+    "pytest-explicit>=1.0.1",
+    "pytest>=9.1.1",
+    "respx>=0.23.1",
+    "tox>=4.58.0",
+]
+lint = [
+    # Ceiling as well as floor: a ruff minor release changes what it reports
+    # and reformats files that were correct under the previous one — matches
+    # edutap.data_provider's own ruff>=0.16,<0.17, and matches the version
+    # already pinned in .pre-commit-config.yaml (v0.16.1) so the hook and
+    # this group cannot silently disagree. ruff was never a project
+    # dependency before this; it only ran inside pre-commit/prek's own
+    # isolated environment.
+    "ruff>=0.16.1,<0.17",
 ]
 typecheck = [
-    "ty",
+    # Ceiling as well as floor, for the same reason as ruff: ty is pre-1.0
+    # and moves fast enough that Task 3 jumps it 49 releases in one commit.
+    # Its releases are all 0.0.x, so there is no separate minor line to float
+    # within — the ceiling pins the current release exactly and asks for a
+    # deliberate bump, and a look at what changed, every single time.
+    "ty>=0.0.66,<0.0.67",
 ]
 dev = [
     {include-group = "test"},
+    {include-group = "lint"},
     {include-group = "typecheck"},
-    "pdbp>=1.7.1", # the maintained successor to pdbpp
+    "pdbp>=1.7.1", # the maintained successor to pdbpp; already floored, unchanged
     # "ipython",  not recommended with pdpb, better use ipdb then
 ]
 ```
 
 Note what is **not** there: the old `test` extra began with `"edutap.wallet-google[callback]"`. Inside an extra that is a recursive self-reference; inside a dependency group it is an ordinary requirement and would be resolved against PyPI, pulling the published package over the local checkout. `callback` therefore moves to the install command instead.
 
-- [ ] **Step 4: Point tox at the group**
+Every floor above is the version that resolved in a fresh `uv venv` + `uv pip install -e
+".[callback,test,typecheck]"` on 2026-08-05, cross-checked against PyPI's current release
+the same day — not a guess. `pdbp` already had a floor for an unrelated reason and stays
+unchanged.
+
+- [ ] **Step 5: Point tox at the group**
 
 In `[tool.tox.env_run_base]`, replace:
 
@@ -139,19 +204,20 @@ extras = ["callback"]
 dependency_groups = ["dev"]
 ```
 
-tox 4.58 supports both keys together. `dev` pulls `test` and `typecheck` in through `include-group`.
+tox 4.58 supports both keys together. `dev` pulls `test`, `lint` and `typecheck` in through `include-group`.
 
-- [ ] **Step 5: Verify the install resolves**
+- [ ] **Step 6: Verify the install resolves**
 
 ```bash
 uv pip install -e ".[callback]" --group dev
+uv pip list | grep -E "^(fastapi|ruff|ty|pdbp) "
 ```
 
-Expected: resolves and installs, including `fastapi`, `pytest`, `ty` and `pdbp`.
+Expected: resolves and installs, including `fastapi`, `pytest`, `ruff`, `ty` and `pdbp` — the second command's versions must be at or above the floors just written in Step 4.
 
-Read the output rather than only the exit code. `edutap-wallet-google` must appear as the local editable path, not as a *downloaded* package — if it is downloaded, a self-reference survived Step 3 and the checkout is being shadowed by the published release.
+Read the output rather than only the exit code. `edutap-wallet-google` must appear as the local editable path, not as a *downloaded* package — if it is downloaded, a self-reference survived Step 4 and the checkout is being shadowed by the published release.
 
-- [ ] **Step 6: Constrain the sdist and delete `MANIFEST.in`**
+- [ ] **Step 7: Constrain the sdist and delete `MANIFEST.in`**
 
 Add to `pyproject.toml`, next to the existing `[tool.hatch.build.targets.wheel]`:
 
@@ -179,7 +245,7 @@ Then:
 git rm MANIFEST.in
 ```
 
-- [ ] **Step 7: Diff the sdist against the baseline**
+- [ ] **Step 8: Diff the sdist against the baseline**
 
 ```bash
 uvx --from build pyproject-build --sdist --outdir dist-after .
@@ -197,7 +263,7 @@ Expected in the diff, as removals only: `.claude/*`, `.dockerignore`, `.editorco
 
 **Every `src/` and `tests/` path must be unchanged.** A removal under either is a mistake in the `include` list, not an improvement.
 
-- [ ] **Step 8: Confirm the license metadata in the built artefact**
+- [ ] **Step 9: Confirm the license metadata in the built artefact**
 
 ```bash
 python3 -c "
@@ -208,9 +274,9 @@ print(t.extractfile(name).read().decode()[:600])
 "
 ```
 
-Expected: `Metadata-Version: 2.4`, `License-Expression: EUPL-1.2`, `License-File: LICENSE`, and **no** `Classifier: License :: OSI Approved …`.
+Expected: `Metadata-Version: 2.4`, `License-Expression: EUPL-1.2`, `License-File: LICENSE`, and **no** `Classifier: License :: OSI Approved …`. This also confirms Step 3's `hatchling>=1.27.0` floor is sufficient — it is the same output that floor was derived from.
 
-- [ ] **Step 9: Clean up and run the suite**
+- [ ] **Step 10: Clean up and run the suite**
 
 ```bash
 rm -rf dist-before dist-after sdist-before.txt sdist-after.txt
@@ -219,23 +285,36 @@ pytest
 
 Expected: PASS.
 
-- [ ] **Step 10: Commit**
+- [ ] **Step 11: Commit**
 
-`MANIFEST.in` was already staged for deletion by the `git rm` in Step 6.
+`MANIFEST.in` was already staged for deletion by the `git rm` in Step 7.
 
 ```bash
 git add pyproject.toml
-git commit -m "build: adopt PEP 639 and PEP 735, and stop shipping internal docs
+git commit -m "build: adopt PEP 639 and PEP 735, and give Renovate real dependency versions
 
 The PEP 639 TODO in pyproject.toml is redeemable: hatchling emits
 Metadata-Version 2.4 with License-Expression, so the license text field and
-the license classifier both go.
+the license classifier both go. hatchling>=1.27.0 is now an explicit floor,
+since it is the first release that actually does this; 1.26.x accepts the
+syntax but silently drops the license fields.
 
 test, typecheck and develop were extras, which published them in the wheel
-metadata although no consumer installs them; they become dependency groups,
-with develop renamed dev. The self-reference to [callback] cannot come along —
-in a group it would resolve against PyPI rather than the checkout — so it
-moves to the install command.
+metadata although no consumer installs them; they become dependency groups
+(test, lint, typecheck, dev), with develop renamed dev and lint newly split
+out for ruff. The self-reference to [callback] cannot come along — in a
+group it would resolve against PyPI rather than the checkout — so it moves
+to the install command.
+
+Every entry in the new groups, in the callback extra, and in
+build-system.requires was previously a bare name or, in pdbp's case, already
+floored — Renovate's pep621 manager skips bare names outright
+(skipReason: unspecified-version) and leaves floors it already satisfies
+untouched. None of them are published in the wheel, so a real constraint
+costs a consumer nothing. ruff and ty additionally get a ceiling, because a
+minor release of either changes behaviour rather than only fixing it. The
+six runtime dependencies in [project.dependencies] are untouched: their open
+floors are deliberate, and the reasoning is in the spec's Part 5.
 
 MANIFEST.in never did anything: hatchling does not read it, and the sdist it
 claimed to trim still contained docs/ and .claude/. An explicit sdist target
@@ -719,7 +798,13 @@ Run: `grep -rn "MANIFEST" --exclude-dir=.git --exclude-dir=.venv .`
 
 Expected: no hits. In particular `[tool.check-manifest]` may still list entries that only made sense with it; leave the section, it is check-manifest's own configuration.
 
-- [ ] **Step 4: Review the whole diff by area**
+- [ ] **Step 4: Confirm no bare-name dependency survived in the touched blocks**
+
+Run: `grep -nE '^\s*"[a-zA-Z][a-zA-Z0-9._-]*",?\s*(#.*)?$' pyproject.toml`
+
+This also matches bare strings that are not dependencies at all — `testpaths`, `explicit-only` and similar list entries — ignore those; read the surrounding block for each hit. Expected: no hits inside `[project.optional-dependencies]`, `[dependency-groups]` or `[build-system.requires]` — every entry there now carries at least a floor (Task 1). `[project.dependencies]` is expected to still show bare entries for `httpx` and `joserfc`; those are two of the six runtime dependencies with no version constraint by design, per the spec's Part 5, and this task does not touch them.
+
+- [ ] **Step 5: Review the whole diff by area**
 
 ```bash
 git diff main...HEAD -- pyproject.toml Makefile .pre-commit-config.yaml
@@ -728,16 +813,17 @@ git diff main...HEAD --stat -- src tests
 
 The first is the substance and should be read line by line. The second is mostly docstring churn from Task 5 and is reviewed by its own commits.
 
-- [ ] **Step 5: Write the pull request description**
+- [ ] **Step 6: Write the pull request description**
 
-Structure it by the five commits' subjects, and state:
+Structure it by the commits' subjects, and state:
 
 1. `[test]`, `[typecheck]` and `[develop]` no longer exist — the install command is now `uv pip install -e ".[callback]" --group dev`. Anyone with a sibling checkout referencing the old extras has to change it.
 2. The sdist lost about 40 files of CI configuration and internal notes; `src/` and `tests/` are unchanged, verified by a file-list diff.
 3. Python 3.10 support is deliberately **not** dropped, and why.
 4. The `D1xx` docstring rules are deliberately ignored, with the count (144) and where the comment explaining it lives.
 5. The ty jump from 0.0.17 to 0.0.66 and anything it made necessary in `[tool.ty.rules]`.
+6. Every `[dependency-groups]`, `callback` and `[build-system.requires]` entry now carries a version constraint Renovate can act on — the sibling `chore/renovate` PR (#95) found none of them actionable before this. The six runtime dependencies in `[project.dependencies]` deliberately keep their open floors; see the spec's Part 5.
 
-- [ ] **Step 6: Stop**
+- [ ] **Step 7: Stop**
 
 Do not push. The user pushes and opens the pull request.

--- a/superpowers/plans/2026-08-04-package-modernisation.md
+++ b/superpowers/plans/2026-08-04-package-modernisation.md
@@ -1,0 +1,743 @@
+# Package Modernisation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring `edutap.wallet_google` up to the project's tooling standard — a `Makefile` as the uniform entry point, PEP 639 and PEP 735 packaging metadata, an `sdist` that stops shipping internal documents, a `ty` pin that can actually be updated, and the full ruff rule selection.
+
+**Architecture:** Five independent changes on one branch, in an order that matters: the packaging metadata defines the `dev` dependency group that the `Makefile` then installs, and the linter rules go last so their large diffs do not sit underneath everything else during review.
+
+**Tech Stack:** hatchling, uv, prek, ruff, ty, tox, pytest.
+
+**Spec:** `superpowers/specs/2026-08-04-package-modernisation-design.md` — read it before starting. It carries the measurements behind every number in this plan.
+
+## Global Constraints
+
+- Branch: `chore/package-modernisation`, already created from `main`. Never commit to `main`. Never `git push` — the user pushes.
+- Conventional Commits. Commit messages, code, comments and identifiers in English.
+- **Do not drop Python 3.10 support in this branch.** Its end of life is 2026-10-31, which has not happened. Narrowing `requires-python` in a published library is a breaking change and belongs in its own release.
+- **Do not write the 144 missing docstrings.** The `D1xx` rules stay in `ignore`; see Task 5.
+- `tests/` stays in the sdist. A distribution packager wants to run the suite.
+- After Task 1 the install command everywhere is `uv pip install -U -e ".[callback]" --group dev`. `[test]`, `[typecheck]` and `[develop]` no longer exist as extras.
+- Each task ends with a green `pytest` before its commit. The suite is fast; run it.
+
+## Environment setup
+
+```bash
+cd worktrees/modernisation
+uv venv
+uv pip install -e ".[test,develop]"   # the *old* extras; Task 1 replaces them
+```
+
+`pytest` below means `.venv/bin/python -m pytest`. Use `-v --no-cov -p no:cacheprovider` for fast single-file runs; the project's `addopts` otherwise force a coverage run.
+
+## File Structure
+
+| File | Responsibility | Task |
+| --- | --- | --- |
+| `pyproject.toml` | license expression, dependency groups, sdist contents, ruff rules, dated 3.10 marker | 1, 3, 4, 5 |
+| `MANIFEST.in` | deleted — hatchling never read it | 1 |
+| `Makefile` | uniform entry point to the common workflows (create) | 2 |
+| `.pre-commit-config.yaml` | `ty` moves to the official hook repository | 3 |
+| `RELEASING.md` | the Python 3.10 removal checklist | 3 |
+| `src/edutap/wallet_google/handlers/fastapi.py`, `handlers/validate.py`, `registry.py`, `credentials.py` | `B904`, `B007`, `B019` fixes | 4 |
+| `src/edutap/wallet_google/clientpool.py`, `models/datatypes/enums.py` | three `# noqa: S105` | 4 |
+| `tests/test_check_models.py`, `test_handler_validate.py`, `test_settings.py` | `B007`, `B017`, `B018` fixes | 4 |
+| every module with a docstring | `D` autofix and the 58 manual fixes | 5 |
+
+---
+
+### Task 1: Packaging metadata
+
+**Files:**
+- Modify: `pyproject.toml:13-33` (license, classifiers), `:51-71` (extras → groups), `[tool.tox.env_run_base]`
+- Delete: `MANIFEST.in`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: the extra `callback` and the dependency groups `test`, `typecheck`, `dev`. Every later task and the `Makefile` install with `-e ".[callback]" --group dev`.
+
+- [ ] **Step 1: Record what the sdist contains today**
+
+```bash
+uvx --from build pyproject-build --sdist --outdir dist-before .
+python3 -c "
+import tarfile, glob
+t = tarfile.open(glob.glob('dist-before/*.tar.gz')[0])
+names = sorted(n.split('/', 1)[1] for n in t.getnames() if '/' in n)
+open('sdist-before.txt', 'w').write('\n'.join(names))
+print(len(names), 'files')
+"
+```
+
+Expected: 108 files. This list is the baseline the last step of this task diffs against; without it, "the sdist still contains what it should" is an opinion.
+
+- [ ] **Step 2: Adopt the PEP 639 license expression**
+
+In `pyproject.toml`, replace lines 14-20 (the `license` field and the whole TODO comment block) with:
+
+```toml
+license = "EUPL-1.2"
+license-files = ["LICENSE"]
+```
+
+and delete this line from `classifiers`:
+
+```toml
+    "License :: OSI Approved :: European Union Public Licence 1.2 (EUPL 1.2)",
+```
+
+PEP 639 forbids carrying both a license expression and a license classifier; leaving the classifier in makes the build fail rather than warn.
+
+- [ ] **Step 3: Move the development extras to dependency groups**
+
+Replace the whole `[project.optional-dependencies]` block (lines 51-71) with:
+
+```toml
+[project.optional-dependencies]
+# The only extra a consumer of this library installs. Everything else that used
+# to live here is a dependency group below: groups are not published in the
+# wheel metadata, which is the right place for tooling nobody downstream needs.
+callback = [
+    "fastapi",
+]
+
+[dependency-groups]
+test = [
+    "freezegun",
+    "pytest-asyncio",
+    "pytest-cov",
+    "pytest-explicit",
+    "pytest",
+    "respx",
+    "tox",
+]
+typecheck = [
+    "ty",
+]
+dev = [
+    {include-group = "test"},
+    {include-group = "typecheck"},
+    "pdbp>=1.7.1", # the maintained successor to pdbpp
+    # "ipython",  not recommended with pdpb, better use ipdb then
+]
+```
+
+Note what is **not** there: the old `test` extra began with `"edutap.wallet-google[callback]"`. Inside an extra that is a recursive self-reference; inside a dependency group it is an ordinary requirement and would be resolved against PyPI, pulling the published package over the local checkout. `callback` therefore moves to the install command instead.
+
+- [ ] **Step 4: Point tox at the group**
+
+In `[tool.tox.env_run_base]`, replace:
+
+```toml
+extras = ["test", "develop"]
+```
+
+with:
+
+```toml
+extras = ["callback"]
+dependency_groups = ["dev"]
+```
+
+tox 4.58 supports both keys together. `dev` pulls `test` and `typecheck` in through `include-group`.
+
+- [ ] **Step 5: Verify the install resolves**
+
+```bash
+uv pip install -e ".[callback]" --group dev
+```
+
+Expected: resolves and installs, including `fastapi`, `pytest`, `ty` and `pdbp`.
+
+Read the output rather than only the exit code. `edutap-wallet-google` must appear as the local editable path, not as a *downloaded* package — if it is downloaded, a self-reference survived Step 3 and the checkout is being shadowed by the published release.
+
+- [ ] **Step 6: Constrain the sdist and delete `MANIFEST.in`**
+
+Add to `pyproject.toml`, next to the existing `[tool.hatch.build.targets.wheel]`:
+
+```toml
+[tool.hatch.build.targets.sdist]
+# hatchling does not read MANIFEST.in — that is a setuptools file, and an sdist
+# built with it in place still contained docs/ and .claude/, both of which it
+# claimed to exclude. These are the contents on purpose:
+#   tests/ stays, so a distribution packager can run the suite.
+#   superpowers/, .claude/, CLAUDE.md are internal working documents.
+#   .github/, docs/ and examples/ are not needed to build or test the package.
+include = [
+    "/src",
+    "/tests",
+    "/README.md",
+    "/CONTRIBUTING.md",
+    "/LICENSE",
+    "/pyproject.toml",
+]
+```
+
+Then:
+
+```bash
+git rm MANIFEST.in
+```
+
+- [ ] **Step 7: Diff the sdist against the baseline**
+
+```bash
+uvx --from build pyproject-build --sdist --outdir dist-after .
+python3 -c "
+import tarfile, glob
+t = tarfile.open(glob.glob('dist-after/*.tar.gz')[0])
+names = sorted(n.split('/', 1)[1] for n in t.getnames() if '/' in n)
+open('sdist-after.txt', 'w').write('\n'.join(names))
+print(len(names), 'files')
+"
+diff sdist-before.txt sdist-after.txt
+```
+
+Expected in the diff, as removals only: `.claude/*`, `.dockerignore`, `.editorconfig`, `.github/*`, `.gitignore`, `.pre-commit-config.yaml`, `CLAUDE.md`, `MANIFEST.in`, `RELEASING.md`, `docs/*`, `examples/*`, `superpowers/*`. `PKG-INFO` stays (hatchling generates it).
+
+**Every `src/` and `tests/` path must be unchanged.** A removal under either is a mistake in the `include` list, not an improvement.
+
+- [ ] **Step 8: Confirm the license metadata in the built artefact**
+
+```bash
+python3 -c "
+import tarfile, glob
+t = tarfile.open(glob.glob('dist-after/*.tar.gz')[0])
+name = [n for n in t.getnames() if n.endswith('PKG-INFO')][0]
+print(t.extractfile(name).read().decode()[:600])
+"
+```
+
+Expected: `Metadata-Version: 2.4`, `License-Expression: EUPL-1.2`, `License-File: LICENSE`, and **no** `Classifier: License :: OSI Approved …`.
+
+- [ ] **Step 9: Clean up and run the suite**
+
+```bash
+rm -rf dist-before dist-after sdist-before.txt sdist-after.txt
+pytest
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+`MANIFEST.in` was already staged for deletion by the `git rm` in Step 6.
+
+```bash
+git add pyproject.toml
+git commit -m "build: adopt PEP 639 and PEP 735, and stop shipping internal docs
+
+The PEP 639 TODO in pyproject.toml is redeemable: hatchling emits
+Metadata-Version 2.4 with License-Expression, so the license text field and
+the license classifier both go.
+
+test, typecheck and develop were extras, which published them in the wheel
+metadata although no consumer installs them; they become dependency groups,
+with develop renamed dev. The self-reference to [callback] cannot come along —
+in a group it would resolve against PyPI rather than the checkout — so it
+moves to the install command.
+
+MANIFEST.in never did anything: hatchling does not read it, and the sdist it
+claimed to trim still contained docs/ and .claude/. An explicit sdist target
+replaces it and drops 40 files of CI configuration and internal notes."
+```
+
+---
+
+### Task 2: Makefile and prek
+
+**Files:**
+- Create: `Makefile`
+- Modify: `pyproject.toml` (`[tool.tox.env.format]`, `[tool.tox.env.lint]`)
+
+**Interfaces:**
+- Consumes: the `callback` extra and the `dev` group from Task 1.
+- Produces: `make venv | lint | reformat | test-local | test-integration | test-matrix`. Later tasks use `make lint` and `make test-local`.
+
+- [ ] **Step 1: Write the Makefile**
+
+Create `Makefile`. It follows `edutap.data_provider`'s, including the reason tools are invoked through the venv interpreter rather than `uv run`:
+
+```makefile
+# Tools run from .venv, not through `uv run`: this package declares an entry point
+# group that uv resolves against the whole environment, and a bare `uv run` can fail
+# in a checkout where sibling eduTAP packages are not installed.
+PYTHON := .venv/bin/python
+VENV   := .venv
+
+.DEFAULT_GOAL := help
+.PHONY: help venv lint reformat test-local test-integration test-matrix
+
+help: ## Show available targets
+	@grep -hE '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) \
+		| awk -F':.*?## ' '{printf "  %-18s %s\n", $$1, $$2}'
+
+venv: ## Create .venv and install the package with the callback extra and dev group
+	test -d $(VENV) || uv venv
+	uv pip install -U -e ".[callback]" --group dev
+
+lint: venv ## Run ruff checks and the type checker
+	$(PYTHON) -m ruff check src tests
+	$(PYTHON) -m ruff format --check src tests
+	uvx ty check
+
+reformat: venv ## Autoformat and autofix
+	$(PYTHON) -m ruff format src tests
+	$(PYTHON) -m ruff check --fix src tests
+
+test-local: venv ## Unit tests, no Google credentials needed
+	$(PYTHON) -m pytest
+
+test-integration: venv ## Tests against the real Google Wallet API, needs credentials
+	$(PYTHON) -m pytest --run-integration
+
+test-matrix: venv ## The full tox matrix, py310 through py314
+	uvx --with "tox-uv,tox-gh" tox
+```
+
+`ty` is invoked with `uvx` rather than `$(PYTHON) -m ty` to match how `.pre-commit-config.yaml` runs it, so `make lint` and the hook cannot disagree about the version.
+
+- [ ] **Step 2: Verify every target**
+
+```bash
+make help
+make venv
+make lint
+make test-local
+```
+
+Expected: `help` lists six targets; `venv` installs; `lint` and `test-local` pass. Do not run `test-integration` — it needs Google credentials and creates permanent objects in the Wallet account.
+
+- [ ] **Step 3: Switch the tox hook environments to prek**
+
+In `pyproject.toml`, `[tool.tox.env.format]` and `[tool.tox.env.lint]` both list `deps = ["pre-commit"]` and call `pre-commit`. Replace with `prek`, which is a drop-in for the same `.pre-commit-config.yaml`:
+
+```toml
+[tool.tox.env.format]
+description = "automatically reformats code"
+skip_install = true
+deps = ["prek"]
+commands = [
+    ["prek", "run", "-a", "ruff"],
+    ["prek", "run", "-a", "ruff-format"],
+]
+
+[tool.tox.env.lint]
+description = "run linters that will help improve the code style"
+skip_install = true
+deps = ["prek"]
+commands = [["prek", "run", "-a"]]
+```
+
+Leave the `ci:` block in `.pre-commit-config.yaml` alone. pre-commit.ci runs server-side on real `pre-commit`; prek is the local runner, and the two share the config file by design.
+
+- [ ] **Step 4: Verify the lint environment still works**
+
+Run: `uvx --with tox-uv tox -e lint`
+
+Expected: PASS, the same hooks as before. If a hook behaves differently under prek, that is a prek incompatibility worth reporting — do not paper over it by reverting only that hook.
+
+- [ ] **Step 5: Document the Makefile**
+
+In `CONTRIBUTING.md`, add near the top of whatever section covers getting started:
+
+```markdown
+## Common tasks
+
+    make help              # list every target
+    make venv              # create .venv and install the package for development
+    make lint              # ruff check, ruff format --check, ty check
+    make reformat          # ruff format and ruff check --fix
+    make test-local        # the unit suite
+    make test-matrix       # the full tox matrix, py310 through py314
+
+`make test-integration` runs against the real Google Wallet API. It needs
+credentials and it creates objects that cannot be deleted; read
+`tests/integration/` before running it.
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Makefile pyproject.toml CONTRIBUTING.md
+git commit -m "build: add a Makefile and switch the local hook runner to prek
+
+Every repository is supposed to expose its common workflows through the same
+make targets; this one had none. Follows edutap.data_provider's Makefile,
+including its reason for calling .venv/bin/python rather than uv run.
+
+prek reads the same .pre-commit-config.yaml, so only the two tox environments
+change. pre-commit.ci keeps running server-side on pre-commit."
+```
+
+---
+
+### Task 3: The two things with an expiry date
+
+**Files:**
+- Modify: `.pre-commit-config.yaml` (the `local` ty hook, and the `ci: skip:` list)
+- Modify: `pyproject.toml:13` (dated comment beside `requires-python`)
+- Modify: `RELEASING.md`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing consumed later.
+
+- [ ] **Step 1: Replace the local ty hook with the official repository**
+
+In `.pre-commit-config.yaml`, delete the whole `- repo: local` block containing the `ty` hook and add:
+
+```yaml
+-   repo: https://github.com/astral-sh/ty-pre-commit
+    rev: v0.0.66
+    hooks:
+    -   id: ty
+```
+
+The point is not the version, it is where the version lives. `entry: uvx ty@0.0.17 check` is a string no tool updates: `pre-commit autoupdate` rewrites `rev:` on remote repositories only, and no Renovate manager reads a version out of an `entry`. That pin sat 49 releases behind. In a `rev:` it is inside pre-commit.ci's monthly autoupdate.
+
+The upstream hook is already `pass_filenames: false` and `always_run: true`, matching the local hook it replaces.
+
+- [ ] **Step 2: Take ty out of the pre-commit.ci skip list**
+
+In the `ci:` block at the top of `.pre-commit-config.yaml`:
+
+```yaml
+    skip: [check-manifest, pyroma]
+```
+
+`ty` was skipped because a `local` hook shelling out to `uvx` cannot run in pre-commit.ci's sandbox. A remote hook can.
+
+- [ ] **Step 3: Run it and expect new diagnostics**
+
+Run: `uvx --with tox-uv tox -e lint`
+
+Expected: **possibly FAIL.** ty is pre-1.0 and this jumps 49 releases. Read what it reports:
+
+- A diagnostic pointing at a real problem: fix the code.
+- A diagnostic from a rule stricter than the project wants right now: add it to `[tool.ty.rules]` as `"warn"`, next to the four already there, with a comment saying why.
+
+Do not silence a category wholesale without reading its instances.
+
+- [ ] **Step 4: Commit the hook change separately**
+
+```bash
+git add .pre-commit-config.yaml pyproject.toml
+git commit -m "build: run ty from its own pre-commit repository
+
+The local hook pinned ty inside an entry string as uvx ty@0.0.17, where
+nothing could update it: pre-commit autoupdate only rewrites rev: on remote
+repositories. It had fallen 49 releases behind. In a rev: it is inside
+pre-commit.ci's monthly autoupdate, which also lets it come off the skip
+list."
+```
+
+- [ ] **Step 5: Mark the Python 3.10 end of life**
+
+In `pyproject.toml`, directly above `requires-python` on line 13:
+
+```toml
+# Python 3.10 reaches end of life on 2026-10-31. Dropping it narrows this
+# field, which is a breaking change for consumers, so it gets its own release
+# rather than riding along with something else. Everything that changes with
+# it: requires-python below, the 3.10 classifier, [tool.ruff] target-version,
+# [tool.ty.environment] python-version, [tool.tox] env_list,
+# [tool.tox.gh.python], and the matrix in .github/workflows/tests.yaml.
+requires-python = ">=3.10"
+```
+
+- [ ] **Step 6: Add it to the release checklist**
+
+In `RELEASING.md`, under "Creating a Release", add as a new first item in the numbered list:
+
+```markdown
+1. Check whether any supported Python version has reached end of life
+   (<https://endoflife.date/python>). Dropping one narrows `requires-python`
+   and is a breaking change: it needs its own release and a note in the
+   release description, not a quiet ride along with other work.
+```
+
+Renumber the items that follow.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pyproject.toml RELEASING.md
+git commit -m "docs: record the Python 3.10 end of life and what it touches
+
+3.10 goes end of life on 2026-10-31. Support is not dropped here — that
+narrows requires-python and belongs in its own release — but the date and the
+seven places that change with it are now written down where someone cutting a
+release will read them."
+```
+
+---
+
+### Task 4: ruff rule groups B and S
+
+**Files:**
+- Modify: `pyproject.toml` (`[tool.ruff.lint]`)
+- Modify: `src/edutap/wallet_google/handlers/fastapi.py` (7 × B904), `handlers/validate.py:334` (B904), `registry.py:223,238` (B007), `credentials.py:21` (B019)
+- Modify: `src/edutap/wallet_google/clientpool.py:59`, `models/datatypes/enums.py:175,177` (S105)
+- Modify: `tests/test_check_models.py:28` (B007), `tests/test_handler_validate.py:100` (B017), `tests/test_settings.py:44,52` (B018)
+
+**Interfaces:**
+- Consumes: `make lint` from Task 2.
+- Produces: `select` containing `B` and `S`. Task 5 extends the same list with `D`.
+
+- [ ] **Step 1: Enable B and S and see the full list**
+
+In `pyproject.toml`, `[tool.ruff.lint]`:
+
+```toml
+select = ["B", "E", "F", "I", "S", "UP", "W"]
+ignore = ["E501"]
+
+[tool.ruff.lint.per-file-ignores]
+# assert *is* the test framework here; S101 in tests is not a finding.
+"tests/**" = ["S101"]
+```
+
+Run: `.venv/bin/python -m ruff check src tests`
+
+Expected: 15 `B` findings and 1 `S101` in `src`, plus 3 `S105`. The 404 `S101` in `tests` must be gone — if they are not, the `per-file-ignores` pattern is wrong.
+
+- [ ] **Step 2: Fix the eight B904 findings**
+
+Seven in `src/edutap/wallet_google/handlers/fastapi.py` (lines 39, 74, 96, 119, 126, 130, 135) and one in `src/edutap/wallet_google/handlers/validate.py:334`. Each is a `raise` inside an `except` block that drops the original traceback. The shape:
+
+```python
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail="…") from error
+```
+
+Use `from error` where the original exception adds information to a debugging session, and `from None` where the original is noise the caller must not see — for example when the original carries a credential or an internal path. Decide per site; do not apply one of them mechanically to all eight.
+
+- [ ] **Step 3: Fix the four B007 findings**
+
+`src/edutap/wallet_google/registry.py:223` (`name`), `:238` (`enum`), and `tests/test_check_models.py:28` (`name`). A loop control variable that is never used gets an underscore prefix:
+
+```python
+    for _name, value in mapping.items():
+```
+
+Do this only where the variable really is unused. If it turns out to be used further down, the finding was telling you the loop is wrong, not the name.
+
+- [ ] **Step 4: Fix B017, B018 and B019**
+
+- `tests/test_handler_validate.py:100` — `B017`, `pytest.raises(Exception)` asserts nothing useful, because every failure mode matches. Narrow it to the exception the code under test actually raises. If that is genuinely unknown, run the test and read what comes out.
+- `tests/test_settings.py:44` and `:52` — `B018`, an expression whose value is discarded. Either it was meant to be an assertion, in which case make it one, or it is dead and gets deleted. Read the surrounding test before choosing.
+- `src/edutap/wallet_google/credentials.py:21` — `B019`, `functools.cache` on a method keeps `self` alive for the process lifetime. This one is a design question, not a lint fix: the cache belongs on a module-level function keyed by the argument, or on the instance. If the class is a long-lived singleton the leak is bounded and a `# noqa: B019` with that reasoning is defensible — but write the reasoning.
+
+- [ ] **Step 5: Annotate the three S105 false positives**
+
+All three are `S105 hardcoded-password-string` matching on a *name*, not a value:
+
+`src/edutap/wallet_google/clientpool.py:59`:
+
+```python
+        token_endpoint = "https://oauth2.googleapis.com/token"  # noqa: S105  # a URL, not a secret
+```
+
+`src/edutap/wallet_google/models/datatypes/enums.py:175` and `:177`:
+
+```python
+    GENERIC_SEASON_PASS = "GENERIC_SEASON_PASS"  # noqa: S105  # an enum member, not a secret
+    GENERIC_PARKING_PASS = "GENERIC_PARKING_PASS"  # noqa: S105  # an enum member, not a secret
+```
+
+Per-line `noqa` rather than ignoring `S105` project-wide, so a genuinely hardcoded secret would still be caught.
+
+- [ ] **Step 6: Deal with the one S101 in src**
+
+It is at `src/edutap/wallet_google/api.py:316`.
+
+An `assert` in library code is removed by `python -O` and must not be load-bearing. Read what it guards: if it is an invariant a caller could violate, it becomes a real `raise` with a message; if it is a developer note about something the type system already guarantees, delete it. Do not add a `# noqa` — that keeps a statement that vanishes under `-O`.
+
+- [ ] **Step 7: Verify**
+
+```bash
+make lint
+make test-local
+```
+
+Expected: both PASS, no `B` or `S` findings.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add pyproject.toml src tests
+git commit -m "style: enable ruff's bugbear and security rules
+
+B found fifteen issues, eight of them raise statements inside except blocks
+that discarded the original traceback, plus a functools.cache on a method.
+
+S is almost entirely S101 in tests, which is what pytest is — ignored per
+file rather than project-wide. The three S105 in src are a URL constant and
+two enum members, annotated individually so a real hardcoded secret would
+still be caught."
+```
+
+---
+
+### Task 5: ruff rule group D
+
+**Files:**
+- Modify: `pyproject.toml` (`[tool.ruff.lint]`)
+- Modify: most modules under `src/` and `tests/`
+
+**Interfaces:**
+- Consumes: the `select` list from Task 4.
+- Produces: nothing consumed later.
+
+Measured on `main` with `convention = "pep257"` set: 508 `D` findings, 201 after
+`--fix --unsafe-fixes`, of which 144 are the "undocumented" `D1xx` rules and 57 are wording
+and layout of docstrings that already exist.
+
+The convention matters to those numbers. Without it there are 864 findings, because
+`D212`, `D213`, `D415` and `D404` are all active; `pep257` switches off the ones that
+belong to other conventions. It also resolves the `D203`/`D211` and `D212`/`D213`
+incompatibility warnings on its own — verified, they disappear from ruff's output — so no
+explicit `ignore` entry for them is needed.
+
+- [ ] **Step 1: Enable D with the undocumented rules excluded**
+
+In `pyproject.toml`, `[tool.ruff.lint]`:
+
+```toml
+select = ["B", "D", "E", "F", "I", "S", "UP", "W"]
+ignore = [
+    "E501",
+    # The "undocumented public …" rules. 144 findings, every one of which needs
+    # a docstring written rather than a fix applied. Enabling them now would buy
+    # 144 hasty docstrings or a permanent blanket ignore. Write the docstrings,
+    # then delete these lines — not the other way round.
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D104",
+    "D107",
+]
+
+[tool.ruff.lint.pydocstyle]
+# Also settles the D203/D211 and D212/D213 incompatibilities, which ruff
+# otherwise warns about on every single run.
+convention = "pep257"
+```
+
+- [ ] **Step 2: Count what that leaves**
+
+Run: `.venv/bin/python -m ruff check --statistics --select D src tests`
+
+Expected: 364 findings — 508 minus the 144 now-ignored `D1xx`. If you see roughly 720, the `[tool.ruff.lint.pydocstyle]` block did not take effect; check it is a top-level table and not nested inside another.
+
+- [ ] **Step 3: Apply the fixes and read the diff**
+
+Only 2 of these are *safe* fixes; the other 305 need `--unsafe-fixes`. A separate safe-only commit would therefore contain two lines and waste a review round, so this is one commit — but one whose diff has to be read rather than trusted.
+
+```bash
+.venv/bin/python -m ruff check --select D --fix --unsafe-fixes src tests
+.venv/bin/python -m ruff format src tests
+git diff
+```
+
+`--unsafe-fixes` rewrites docstring *text*: it moves summary lines onto the first line, reflows single-line docstrings that were wrapped, and adjusts punctuation. Read it. A docstring that now says something false is worse than one that was merely punctuated wrongly, and ruff cannot tell the difference.
+
+- [ ] **Step 4: Verify and commit**
+
+```bash
+make test-local
+git add -A src tests
+git commit -m "style: apply ruff's pydocstyle fixes
+
+Almost all of these need --unsafe-fixes, which rewrites docstring text rather
+than only layout, so the diff was read rather than trusted."
+```
+
+- [ ] **Step 5: Fix the 57 remaining by hand**
+
+Run: `.venv/bin/python -m ruff check --select D src tests`
+
+Expected: 57, in three kinds:
+
+- `D401` (30) `non-imperative-mood` — "Returns the client" becomes "Return the client".
+- `D205` (25) `missing-blank-line-after-summary` — insert a blank line between the one-line summary and the body.
+- `D400` (2) `missing-trailing-period`.
+
+`D401` is the one to be careful with: rewriting the mood is easy, but if the resulting sentence no longer describes what the function does, fix the sentence rather than the mood.
+
+- [ ] **Step 6: Verify**
+
+```bash
+make lint
+make test-local
+```
+
+Expected: both PASS, no `D` findings outside the ignored `D1xx`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A src tests
+git commit -m "style: fix the docstrings ruff could not fix automatically
+
+Mood, summary-line layout and punctuation across 57 docstrings. The 144
+missing docstrings the D1xx rules would report stay ignored and are separate
+work; see the comment in pyproject.toml."
+```
+
+---
+
+### Task 6: Full verification and pull request preparation
+
+**Files:** none modified.
+
+**Interfaces:**
+- Consumes: Tasks 1-5.
+- Produces: a branch ready for review.
+
+- [ ] **Step 1: Everything green from the Makefile**
+
+```bash
+make lint
+make test-local
+make test-matrix
+```
+
+Expected: all PASS. `test-matrix` builds five environments and is slow; it is also the only step that proves the dependency-group change works on every supported interpreter rather than just the one in `.venv`.
+
+- [ ] **Step 2: Confirm no stale reference to the removed extras**
+
+Run: `grep -rn "\[test\]\|\[typecheck\]\|\[develop\]\|test,develop" --exclude-dir=.git --exclude-dir=.venv .`
+
+Expected: no hits in `pyproject.toml`, the workflows, `CONTRIBUTING.md`, `CLAUDE.md` or `RELEASING.md`. `.github/workflows/` installs tox rather than the extras, so it should already be clean — check rather than assume.
+
+- [ ] **Step 3: Confirm `MANIFEST.in` is gone and nothing references it**
+
+Run: `grep -rn "MANIFEST" --exclude-dir=.git --exclude-dir=.venv .`
+
+Expected: no hits. In particular `[tool.check-manifest]` may still list entries that only made sense with it; leave the section, it is check-manifest's own configuration.
+
+- [ ] **Step 4: Review the whole diff by area**
+
+```bash
+git diff main...HEAD -- pyproject.toml Makefile .pre-commit-config.yaml
+git diff main...HEAD --stat -- src tests
+```
+
+The first is the substance and should be read line by line. The second is mostly docstring churn from Task 5 and is reviewed by its own commits.
+
+- [ ] **Step 5: Write the pull request description**
+
+Structure it by the five commits' subjects, and state:
+
+1. `[test]`, `[typecheck]` and `[develop]` no longer exist — the install command is now `uv pip install -e ".[callback]" --group dev`. Anyone with a sibling checkout referencing the old extras has to change it.
+2. The sdist lost about 40 files of CI configuration and internal notes; `src/` and `tests/` are unchanged, verified by a file-list diff.
+3. Python 3.10 support is deliberately **not** dropped, and why.
+4. The `D1xx` docstring rules are deliberately ignored, with the count (144) and where the comment explaining it lives.
+5. The ty jump from 0.0.17 to 0.0.66 and anything it made necessary in `[tool.ty.rules]`.
+
+- [ ] **Step 6: Stop**
+
+Do not push. The user pushes and opens the pull request.

--- a/superpowers/plans/2026-08-04-package-modernisation.md
+++ b/superpowers/plans/2026-08-04-package-modernisation.md
@@ -4,7 +4,7 @@
 
 **Goal:** Bring `edutap.wallet_google` up to the project's tooling standard — a `Makefile` as the uniform entry point, PEP 639 and PEP 735 packaging metadata with version constraints Renovate can act on, an `sdist` that stops shipping internal documents, a `ty` pin that can actually be updated, and the full ruff rule selection.
 
-**Architecture:** Five independent changes on one branch, in an order that matters: the packaging metadata (Task 1) defines the `dev` dependency group — and gives every entry in it, in `[build-system.requires]`, and in the `callback` extra a real version constraint. A floor alone only stops Renovate from skipping an entry outright; making it actually actionable needs `rangeStrategy: "bump"` on the matching `renovate.json5` rule too — Task 1's final steps carry that, gated on the sibling `chore/renovate` PR (#95) merging first. The `Makefile` (Task 2) then installs from the same group and depends on finding `ruff` and `ty` in it. The linter rules go last so their large diffs do not sit underneath everything else during review. The six runtime dependencies in `[project.dependencies]` are out of scope for every task: their open floors stay open, by design — see the spec's Part 5.
+**Architecture:** Five independent changes on one branch, in an order that matters: the packaging metadata (Task 1) defines the `dev` dependency group and gives every entry in it, and in `[build-system.requires]`, a real version constraint. A floor alone only stops Renovate from skipping an entry outright; making it actually actionable needs `rangeStrategy: "bump"` on the matching `renovate.json5` rule too — Task 1's final steps carry that, gated on the sibling `chore/renovate` PR (#95) merging first. The `callback` extra is published wheel metadata a consumer resolves, so it follows the same rule as `[project.dependencies]` instead: no constraint without a real code reason, and never `bump`. The `Makefile` (Task 2) then installs from the same group and depends on finding `ruff` and `ty` in it. The linter rules go last so their large diffs do not sit underneath everything else during review. The six runtime dependencies in `[project.dependencies]` are out of scope for every task: their open floors stay open, by design — see the spec's Part 5.
 
 **Tech Stack:** hatchling, uv, prek, ruff, ty, tox, pytest.
 
@@ -83,7 +83,7 @@ what it reports, `ty` is pre-1.0 and moving fast — not as part of the actionab
 
 **Interfaces:**
 - Consumes: nothing for Steps 1-11. Steps 12-13 consume `renovate.json5` from `chore/renovate` (PR #95), merged into `main` and rebased into this branch.
-- Produces: the extra `callback` and the dependency groups `test`, `lint`, `typecheck`, `dev`, every entry version-constrained, plus a floored `[build-system.requires]`. Every later task and the `Makefile` install with `-e ".[callback]" --group dev`; Task 2's `make lint` additionally depends on `ruff` and `ty` resolving out of this group. Steps 12-13 additionally produce a `renovate.json5` "development dependencies" rule with `rangeStrategy: "bump"`, which is what makes the floors above actionable rather than merely present.
+- Produces: the extra `callback` (published, unconstrained — no code reason for a floor exists) and the dependency groups `test`, `lint`, `typecheck`, `dev`, every entry version-constrained, plus a floored `[build-system.requires]`. Every later task and the `Makefile` install with `-e ".[callback]" --group dev`; Task 2's `make lint` additionally depends on `ruff` and `ty` resolving out of this group. Steps 12-13 additionally produce a `renovate.json5` "development dependencies" rule matching `dependency-groups` and `build-system.requires` (not `project.optional-dependencies` — see Step 12) with `rangeStrategy: "bump"`, which is what makes the floors above actionable rather than merely present.
 
 - [ ] **Step 1: Record what the sdist contains today**
 
@@ -157,11 +157,15 @@ Replace the whole `[project.optional-dependencies]` block (lines 51-71) with:
 [project.optional-dependencies]
 # The only extra a consumer of this library installs. Everything else that used
 # to live here is a dependency group below: groups are not published in the
-# wheel metadata, which is the right place for tooling nobody downstream needs
-# — and, per the spec's Part 5, the right place to give Renovate a version
-# constraint to act on, which none of these had before.
+# wheel metadata, which is the right place for tooling nobody downstream needs.
+#
+# `callback` does not get the same treatment: it IS published, so it follows
+# the spec's Part 5 rule for [project.dependencies], not the dependency-groups
+# rule — a floor only when a real code requirement backs it, no ceiling, no
+# Renovate `bump`. handlers/fastapi.py needs nothing past FastAPI's earliest
+# 0.x releases, so no floor is added.
 callback = [
-    "fastapi>=0.141.1",
+    "fastapi",
 ]
 
 [dependency-groups]
@@ -203,10 +207,13 @@ dev = [
 
 Note what is **not** there: the old `test` extra began with `"edutap.wallet-google[callback]"`. Inside an extra that is a recursive self-reference; inside a dependency group it is an ordinary requirement and would be resolved against PyPI, pulling the published package over the local checkout. `callback` therefore moves to the install command instead.
 
-Every floor above is the version that resolved in a fresh `uv venv` + `uv pip install -e
-".[callback,test,typecheck]"` on 2026-08-05, cross-checked against PyPI's current release
-the same day — not a guess. `pdbp` already had a floor for an unrelated reason and stays
-unchanged.
+Every floor above except `callback`'s is the version that resolved in a fresh `uv venv` + `uv
+pip install -e ".[callback,test,typecheck]"` on 2026-08-05, cross-checked against PyPI's
+current release the same day — not a guess. `pdbp` already had a floor for an unrelated
+reason and stays unchanged. `callback` deliberately gets no floor at all: it is published
+metadata, so "the version that happened to resolve today" is not a justification this plan
+accepts for it, the same way it would not be accepted for one of the six entries in
+`[project.dependencies]`.
 
 - [ ] **Step 5: Point tox at the group**
 
@@ -374,13 +381,13 @@ Replace it with:
 
 ```json5
 {
-  // The callback extra plus everything now in [dependency-groups] (test, lint,
-  // typecheck, dev) and in build-system.requires (hatchling, hatch-vcs): none of
-  // it is installed by a consumer of the library, and none of it is published in
-  // the wheel or sdist metadata a consumer resolves. Every entry here carries a
-  // version constraint as of chore/package-modernisation (Task 1) — but a floor
-  // alone is not sufficient. pdbp>=1.7.1 was already floored before that work,
-  // and a dry run against this repository (--dry-run=full, v44.11.6) still
+  // Everything now in [dependency-groups] (test, lint, typecheck, dev) and in
+  // build-system.requires (hatchling, hatch-vcs): none of it is installed by
+  // a consumer of the library, and none of it is published in the wheel or
+  // sdist metadata a consumer resolves. Every entry here carries a version
+  // constraint as of chore/package-modernisation (Task 1) — but a floor alone
+  // is not sufficient. pdbp>=1.7.1 was already floored before that work, and
+  // a dry run against this repository (--dry-run=full, v44.11.6) still
   // produced nothing for it: the default rangeStrategy for pep621 is "replace",
   // which leaves an open floor unchanged whenever the newest release already
   // satisfies it — which it always does. rangeStrategy: "bump" instead raises
@@ -388,9 +395,20 @@ Replace it with:
   // because nothing downstream resolves these ranges — unlike the
   // runtime-dependency rule below, where the same setting would force every
   // consumer to upgrade in lockstep.
+  //
+  // project.optional-dependencies is deliberately NOT in matchDepTypes below,
+  // even though it matched the "before" rule above. After Task 1 it holds only
+  // the callback extra, and callback is published wheel metadata that a
+  // consumer of this library actually resolves — unlike everything else this
+  // rule groups. bump would ratchet callback's fastapi floor to each new
+  // FastAPI release and force every application using this extra to upgrade
+  // in lockstep, which is exactly the harm the runtime-dependency rule below
+  // exists to avoid. callback currently carries no floor at all (Task 1 found
+  // no code reason for one), so this rule has nothing to match there today
+  // regardless; if callback ever gets a real floor, it belongs with the
+  // runtime-dependency rule's reasoning, not this one.
   matchManagers: ["pep621"],
   matchDepTypes: [
-    "project.optional-dependencies",
     "dependency-groups",
     "build-system.requires",
   ],
@@ -429,11 +447,16 @@ floored and a dry run against this repository still proposed nothing for
 it, because pep621's default rangeStrategy (replace) leaves a satisfied
 floor unchanged. bump raises the floor itself on each release instead.
 
-Safe here because nothing downstream resolves a dependency group, the
-callback extra, or build-system.requires — unlike project.dependencies,
-where the same setting would force every consumer of this library to
-upgrade in lockstep. build-system.requires also moves into this rule,
-closing a gap the rule's own comment already flagged."
+Safe here because nothing downstream resolves a dependency group or
+build-system.requires — unlike project.dependencies, where the same
+setting would force every consumer of this library to upgrade in
+lockstep. build-system.requires also moves into this rule, closing a gap
+the rule's own comment already flagged.
+
+project.optional-dependencies stays out of this rule on purpose: after
+Task 1 it holds only the published callback extra, which a consumer of
+this library resolves directly, so it follows project.dependencies'
+rule (open floor, no bump) rather than this one."
 ```
 
 ---
@@ -943,7 +966,7 @@ Structure it by the commits' subjects, and state:
 3. Python 3.10 support is deliberately **not** dropped, and why.
 4. The `D1xx` docstring rules are deliberately ignored, with the count (144) and where the comment explaining it lives.
 5. The ty jump from 0.0.17 to 0.0.66 and anything it made necessary in `[tool.ty.rules]`.
-6. Every `[dependency-groups]`, `callback` and `[build-system.requires]` entry now carries a version constraint — necessary, per a `chore/renovate` (PR #95) dry run that found none of them actionable before this, but not sufficient on its own: `pdbp>=1.7.1` was already floored and still produced nothing. Actionability needs `rangeStrategy: "bump"` on the matching `renovate.json5` rule too (Task 1, Steps 12-13), which is blocked on #95 merging and may still be pending when this PR is opened — say so explicitly if it is. The six runtime dependencies in `[project.dependencies]` deliberately keep their open floors; see the spec's Part 5.
+6. Every `[dependency-groups]` and `[build-system.requires]` entry now carries a version constraint — necessary, per a `chore/renovate` (PR #95) dry run that found none of them actionable before this, but not sufficient on its own: `pdbp>=1.7.1` was already floored and still produced nothing. Actionability needs `rangeStrategy: "bump"` on the matching `renovate.json5` rule too (Task 1, Steps 12-13), which is blocked on #95 merging and may still be pending when this PR is opened — say so explicitly if it is. `callback` is deliberately excluded from this: it is published wheel metadata a consumer resolves, so it follows `[project.dependencies]`'s rule instead — no constraint without a real code reason, and never `bump` — and it keeps no floor at all. The six runtime dependencies in `[project.dependencies]` deliberately keep their open floors; see the spec's Part 5.
 
 - [ ] **Step 7: Stop**
 

--- a/superpowers/specs/2026-08-04-package-modernisation-design.md
+++ b/superpowers/specs/2026-08-04-package-modernisation-design.md
@@ -14,10 +14,13 @@ are four gaps, each verified rather than assumed:
 3. Two packaging standards the project can now adopt — one of which its own `pyproject.toml`
    already carries a TODO for — plus an `sdist` that ships internal working documents.
 4. The ruff rule selection is narrower than the project standard.
+5. None of the repository's Python dependencies are actionable by Renovate — not because
+   Renovate is misconfigured, but because of how they are declared here, verified from
+   Renovate's source during a sibling branch's review.
 
-These are grouped into four parts below. They land on one branch,
+These are grouped into five parts below. They land on one branch,
 `chore/package-modernisation`, because they overlap heavily in `pyproject.toml` and
-splitting them would mean four branches rebasing over each other for the same file.
+splitting them would mean five branches rebasing over each other for the same file.
 
 ## Part 1: Makefile and prek
 
@@ -238,6 +241,127 @@ Only 2 of the fixes are *safe*; the other 305 need `--unsafe-fixes`, which rewri
 docstring text rather than only layout. That pass is therefore reviewed rather than
 trusted — but it is not worth splitting off a safe-only commit containing two lines.
 
+## Part 5: Dependency version constraints, so Renovate has something to act on
+
+A sibling branch, `chore/renovate` (PR #95), added a Renovate configuration to this
+repository. Its review turned up something the Renovate configuration itself cannot fix:
+measured against `pyproject.toml` on `main`, Renovate can act on none of the Python
+dependencies.
+
+| Block | Entries | Actionable | Why not |
+| --- | --- | --- | --- |
+| `[project.dependencies]` | 6 | 0 | `httpx`, `joserfc` are bare names; `authlib>=1.7.2`, `cryptography>=48.0.1`, `pydantic-settings>=2.14.2`, `pydantic[email]>=2.0` are open floors |
+| `[project.optional-dependencies]` | 11 | 0 | ten bare names (`fastapi`, `freezegun`, `pytest`, `pytest-asyncio`, `pytest-cov`, `pytest-explicit`, `respx`, `tox`, `ty`, and the `edutap.wallet-google[callback]` self-reference); one open floor, `pdbp>=1.7.1` |
+| `[build-system.requires]` | 2 | 0 | `hatchling`, `hatch-vcs`, both bare |
+
+### The mechanism
+
+Established from Renovate's source, not just from its observed behaviour on this one repo.
+Two separate reasons produce the same zero:
+
+A dependency with no version operator at all — `httpx`, `joserfc`, and the ten bare names
+above — gets `skipReason: "unspecified-version"` in Renovate's pep621 manager and is
+skipped before any update logic runs.
+
+A dependency with an open `>=` floor and no ceiling *is* processed, but the pep621
+manager's default `rangeStrategy` is `replace`, and `replace` only rewrites a range when
+the candidate version does not already satisfy it. An open floor is satisfied by every
+future release by construction, so `replace` returns the range unchanged forever. This is
+not specific to runtime dependencies — it is exactly why `pdbp>=1.7.1` is equally inert
+today.
+
+The one thing that does move an open floor is a security advisory: Renovate's
+`vulnerabilityAlerts` preset defaults `rangeStrategy` to `bump` with no lockfile involved,
+`prCreation` to `"immediate"`, and `schedule` to empty — none of the usual scheduling or
+range-preservation rules apply to a vulnerability fix. That is not hypothetical: it is how
+`authlib>=1.7.2`, `cryptography>=48.0.1` and `pydantic-settings>=2.14.2` reached their
+current floors, in PR #93 ("chore: stop tracking uv.lock and raise runtime dependency
+floors").
+
+So Renovate's effective coverage of this repository, as configured on `chore/renovate`, is
+GitHub Actions and nothing in `pyproject.toml`.
+
+### Runtime dependencies keep their open floors
+
+This is deliberate, not an oversight left for later. An upper bound on a *library's*
+runtime dependency creates an unsolvable resolution conflict for every consumer who needs
+a newer release of that dependency for a reason of their own — this package does not get
+to decide that for them. The floors themselves are security floors: the comment already
+sitting above `[project.dependencies]` says "Keep them as floors, not equalities," and that
+comment is untouched by this plan.
+
+`rangeStrategy: "bump"` project-wide is rejected for the identical reason a ceiling is: it
+would ratchet every runtime floor to the newest release on every publication of `authlib`,
+`cryptography`, and the rest, forcing every downstream consumer onto that floor in
+lockstep with a package they may not otherwise need to touch.
+
+The one path that legitimately moves a runtime floor is exactly the one already in use — a
+`vulnerabilityAlerts`-triggered PR, as in PR #93. Nothing in this part changes that path or
+touches the six entries in `[project.dependencies]`. This is written down here so it
+survives contact with someone who, on seeing the Renovate coverage table above,
+"helpfully" adds ceilings to fix it.
+
+### The non-published dependencies get real version constraints
+
+After this plan's Task 1, everything except `callback` lives in `[dependency-groups]`, and
+a dependency group is never written into the wheel or sdist metadata — nothing that
+installs this package as a dependency ever resolves it. Constraining these costs a
+consumer of the library nothing, and it is the difference between "skipped" and
+"actionable" for Renovate.
+
+Every entry gets at least a floor, and the floor is the version measured resolving in a
+fresh install on 2026-08-05 — `uv venv` followed by `uv pip install -e
+".[callback,test,typecheck]"` in a clean checkout, cross-checked against the version PyPI
+reports as current the same day — not a guess:
+
+| Dependency | Floor | Source |
+| --- | --- | --- |
+| `fastapi` | `>=0.141.1` | fresh install |
+| `freezegun` | `>=1.5.5` | fresh install |
+| `pytest` | `>=9.1.1` | fresh install |
+| `pytest-asyncio` | `>=1.4.0` | fresh install |
+| `pytest-cov` | `>=7.1.0` | fresh install |
+| `pytest-explicit` | `>=1.0.1` | fresh install |
+| `respx` | `>=0.23.1` | fresh install |
+| `tox` | `>=4.58.0` | fresh install |
+| `pdbp` | `>=1.7.1` (unchanged) | already floored, for an unrelated reason — see its own comment |
+
+Two tools get a ceiling as well as a floor, because a minor release changes what they
+*report*, not only what they fix:
+
+- **`ruff`** — a minor release changes what the linter flags and reformats files that were
+  correct under the previous minor. This is exactly `edutap.data_provider`'s own
+  `ruff>=0.16,<0.17`, and the floor here — `>=0.16.1,<0.17` — is the version currently
+  pinned in `.pre-commit-config.yaml` (`v0.16.1`) and confirmed as PyPI's latest release on
+  2026-08-05, so the pre-commit hook and the dependency-group entry cannot silently
+  disagree. `ruff` was not previously a project dependency at all — it only ever ran inside
+  `pre-commit`/`prek`'s own isolated environment — so this also closes a latent gap: without
+  it, `make lint`'s `$(PYTHON) -m ruff …` (Task 2) would have nothing installed to find.
+- **`ty`** — pre-1.0 and moving fast enough that this plan's Task 3 jumps it 49 releases in
+  one commit. `ty`'s releases are all `0.0.x`; there is no separate minor line to float
+  within, so the ceiling — `>=0.0.66,<0.0.67` — pins the exact current release and requires
+  a deliberate bump, and a look at the diagnostics it adds (per Task 3), for every single
+  release that follows. That is the right amount of friction for a tool this early in its
+  life.
+
+`[build-system.requires]` gets floors too:
+
+- **`hatchling`** needs one anyway, for a reason independent of Renovate: this plan's Task 1
+  adopts PEP 639, and `license = "EUPL-1.2"` with `license-files = ["LICENSE"]` only
+  produces a `Metadata-Version: 2.4` build with `License-Expression`/`License-File` fields
+  from a hatchling that understands the array-of-strings form of `license-files`. Verified
+  by building a throwaway package against four hatchling releases: 1.24.0 and 1.25.0 reject
+  the syntax outright (`TypeError: Field 'project.license-files' must be a table` — the
+  pre-PEP-639 table-of-globs form); 1.26.0 through 1.26.3 accept it without error but
+  silently build `Metadata-Version: 2.3` with no license fields at all; 1.27.0 is the first
+  release that emits `Metadata-Version: 2.4`, `License-Expression: EUPL-1.2`,
+  `License-File: LICENSE`. The floor is `hatchling>=1.27.0` — the minimum that makes Task
+  1's own change work, not merely the version that happens to be installed today (1.31.0).
+  This makes Task 1's implicit requirement explicit instead of leaving it to be discovered
+  as an opaque, silent metadata downgrade.
+- **`hatch-vcs`** has no such constraint driving it; its floor, `>=0.5.0`, is simply the
+  version PyPI reports as current on 2026-08-05.
+
 ## Non-goals
 
 Writing the 144 missing docstrings. Dropping Python 3.10. Replacing tox, hatchling or
@@ -245,7 +369,9 @@ pytest. Adding a local `docs/conf.py` — the documentation is built centrally f
 docs.edutap.eu, and giving this repository a second, divergent Sphinx configuration would
 create a build that agrees with nothing. It is a real gap, noted here so it is not
 rediscovered, and it needs a decision at the level of the whole eduTAP documentation
-tree rather than in this package.
+tree rather than in this package. **Adding upper bounds to the six runtime dependencies in
+`[project.dependencies]`** — Part 5 explains why that is a deliberate non-goal, not
+something left for later: it would break dependency resolution for consumers.
 
 ## Risks
 
@@ -259,10 +385,17 @@ tree rather than in this package.
   `edutap.wallet-google[develop]`.** That is a development-only extra of a library, so the
   blast radius is this repository and any sibling checkout that names it. `grep` for it
   before merging.
+- **The `ruff` and `ty` ceilings mean every one of their releases needs a manual (or
+  Renovate-proposed) bump, not just the ones that matter.** That is the intended trade-off
+  for two tools whose minor releases change behaviour — see Part 5 — but it means more
+  version-bump PRs to review than the other dependency-group entries generate.
 
 ## Verification
 
 `make lint`, `make test-local` and `make test-matrix` all green. An sdist built before and
 after, with the two file lists diffed explicitly. `uv pip install -e ".[callback]" --group
 dev` resolving in a clean environment. A wheel's `METADATA` showing
-`License-Expression: EUPL-1.2`.
+`License-Expression: EUPL-1.2`. Every entry in `[dependency-groups]`, the `callback`
+extra, and `[build-system.requires]` carrying a version constraint — `grep` confirms no
+bare names remain — with `ruff`'s floor matching what `.pre-commit-config.yaml` pins, so
+`make lint` and the pre-commit hook cannot silently run different versions.

--- a/superpowers/specs/2026-08-04-package-modernisation-design.md
+++ b/superpowers/specs/2026-08-04-package-modernisation-design.md
@@ -159,10 +159,23 @@ the version in a `rev:` where pre-commit.ci's monthly autoupdate can reach it:
 ```
 
 The hook is `pass_filenames: false` and `always_run: true`, matching the current local
-hook's behaviour. `ty` must come out of the `skip:` list in the `ci:` block once it is a
-remote hook that pre-commit.ci can actually run — unless it turns out to be too slow there,
-in which case it stays skipped and the point still stands, because the *revision* is now
-maintained either way.
+hook's behaviour.
+
+This section originally expected `ty` to come out of the `skip:` list in the `ci:` block
+once it was a remote hook, hedged with "unless it turns out to be too slow there".
+**Measured on PR #96: it stays skipped, and the reason is not slowness.** The hook's entry
+is `uv check --quiet --preview-features=check-command --ty-version=0.0.66`, and `uv check`
+builds the project, which resolves `build-system.requires` against PyPI. pre-commit.ci
+disables network access while hooks run, so the build fails with
+`dns error: Temporary failure in name resolution` before ty type-checks anything. That is
+architectural — no pin, rev bump or timeout setting changes it — and it applies to any
+hook that resolves dependencies at run time, not just this one.
+
+The hedge's conclusion still holds, and is the actual point of the change: the *revision*
+is maintained either way, because `rev:` is what pre-commit.ci's monthly autoupdate
+rewrites, whether or not the hook is in `skip:`. And ty is not left unchecked — the
+GitHub Actions `lint` job runs `tox -e lint`, which runs every hook including ty, with
+network available. Verified passing at v0.0.66 on PR #96.
 
 Given ty is pre-1.0 and moves fast, expect the jump from 0.0.17 to 0.0.66 to surface new
 diagnostics. `[tool.ty.rules]` already downgrades four rules to warnings; anything new gets

--- a/superpowers/specs/2026-08-04-package-modernisation-design.md
+++ b/superpowers/specs/2026-08-04-package-modernisation-design.md
@@ -267,6 +267,17 @@ dependencies.
 | `[project.optional-dependencies]` | 11 | 0 | ten bare names (`fastapi`, `freezegun`, `pytest`, `pytest-asyncio`, `pytest-cov`, `pytest-explicit`, `respx`, `tox`, `ty`, and the `edutap.wallet-google[callback]` self-reference); one open floor, `pdbp>=1.7.1` |
 | `[build-system.requires]` | 2 | 0 | `hatchling`, `hatch-vcs`, both bare |
 
+This table is the baseline this part reasons from: `pyproject.toml` as it stood on `main`
+before this branch. It is no longer the state at the tip of `chore/package-modernisation` —
+this plan's Task 3 (commit `3da2e5a`) gave `httpx` a floor, `httpx>=0.15`, for a reason that
+has nothing to do with Renovate: `api.py` sends request bodies with `content=`, added in
+httpx 0.15.0, and below that version the calls raise `TypeError`. It is a feature floor, the
+same kind the `authlib`/`cryptography`/`pydantic-settings` floors already were, and it
+happens to make `httpx` actionable to Renovate (an open floor with `replace`, same as those
+three — see "The mechanism" below for why that is necessary but not sufficient on its own).
+By the time this branch merges, `joserfc` is the only entry left bare in
+`[project.dependencies]`; the other five, including `httpx`, carry a floor.
+
 ### The mechanism
 
 Confirmed by running Renovate itself against the repository (`--dry-run=full`, v44.11.6),
@@ -320,10 +331,13 @@ and rejected here: nothing downstream resolves a dependency group, but every con
 this library resolves `[project.dependencies]`.
 
 The one path that legitimately moves a runtime floor is exactly the one already in use — a
-`vulnerabilityAlerts`-triggered PR, as in PR #93. Nothing in this part changes that path or
-touches the six entries in `[project.dependencies]`. This is written down here so it
-survives contact with someone who, on seeing the Renovate coverage table above,
-"helpfully" adds ceilings to fix it.
+`vulnerabilityAlerts`-triggered PR, as in PR #93. Nothing in *this part* changes that path or
+proposes touching any of the six entries in `[project.dependencies]` — Part 5 adds no
+ceiling and no `rangeStrategy: "bump"` to any of them. That is a separate claim from whether
+another task on this branch edits one of the six: Task 3 does, giving `httpx` a feature
+floor (see the note under the table above) for a reason internal to `api.py`, not to make it
+Renovate-actionable. This is written down here so it survives contact with someone who, on
+seeing the Renovate coverage table above, "helpfully" adds ceilings to fix it.
 
 ### Floors are necessary but not sufficient
 
@@ -343,10 +357,14 @@ on the rule that already groups them as "development dependencies." `bump` raise
 itself to each new release, rather than leaving a satisfied floor alone. That is exactly the
 mechanism the `vulnerabilityAlerts` preset already uses for a security advisory (previous
 section); this part turns it on permanently, but only for the entries where doing so is
-free — nothing downstream resolves a dependency group, an optional extra nobody but this
-repository's own tooling installs, or `[build-system.requires]`, so ratcheting all three
-forward on every release costs no consumer anything. `[project.dependencies]` gets none of
-this, for the reason in the previous section.
+free — nothing downstream resolves a dependency group or `[build-system.requires]`, so
+ratcheting either forward on every release costs no consumer anything. `[project.dependencies]`
+gets none of this, for the reason in the previous section — and neither does the `callback`
+extra in `[project.optional-dependencies]`, for the identical reason: unlike `test`,
+`typecheck` and the rest of what used to share that table with it, `callback` is published
+and a consumer resolves it, so it follows `[project.dependencies]`'s rule, not this one. See
+"The non-published dependencies get real version constraints" below for where that leaves
+`callback`.
 
 `renovate.json5` is not in this checkout. It lives on `chore/renovate` (PR #95), still
 open. This branch can state the rule change here and write it into the implementation plan,
@@ -361,14 +379,21 @@ installs this package as a dependency ever resolves it. Constraining these costs
 consumer of the library nothing, which is what makes `bump` safe for them; the constraint
 itself is what stops Renovate skipping them outright.
 
-Every entry gets at least a floor, and the floor is the version measured resolving in a
-fresh install on 2026-08-05 — `uv venv` followed by `uv pip install -e
+`callback` is deliberately not in the table below, for the reason given at the end of the
+previous section: it is published, a consumer resolves it, and "the version that happened
+to resolve in a fresh install today" is not a justification this plan accepts for a
+published entry — that is precisely the harm Part 5 rejects for `[project.dependencies]`.
+`fastapi` keeps no floor at all, because nothing in `handlers/fastapi.py` needs one; it
+would get one the same way `httpx>=0.15` in `[project.dependencies]` did, by pointing at an
+actual code requirement, if one ever exists.
+
+Every other entry gets at least a floor, and the floor is the version measured resolving in
+a fresh install on 2026-08-05 — `uv venv` followed by `uv pip install -e
 ".[callback,test,typecheck]"` in a clean checkout, cross-checked against the version PyPI
 reports as current the same day — not a guess:
 
 | Dependency | Floor | Source |
 | --- | --- | --- |
-| `fastapi` | `>=0.141.1` | fresh install |
 | `freezegun` | `>=1.5.5` | fresh install |
 | `pytest` | `>=9.1.1` | fresh install |
 | `pytest-asyncio` | `>=1.4.0` | fresh install |
@@ -431,12 +456,22 @@ The floors above are this branch's job and land in Task 1 regardless. The pairin
 `chore/package-modernisation` — it is being added by the sibling `chore/renovate` branch
 (PR #95), still open at the time of writing. Concretely, the "development dependencies"
 packageRule there currently reads `matchDepTypes: ["project.optional-dependencies"]`; after
-Task 1 moves most of what it matches into `[dependency-groups]`, that needs to become
-`matchDepTypes: ["project.optional-dependencies", "dependency-groups",
-"build-system.requires"]` with `rangeStrategy: "bump"` added — folding
-`build-system.requires` into the same rule closes a gap `chore/renovate`'s own comment
-already flags ("build-system.requires … match neither rule … acknowledged rather than given
-a third rule"), rather than leaving it to become a second, near-identical rule.
+Task 1 moves most of what it matched into `[dependency-groups]`, that needs to become
+`matchDepTypes: ["dependency-groups", "build-system.requires"]` with `rangeStrategy: "bump"`
+added — folding `build-system.requires` into the same rule closes a gap `chore/renovate`'s
+own comment already flags ("build-system.requires … match neither rule … acknowledged rather
+than given a third rule"), rather than leaving it to become a second, near-identical rule.
+
+`project.optional-dependencies` drops out of this rule rather than carrying over into it.
+Earlier drafts of this part kept it in the `matchDepTypes` list, reasoning that `callback` —
+the one entry left there after Task 1 — was as unpublished as everything else being folded
+in. It is not: `callback` is the extra a consumer of this library actually installs (see
+"PEP 735" above), exactly like the six entries in `[project.dependencies]`, and the same
+argument that keeps `bump` off those six applies to it. Task 1 does not give `fastapi` a
+floor at all — `handlers/fastapi.py` only needs symbols present since FastAPI's earliest
+0.x releases — so there is nothing in `[project.optional-dependencies]` for this rule to
+match today regardless. If a real floor is ever added there for an actual code reason, it
+follows `[project.dependencies]`'s rule (open floor, `replace`, no `bump`), not this one.
 
 This branch can write that change down — Task 1's Steps 12-13 do — but cannot commit it
 until #95 merges to `main` and `chore/package-modernisation` is rebased onto the result.

--- a/superpowers/specs/2026-08-04-package-modernisation-design.md
+++ b/superpowers/specs/2026-08-04-package-modernisation-design.md
@@ -256,30 +256,38 @@ dependencies.
 
 ### The mechanism
 
-Established from Renovate's source, not just from its observed behaviour on this one repo.
-Two separate reasons produce the same zero:
+Confirmed by running Renovate itself against the repository (`--dry-run=full`, v44.11.6),
+not only by reasoning from its source. An earlier version of this section relied on the
+source-code mechanism alone and got the next section's conclusion wrong — see "Floors are
+necessary but not sufficient" below for what the dry run corrected.
+
+Two separate reasons produce the same zero in the table above:
 
 A dependency with no version operator at all — `httpx`, `joserfc`, and the ten bare names
 above — gets `skipReason: "unspecified-version"` in Renovate's pep621 manager and is
-skipped before any update logic runs.
+skipped before any update logic runs. The dry run reports exactly 15 of these.
 
 A dependency with an open `>=` floor and no ceiling *is* processed, but the pep621
 manager's default `rangeStrategy` is `replace`, and `replace` only rewrites a range when
 the candidate version does not already satisfy it. An open floor is satisfied by every
 future release by construction, so `replace` returns the range unchanged forever. This is
 not specific to runtime dependencies — it is exactly why `pdbp>=1.7.1` is equally inert
-today.
+today, and the dry run confirms it: `authlib`, `cryptography`, `pydantic-settings`,
+`pydantic` and `pdbp` are all extracted with no `skipReason`, and not one of them produces
+an update.
 
-The one thing that does move an open floor is a security advisory: Renovate's
-`vulnerabilityAlerts` preset defaults `rangeStrategy` to `bump` with no lockfile involved,
-`prCreation` to `"immediate"`, and `schedule` to empty — none of the usual scheduling or
-range-preservation rules apply to a vulnerability fix. That is not hypothetical: it is how
-`authlib>=1.7.2`, `cryptography>=48.0.1` and `pydantic-settings>=2.14.2` reached their
-current floors, in PR #93 ("chore: stop tracking uv.lock and raise runtime dependency
-floors").
+The one thing that does move an open floor without a config change is a security advisory:
+Renovate's `vulnerabilityAlerts` preset defaults `rangeStrategy` to `bump` with no lockfile
+involved, `prCreation` to `"immediate"`, and `schedule` to empty — none of the usual
+scheduling or range-preservation rules apply to a vulnerability fix. That is not
+hypothetical: it is how `authlib>=1.7.2`, `cryptography>=48.0.1` and
+`pydantic-settings>=2.14.2` reached their current floors, in PR #93 ("chore: stop tracking
+uv.lock and raise runtime dependency floors").
 
-So Renovate's effective coverage of this repository, as configured on `chore/renovate`, is
-GitHub Actions and nothing in `pyproject.toml`.
+So Renovate's effective coverage of this repository, as configured on `chore/renovate`
+before this part, is GitHub Actions and nothing in `pyproject.toml`: the dry run's only two
+proposed branches, repository-wide, are `renovate/astral-sh-setup-uv-9.x` and
+`renovate/hynek-build-and-inspect-python-package-3.x`.
 
 ### Runtime dependencies keep their open floors
 
@@ -290,10 +298,13 @@ to decide that for them. The floors themselves are security floors: the comment 
 sitting above `[project.dependencies]` says "Keep them as floors, not equalities," and that
 comment is untouched by this plan.
 
-`rangeStrategy: "bump"` project-wide is rejected for the identical reason a ceiling is: it
-would ratchet every runtime floor to the newest release on every publication of `authlib`,
-`cryptography`, and the rest, forcing every downstream consumer onto that floor in
-lockstep with a package they may not otherwise need to touch.
+`rangeStrategy: "bump"` — the fix this part applies elsewhere, see below — is rejected here
+project-wide for the identical reason a ceiling is: it would ratchet every runtime floor to
+the newest release on every publication of `authlib`, `cryptography`, and the rest, forcing
+every downstream consumer onto that floor in lockstep with a package they may not otherwise
+need to touch. That contrast is exactly why `bump` is safe for the dependency groups below
+and rejected here: nothing downstream resolves a dependency group, but every consumer of
+this library resolves `[project.dependencies]`.
 
 The one path that legitimately moves a runtime floor is exactly the one already in use — a
 `vulnerabilityAlerts`-triggered PR, as in PR #93. Nothing in this part changes that path or
@@ -301,13 +312,41 @@ touches the six entries in `[project.dependencies]`. This is written down here s
 survives contact with someone who, on seeing the Renovate coverage table above,
 "helpfully" adds ceilings to fix it.
 
+### Floors are necessary but not sufficient
+
+The first version of this part said "every entry gets at least a floor" and treated that as
+the fix. It is necessary — an unfloored entry is skipped outright — but the dry run showed
+it is not sufficient: `pdbp>=1.7.1` is the control case. It was already a floored,
+already-a-dependency-group-shaped entry before any of this part's other changes, and
+Renovate's dry run still produced nothing for it, for the mechanism reason above —
+`replace` leaves a satisfied floor untouched. Giving every other entry in
+`[dependency-groups]` the same kind of open floor would have reproduced exactly the same
+nothing. Two branches, both GitHub Actions, is what the whole repository's Renovate
+configuration currently proposes; zero of them touch a Python dependency.
+
+The fix is pairing the floor with `rangeStrategy: "bump"` on the packageRule that matches
+these entries in `renovate.json5` — not on the manager or the repository as a whole, only
+on the rule that already groups them as "development dependencies." `bump` raises the floor
+itself to each new release, rather than leaving a satisfied floor alone. That is exactly the
+mechanism the `vulnerabilityAlerts` preset already uses for a security advisory (previous
+section); this part turns it on permanently, but only for the entries where doing so is
+free — nothing downstream resolves a dependency group, an optional extra nobody but this
+repository's own tooling installs, or `[build-system.requires]`, so ratcheting all three
+forward on every release costs no consumer anything. `[project.dependencies]` gets none of
+this, for the reason in the previous section.
+
+`renovate.json5` is not in this checkout. It lives on `chore/renovate` (PR #95), still
+open. This branch can state the rule change here and write it into the implementation plan,
+but cannot make the edit until #95 merges to `main` and `chore/package-modernisation` is
+rebased onto the result — see Global Constraints in the plan, and Task 1's final steps.
+
 ### The non-published dependencies get real version constraints
 
 After this plan's Task 1, everything except `callback` lives in `[dependency-groups]`, and
 a dependency group is never written into the wheel or sdist metadata — nothing that
 installs this package as a dependency ever resolves it. Constraining these costs a
-consumer of the library nothing, and it is the difference between "skipped" and
-"actionable" for Renovate.
+consumer of the library nothing, which is what makes `bump` safe for them; the constraint
+itself is what stops Renovate skipping them outright.
 
 Every entry gets at least a floor, and the floor is the version measured resolving in a
 fresh install on 2026-08-05 — `uv venv` followed by `uv pip install -e
@@ -324,10 +363,12 @@ reports as current the same day — not a guess:
 | `pytest-explicit` | `>=1.0.1` | fresh install |
 | `respx` | `>=0.23.1` | fresh install |
 | `tox` | `>=4.58.0` | fresh install |
-| `pdbp` | `>=1.7.1` (unchanged) | already floored, for an unrelated reason — see its own comment |
+| `pdbp` | `>=1.7.1` (unchanged) | already floored, for an unrelated reason — see its own comment; the entry `bump` is defined against |
 
-Two tools get a ceiling as well as a floor, because a minor release changes what they
-*report*, not only what they fix:
+Two tools get a ceiling as well as a floor. With `bump` in place this is no longer what
+makes them visible to Renovate — every entry in the group gets that from `bump` regardless
+of a ceiling — so the ceilings are kept on their own merits, not as part of the
+actionability mechanism:
 
 - **`ruff`** — a minor release changes what the linter flags and reformats files that were
   correct under the previous minor. This is exactly `edutap.data_provider`'s own
@@ -336,15 +377,23 @@ Two tools get a ceiling as well as a floor, because a minor release changes what
   2026-08-05, so the pre-commit hook and the dependency-group entry cannot silently
   disagree. `ruff` was not previously a project dependency at all — it only ever ran inside
   `pre-commit`/`prek`'s own isolated environment — so this also closes a latent gap: without
-  it, `make lint`'s `$(PYTHON) -m ruff …` (Task 2) would have nothing installed to find.
+  it, `make lint`'s `$(PYTHON) -m ruff …` (Task 2) would have nothing installed to find. The
+  ceiling means `bump` can keep advancing the floor silently through patch releases inside
+  `0.16.x`, which ruff's own release policy keeps behaviour-stable, while a release that
+  crosses into `0.17` still needs a deliberate ceiling change — whether `bump` actually
+  respects an upper bound that way, rather than proposing to jump straight past it, is
+  unverified and worth checking the first time Task 1's Step 13 dry run sees a `0.17`
+  release available.
 - **`ty`** — pre-1.0 and moving fast enough that this plan's Task 3 jumps it 49 releases in
   one commit. `ty`'s releases are all `0.0.x`; there is no separate minor line to float
-  within, so the ceiling — `>=0.0.66,<0.0.67` — pins the exact current release and requires
-  a deliberate bump, and a look at the diagnostics it adds (per Task 3), for every single
-  release that follows. That is the right amount of friction for a tool this early in its
-  life.
+  within, so the ceiling — `>=0.0.66,<0.0.67` — pins the exact current release, meaning
+  every single subsequent release needs a deliberate ceiling change and a look at the
+  diagnostics it adds (per Task 3), `bump` or not. That is the right amount of friction for
+  a tool this early in its life.
 
-`[build-system.requires]` gets floors too:
+`[build-system.requires]` gets floors too, and — since it is exactly as unpublished as a
+dependency group — the same `bump` rangeStrategy, via the same `renovate.json5` rule
+extended to match it:
 
 - **`hatchling`** needs one anyway, for a reason independent of Renovate: this plan's Task 1
   adopts PEP 639, and `license = "EUPL-1.2"` with `license-files = ["LICENSE"]` only
@@ -361,6 +410,25 @@ Two tools get a ceiling as well as a floor, because a minor release changes what
   as an opaque, silent metadata downgrade.
 - **`hatch-vcs`** has no such constraint driving it; its floor, `>=0.5.0`, is simply the
   version PyPI reports as current on 2026-08-05.
+
+### The `renovate.json5` change this depends on
+
+The floors above are this branch's job and land in Task 1 regardless. The pairing with
+`rangeStrategy: "bump"` is a `renovate.json5` edit, and that file does not exist on
+`chore/package-modernisation` — it is being added by the sibling `chore/renovate` branch
+(PR #95), still open at the time of writing. Concretely, the "development dependencies"
+packageRule there currently reads `matchDepTypes: ["project.optional-dependencies"]`; after
+Task 1 moves most of what it matches into `[dependency-groups]`, that needs to become
+`matchDepTypes: ["project.optional-dependencies", "dependency-groups",
+"build-system.requires"]` with `rangeStrategy: "bump"` added — folding
+`build-system.requires` into the same rule closes a gap `chore/renovate`'s own comment
+already flags ("build-system.requires … match neither rule … acknowledged rather than given
+a third rule"), rather than leaving it to become a second, near-identical rule.
+
+This branch can write that change down — Task 1's Steps 12-13 do — but cannot commit it
+until #95 merges to `main` and `chore/package-modernisation` is rebased onto the result.
+Until then, this part's floors are real and the `bump` pairing is designed but not yet
+applied.
 
 ## Non-goals
 
@@ -389,6 +457,14 @@ something left for later: it would break dependency resolution for consumers.
   Renovate-proposed) bump, not just the ones that matter.** That is the intended trade-off
   for two tools whose minor releases change behaviour — see Part 5 — but it means more
   version-bump PRs to review than the other dependency-group entries generate.
+- **The `renovate.json5` half of Part 5 cannot land with this branch.** It depends on PR
+  #95 merging first; until then the floors this branch adds are real but inert in exactly
+  the way `pdbp>=1.7.1` already is. Task 1's Steps 12-13 exist to make sure that edit does
+  not get forgotten once #95 merges — the floors alone are easy to mistake for "done."
+- **Whether Renovate's `bump` strategy respects an explicit ceiling, rather than proposing
+  to jump straight past it, is asserted here but not yet verified against this repository.**
+  The first dry run that sees a release cross one of the `ruff`/`ty` ceilings (Task 1, Step
+  13) is the actual test.
 
 ## Verification
 
@@ -398,4 +474,8 @@ dev` resolving in a clean environment. A wheel's `METADATA` showing
 `License-Expression: EUPL-1.2`. Every entry in `[dependency-groups]`, the `callback`
 extra, and `[build-system.requires]` carrying a version constraint — `grep` confirms no
 bare names remain — with `ruff`'s floor matching what `.pre-commit-config.yaml` pins, so
-`make lint` and the pre-commit hook cannot silently run different versions.
+`make lint` and the pre-commit hook cannot silently run different versions. Once #95 has
+merged and this branch is rebased: a Renovate dry run (`--dry-run=full`) showing the
+`development dependencies` rule's entries extracted with `rangeStrategy: "bump"` and no
+`skipReason` — the same dry run that, before the `renovate.json5` change, produced only
+two branches repository-wide and none for a Python dependency.

--- a/superpowers/specs/2026-08-04-package-modernisation-design.md
+++ b/superpowers/specs/2026-08-04-package-modernisation-design.md
@@ -1,0 +1,268 @@
+# Package modernisation: Makefile, packaging metadata, tool pins, linter rules
+
+Status: designed, ready to implement.
+
+## Why
+
+The package is already on the current toolchain in the ways that matter most — uv drives
+CI and tox, ruff is the only linter and formatter, ty is the type checker, the tox matrix
+lives in `[tool.tox]` as native TOML, and the version comes from `hatch-vcs`. What is left
+are four gaps, each verified rather than assumed:
+
+1. There is no `Makefile`, so there is no uniform entry point to the common workflows.
+2. Two things carry a silent expiry date: the `ty` pin and Python 3.10 support.
+3. Two packaging standards the project can now adopt — one of which its own `pyproject.toml`
+   already carries a TODO for — plus an `sdist` that ships internal working documents.
+4. The ruff rule selection is narrower than the project standard.
+
+These are grouped into four parts below. They land on one branch,
+`chore/package-modernisation`, because they overlap heavily in `pyproject.toml` and
+splitting them would mean four branches rebasing over each other for the same file.
+
+## Part 1: Makefile and prek
+
+### Makefile
+
+`edutap.data_provider` already has one, and it is the template: a `PYTHON := .venv/bin/python`
+variable, a self-documenting `help` default goal, and `venv` as a prerequisite of every
+other target so no one runs `make lint` against a missing environment.
+
+The targets, matching the project standard:
+
+| Target | Does |
+| --- | --- |
+| `help` | lists the targets (default goal) |
+| `venv` | `uv venv` plus `uv pip install -U -e ".[callback]" --group dev` |
+| `lint` | `ruff check`, `ruff format --check`, `ty check` |
+| `reformat` | `ruff format`, `ruff check --fix` |
+| `test-local` | `pytest` — the unit suite |
+| `test-integration` | `pytest --run-integration` — needs Google credentials |
+| `test-matrix` | `uvx --with "tox-uv,tox-gh" tox` — every supported Python |
+
+`test-matrix` is this package's third suite, in the slot the standard leaves open for
+"further, more expensive suites". It is separate from `test-local` because it builds five
+interpreters' worth of environments.
+
+Tools are called through `$(PYTHON) -m …` rather than `uv run`, for data_provider's
+recorded reason: this package declares an entry point group, and a bare `uv run` resolves
+it against the whole environment.
+
+### prek
+
+`prek` replaces `pre-commit` as the local hook runner. It reads the same
+`.pre-commit-config.yaml`, so nothing about the hooks changes — only the two tox
+environments `format` and `lint`, whose `deps` and `commands` name `pre-commit` today.
+
+pre-commit.ci keeps running server-side on the real `pre-commit`; the two coexist by
+design, and the `ci:` block in `.pre-commit-config.yaml` is untouched.
+
+## Part 2: Packaging metadata
+
+### PEP 639 — the TODO in `pyproject.toml` is now redeemable
+
+`pyproject.toml` carries an eight-line comment asking for the SPDX license expression
+"when implemented in PyPI, twine, pyroma, etc." It is implemented. Verified by building a
+throwaway package with hatchling 1.31:
+
+```
+Metadata-Version: 2.4
+License-Expression: EUPL-1.2
+License-File: LICENSE
+```
+
+So `license = { text = "EUPL 1.2" }` becomes `license = "EUPL-1.2"`, `license-files =
+["LICENSE"]` is added, the `License :: OSI Approved :: …` classifier goes (PEP 639 forbids
+carrying both), and the TODO block is deleted.
+
+### PEP 735 — dev dependencies are not extras
+
+`test`, `typecheck` and `develop` are declared as extras today, which publishes them in the
+wheel metadata even though no consumer of the library would ever install
+`edutap.wallet-google[test]`. They become `[dependency-groups]`, which is the standard for
+exactly this, and `develop` is renamed `dev` in the move — free, because dependency groups
+are not published metadata.
+
+`callback` stays a real extra. It is the one a consumer genuinely installs.
+
+**The self-reference has to go.** The `test` extra currently begins with
+`"edutap.wallet-google[callback]"`. Inside `[project.optional-dependencies]` that is a
+well-defined recursive self-reference; inside a dependency group it is not special-cased at
+all and would be resolved against an index, i.e. it would pull the *published* package from
+PyPI over the local checkout. So `callback` comes off the group and onto the install
+command, and `dev` pulls the other groups in through `include-group`:
+
+```toml
+[project.optional-dependencies]
+callback = ["fastapi"]
+
+[dependency-groups]
+test = ["freezegun", "pytest", "pytest-asyncio", "pytest-cov", "pytest-explicit", "respx", "tox"]
+typecheck = ["ty"]
+dev = [
+    {include-group = "test"},
+    {include-group = "typecheck"},
+    "pdbp>=1.7.1",
+]
+```
+
+Verified in a throwaway project: `uv pip install -e ".[callback]" --group dev` resolves the
+local editable package, the extra and all three groups transitively. tox 4.58 ships native
+`dependency_groups` support (`tox/tox_env/python/dependency_groups.py`, registered as a
+config key in `tox_env/python/runner.py`) and accepts it alongside `extras`, so the tox
+environments change from `extras = ["test", "develop"]` to `extras = ["callback"]` plus
+`dependency_groups = ["dev"]`.
+
+### The sdist ships internal working documents
+
+`MANIFEST.in` is dead. It is a setuptools file, hatchling does not read it, and the sdist
+proves it: `MANIFEST.in` says `recursive-exclude docs *` and `recursive-exclude .claude *`,
+yet an sdist built from `main` contains both. The full top level of the current sdist:
+
+```
+.claude  .dockerignore  .editorconfig  .github  .gitignore  .pre-commit-config.yaml
+CLAUDE.md  CONTRIBUTING.md  LICENSE  MANIFEST.in  PKG-INFO  README.md  RELEASING.md
+docs  examples  pyproject.toml  src  superpowers  tests
+```
+
+108 files, including `superpowers/` (internal specs and plans), `CLAUDE.md`, `.claude/` and
+the CI configuration. None of that belongs in a distribution on PyPI.
+
+The fix is an explicit `[tool.hatch.build.targets.sdist]` section. `tests/` **stays** — a
+consumer packaging this for a distribution wants to run the suite — and so do `README.md`,
+`LICENSE`, `CONTRIBUTING.md` and `pyproject.toml`. Everything else at the top level goes,
+and `MANIFEST.in` is deleted with it.
+
+`check-manifest` stays as a hook. Its job — noticing that a file tracked in git is missing
+from the sdist — is still worth doing, and it is the thing that will complain if the new
+`sdist` section is too aggressive.
+
+## Part 3: The two things with an expiry date
+
+### The `ty` pin cannot be updated by anything
+
+`.pre-commit-config.yaml` runs ty as a `local` hook: `entry: uvx ty@0.0.17 check`. That pin
+is at 0.0.17; ty is at 0.0.66. Nothing will ever move it — pre-commit's `autoupdate` only
+rewrites the `rev:` of remote repositories, and no Renovate manager reads a version out of
+an `entry` string. It has been stuck for 49 releases and would stay stuck.
+
+`astral-sh/ty-pre-commit` exists and is the official hook repository. Switching to it puts
+the version in a `rev:` where pre-commit.ci's monthly autoupdate can reach it:
+
+```yaml
+-   repo: https://github.com/astral-sh/ty-pre-commit
+    rev: v0.0.66
+    hooks:
+    -   id: ty
+```
+
+The hook is `pass_filenames: false` and `always_run: true`, matching the current local
+hook's behaviour. `ty` must come out of the `skip:` list in the `ci:` block once it is a
+remote hook that pre-commit.ci can actually run — unless it turns out to be too slow there,
+in which case it stays skipped and the point still stands, because the *revision* is now
+maintained either way.
+
+Given ty is pre-1.0 and moves fast, expect the jump from 0.0.17 to 0.0.66 to surface new
+diagnostics. `[tool.ty.rules]` already downgrades four rules to warnings; anything new gets
+the same treatment or a fix, and the jump is its own commit so the noise is reviewable.
+
+### Python 3.10 reaches end of life on 2026-10-31
+
+That is under three months away. The package declares `requires-python = ">=3.10"` and
+tests py310 through py314.
+
+**Support is not dropped in this branch.** 3.10 is still supported today, and narrowing
+`requires-python` in a published library is a breaking change for consumers — it belongs in
+its own release with its own note, not smuggled into a modernisation branch.
+
+What this branch does is make sure it is not forgotten: a dated comment beside
+`requires-python` naming the date and listing every place that changes with it
+(`requires-python`, `classifiers`, `[tool.ruff] target-version`, `[tool.ty.environment]
+python-version`, `[tool.tox] env_list`, `[tool.tox.gh.python]`, the CI matrix in
+`tests.yaml`), plus a line in `RELEASING.md`.
+
+## Part 4: ruff rule groups
+
+Current selection is `["E", "F", "W", "I", "UP"]`. The project standard also names `B`
+(bugbear), `S` (bandit/security) and `D` (pydocstyle). Measured against the code on `main`
+with ruff 0.16.1:
+
+### B — 15 findings, all worth fixing
+
+```
+8  B904  raise-without-from-inside-except
+3  B007  unused-loop-control-variable
+2  B018  useless-expression
+1  B017  assert-raises-exception
+1  B019  cached-instance-method
+```
+
+`B904` is the substantive one: eight `raise` statements inside `except` blocks that lose
+the original traceback. `B019` (`cached-instance-method`) is a genuine memory-leak class of
+bug and needs looking at rather than silencing.
+
+### S — 408 findings, of which 4 are in `src` and 3 of those are false positives
+
+```
+src:    3 S105 hardcoded-password-string, 1 S101 assert
+tests:  404 S101 assert
+```
+
+`S101` in tests is what pytest is: `per-file-ignores` for `tests/**`. The three `S105` are
+a `token_endpoint` URL constant, an enum member named `GENERIC_SEASON_PASS`, and one
+further match — each gets a `# noqa: S105` with the reason, not a blanket ignore, so a real
+hardcoded secret would still be caught.
+
+### D — 508 findings, 201 after autofix, 57 after excluding the undocumented rules
+
+`D` is enabled together with `[tool.ruff.lint.pydocstyle] convention = "pep257"`. The
+convention is not cosmetic: without it there are 864 findings rather than 508, because
+`D212`, `D213`, `D415` and `D404` are all active, and those belong to conventions this
+project does not follow. It also settles the `D203`/`D211` and `D212`/`D213`
+incompatibilities that ruff otherwise warns about on every run, so no explicit `ignore`
+entry is needed for them — verified, the warnings disappear.
+
+Measured on a scratch copy with the convention set: `ruff check --select D --fix
+--unsafe-fixes` takes 508 down to 201. What is left splits cleanly:
+
+| | Count | Nature |
+| --- | --- | --- |
+| `D100`/`D101`/`D102`/`D103`/`D104`/`D107` | 144 | missing docstrings — writing prose |
+| `D401`, `D205`, `D400` | 57 | wording and layout of docstrings that exist |
+
+So `D` is enabled with the `D1xx` "undocumented" rules ignored, the 57 remaining fixed by
+hand, and writing the 144 missing docstrings left as separate future work. Enabling `D1xx`
+now would mean either 144 hastily-written docstrings or a permanent blanket ignore, and
+both are worse than an honest, narrow exclusion.
+
+Only 2 of the fixes are *safe*; the other 305 need `--unsafe-fixes`, which rewrites
+docstring text rather than only layout. That pass is therefore reviewed rather than
+trusted — but it is not worth splitting off a safe-only commit containing two lines.
+
+## Non-goals
+
+Writing the 144 missing docstrings. Dropping Python 3.10. Replacing tox, hatchling or
+pytest. Adding a local `docs/conf.py` — the documentation is built centrally for
+docs.edutap.eu, and giving this repository a second, divergent Sphinx configuration would
+create a build that agrees with nothing. It is a real gap, noted here so it is not
+rediscovered, and it needs a decision at the level of the whole eduTAP documentation
+tree rather than in this package.
+
+## Risks
+
+- **The ty jump from 0.0.17 to 0.0.66 will surface diagnostics.** Expected, its own commit.
+- **The `--unsafe-fixes` docstring pass touches a lot of files.** Its whole value is the
+  reviewable diff; anyone merging without reading it gets what they deserve.
+- **The new `[tool.hatch.build.targets.sdist]` could exclude something needed.** The check
+  is a file-list comparison of the sdist before and after, not a guess. `check-manifest`
+  stays as the second net.
+- **Renaming the `develop` extra to a `dev` group breaks anyone installing
+  `edutap.wallet-google[develop]`.** That is a development-only extra of a library, so the
+  blast radius is this repository and any sibling checkout that names it. `grep` for it
+  before merging.
+
+## Verification
+
+`make lint`, `make test-local` and `make test-matrix` all green. An sdist built before and
+after, with the two file lists diffed explicitly. `uv pip install -e ".[callback]" --group
+dev` resolving in a clean environment. A wheel's `METADATA` showing
+`License-Expression: EUPL-1.2`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,7 @@ def mock_session(monkeypatch):
 @pytest.fixture
 def mock_request_response(mock_session):
     """Fixture to load a mock request response from a json file.
+
     Prepares a mock response and status code for a given url and method.
     """
     import httpx

--- a/tests/data/test_wallet_google_plugins/plugins.py
+++ b/tests/data/test_wallet_google_plugins/plugins.py
@@ -4,9 +4,7 @@ import asyncio
 
 
 class TestImageProvider:
-    """
-    Implementation of edutap.wallet_google.protocols.ImageProvider
-    """
+    """Implementation of edutap.wallet_google.protocols.ImageProvider."""
 
     async def image_by_id(self, image_id: str) -> ImageData:
         # return some predictable data for unit testing
@@ -23,7 +21,7 @@ class TestImageProvider:
 
 class TestCallbackHandler:
     """
-    Implementation of edutap.wallet_google.protocols.CallbackHandler
+    Implementation of edutap.wallet_google.protocols.CallbackHandler.
 
     Used in tests to simulate a callback handler and possible errors.
     """

--- a/tests/test_api_sync.py
+++ b/tests/test_api_sync.py
@@ -181,6 +181,20 @@ def test_update_404_not_found(mock_session):
     assert "not found" in str(exc_info.value)
 
 
+def test_update_missing_resource_id_raises_value_error(mock_session):
+    """Test that update() raises ValueError when the resource-id field is unset.
+
+    Issuer.issuerId is `str | None`, unlike most models whose resource-id
+    field is required, so this is reachable through the public API: a
+    caller can build an Issuer without ever setting issuerId and pass it
+    to update().
+    """
+    data = new("Issuer", {"name": "Test Issuer"})
+
+    with pytest.raises(ValueError, match="resource_id"):
+        update(data)
+
+
 @respx.mock
 def test_message_generic_object(mock_session):
     """Test sending a message to a GenericObject."""

--- a/tests/test_check_models.py
+++ b/tests/test_check_models.py
@@ -9,6 +9,7 @@ import importlib
 import inspect
 import json
 import pathlib
+import pkgutil
 import pytest
 
 
@@ -23,11 +24,16 @@ MODEL_ALIAS_DICT = {
 
 def find_models() -> dict[str, type]:
     models: dict[str, type] = {}
-    # Imported by name, not reached for as an attribute of the package: see the
-    # note in edutap.wallet_google.registry._find_models().
+    # Enumerate the submodules from the package path and import each one: see
+    # the note in edutap.wallet_google.registry._find_models(). This test exists
+    # to catch a datatypes model that drifted from Google's schema, so it has to
+    # see modules nothing else imported — that is precisely the case where a
+    # model would go unchecked.
     datatypes_module = importlib.import_module("edutap.wallet_google.models.datatypes")
-    for name, module in inspect.getmembers(datatypes_module, inspect.ismodule):
-        # print(f"Module: 'name', '{module}'")
+    for module_info in pkgutil.iter_modules(datatypes_module.__path__):
+        module = importlib.import_module(
+            f"edutap.wallet_google.models.datatypes.{module_info.name}"
+        )
         for cls_name, cls in inspect.getmembers(module, inspect.isclass):
             if (
                 cls.__module__.startswith("edutap.wallet_google.models.datatypes")

--- a/tests/test_check_models.py
+++ b/tests/test_check_models.py
@@ -85,7 +85,7 @@ def discovery_api_data(module_tmp_path):
 
 @pytest.fixture(scope="module")
 def wallet_api_data(module_tmp_path):
-    """Loads the Google Wallet API data from the local file."""
+    """Load the Google Wallet API data from the local file."""
     filename = module_tmp_path / "wallet_api_data.json"
     if not filename.exists():
         request_api_data_write_to_file(

--- a/tests/test_check_models.py
+++ b/tests/test_check_models.py
@@ -23,8 +23,9 @@ MODEL_ALIAS_DICT = {
 
 def find_models() -> dict[str, type]:
     models: dict[str, type] = {}
-    pkg = importlib.import_module("edutap.wallet_google")
-    datatypes_module = pkg.models.datatypes
+    # Imported by name, not reached for as an attribute of the package: see the
+    # note in edutap.wallet_google.registry._find_models().
+    datatypes_module = importlib.import_module("edutap.wallet_google.models.datatypes")
     for name, module in inspect.getmembers(datatypes_module, inspect.ismodule):
         # print(f"Module: 'name', '{module}'")
         for cls_name, cls in inspect.getmembers(module, inspect.isclass):

--- a/tests/test_handler_validate.py
+++ b/tests/test_handler_validate.py
@@ -213,6 +213,10 @@ async def test_cache_expiration_refresh(mock_settings):
     cached_after = GOOGLE_ROOT_SIGNING_PUBLIC_KEYS_VALUE.get(
         mock_settings.google_environment
     )
+    # dict.get() returns None for a missing key; assert the entry is there so a
+    # cache that was not refilled fails on this line instead of on the unpacking
+    # below with a bare "cannot unpack non-iterable NoneType".
+    assert cached_after is not None
     _, cache_exp_after = cached_after
     assert cache_exp_after > time.time()  # New expiration in future
 

--- a/tests/test_handler_validate.py
+++ b/tests/test_handler_validate.py
@@ -157,10 +157,7 @@ async def test_message_expiration_just_before_expiry(mock_settings):
 @pytest.mark.asyncio
 @freeze_time("2025-10-15 10:01:00")
 async def test_message_expiration_expiry_check_ignored(mock_settings):
-    """
-    Test that the handler_callback_verify_expiry set to 0 disables
-    check for key expiration (needed for testing) (async).
-    """
+    """Test that the handler_callback_verify_expiry set to 0 disables check for key expiration (needed for testing) (async)."""
     from edutap.wallet_google.handlers.validate import verified_signed_message
 
     mock_settings.handler_callback_verify_signature = "1"

--- a/tests/test_handler_validate.py
+++ b/tests/test_handler_validate.py
@@ -91,13 +91,15 @@ async def test_handler_validate_ok(mock_settings):
 
 @pytest.mark.asyncio
 async def test_handler_validate_invalid(mock_settings):
-    """Test that invalid signature raises exception (async)."""
+    """Test that an invalid (expired) message raises ValueError."""
     from edutap.wallet_google.handlers.validate import verified_signed_message
 
     mock_settings.handler_callback_verify_signature = "1"
 
+    # expTimeMillis is 0 in the fixture, so this always fails the expiry
+    # check with a ValueError, before signature verification is even reached.
     data = CallbackData.model_validate(callback_data_for_test_failure)
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError, match="Expired message"):
         await verified_signed_message(data)
 
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -95,9 +95,7 @@ class DummyCallbackHandler:
 
 
 def test_add_plugin():
-    """
-    test adding plugins at runtime
-    """
+    """Test adding plugins at runtime."""
     from edutap.wallet_google.plugins import add_plugin
     from edutap.wallet_google.plugins import get_callback_handlers
     from edutap.wallet_google.plugins import get_image_providers

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -41,7 +41,7 @@ def test_settings_cached(mock_settings):
 def test_settings_no_credentials_file(mock_settings):
     mock_settings.credentials_file = pathlib.Path("nonexistent.json")
     with pytest.raises(FileNotFoundError):
-        mock_settings.credentials_info
+        assert mock_settings.credentials_info
 
 
 def test_settings_wrong_credentials_file(mock_settings):
@@ -49,4 +49,4 @@ def test_settings_wrong_credentials_file(mock_settings):
         ROOT_DIR / "tests" / "data" / "credentials_fake_wrong.json"
     )
     with pytest.raises(ValueError):
-        mock_settings.credentials_info
+        assert mock_settings.credentials_info

--- a/tests/test_tool_version_pins.py
+++ b/tests/test_tool_version_pins.py
@@ -1,0 +1,55 @@
+"""Keep the ruff and ty version pins in sync between two files that duplicate them.
+
+``pyproject.toml``'s ``dependency-groups.lint``/``.typecheck`` entries and
+``.pre-commit-config.yaml``'s ``rev:`` lines both pin ruff and ty, and both
+files carry a comment claiming the two "cannot silently disagree" — but
+nothing enforced that claim. pre-commit.ci rewrites the ``rev:`` lines on its
+monthly autoupdate schedule regardless of the ``ci: skip:`` list, so the pins
+can drift apart with no failure anywhere except a confusing local/CI mismatch
+weeks later. These tests make that drift a fast, obvious test failure instead.
+"""
+
+from pathlib import Path
+
+import re
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT_TEXT = (REPO_ROOT / "pyproject.toml").read_text()
+PRE_COMMIT_CONFIG_TEXT = (REPO_ROOT / ".pre-commit-config.yaml").read_text()
+
+
+def _dependency_group_floor(package: str) -> str:
+    """Return the floor version pinned for ``package`` in a dependency group."""
+    match = re.search(rf'"{re.escape(package)}>=([0-9.]+)', PYPROJECT_TEXT)
+    assert match, f"no {package!r} floor found in pyproject.toml's dependency-groups"
+    return match.group(1)
+
+
+def _pre_commit_rev(repo_url: str) -> str:
+    """Return the ``rev:`` pinned for the pre-commit repo at ``repo_url``."""
+    match = re.search(
+        rf"-\s+repo:\s+{re.escape(repo_url)}.*?rev:\s+v?([0-9.]+)",
+        PRE_COMMIT_CONFIG_TEXT,
+        re.DOTALL,
+    )
+    assert match, f"no rev: found for repo {repo_url!r} in .pre-commit-config.yaml"
+    return match.group(1)
+
+
+def test_ruff_version_matches_across_pyproject_and_pre_commit():
+    group_floor = _dependency_group_floor("ruff")
+    hook_rev = _pre_commit_rev("https://github.com/astral-sh/ruff-pre-commit")
+    assert group_floor == hook_rev, (
+        f"pyproject.toml pins ruff>={group_floor} but .pre-commit-config.yaml "
+        f"pins rev: v{hook_rev} — update both together."
+    )
+
+
+def test_ty_version_matches_across_pyproject_and_pre_commit():
+    group_floor = _dependency_group_floor("ty")
+    hook_rev = _pre_commit_rev("https://github.com/astral-sh/ty-pre-commit")
+    assert group_floor == hook_rev, (
+        f"pyproject.toml pins ty>={group_floor} but .pre-commit-config.yaml "
+        f"pins rev: v{hook_rev} — update both together."
+    )


### PR DESCRIPTION
Package modernisation across six tasks: PEP 639/735 packaging metadata, a `Makefile` and `prek` as the local hook runner, `ty` promoted to a real pre-commit hook with its diagnostics triaged, `ruff`'s bugbear/security rules, and `ruff`'s docstring convention. All six tasks are done; this branch is ready for review.

## Breaking for developers

`[test]`, `[typecheck]` and `[develop]` no longer exist as extras. The install command is now:

```bash
uv pip install -U -e ".[callback]" --group dev
```

or just `make venv`. Anyone with a sibling checkout referencing the old extras has to change it — `CLAUDE.md` itself still had the old command in three places until this branch's own verification pass caught it.

## Three real bugs, found while triaging lint output

These are easy to miss under the size of this diff (most of it is docstring reformatting), so calling them out explicitly:

1. **`register_model.__call__` was erasing every decorated model class to the base type.** It was annotated `(cls: type[Model]) -> type[Model]` — no `TypeVar` was involved at all — so `@register_model(...) class EventTicketClass(ClassModel): ...` type-checked as returning `Model`, not `EventTicketClass` — for every downstream consumer, not just this package. Introducing `ModelT = TypeVar("ModelT", bound="Model")` and threading it through the signature cleared 132 of `ty`'s 248 initial diagnostics in one commit.
2. **Eight call sites passed `data=<bytes>` to `httpx`**, a spelling `httpx` deprecated in favour of `content=` for raw bytes. Now `content=` throughout, confirmed byte-identical against `httpx`'s `_content.py` (same headers, body and stream class). `make test-integration` has never been run against this change — it has only been exercised against `respx` mocks, not the real Google Wallet API.
3. **`_prepare_update()` guarded a required-but-optional resource ID with `assert`**, which `python -O` strips. An `Issuer` model instance with no `issuerId` set would have silently sent its update request to `.../issuer/None` against the live Google Wallet API instead of failing locally. Now a `ValueError` with a message, covered by a new regression test.

Also fixed in the same pass: model discovery used `inspect.getmembers`, which only sees modules something else already imported — a new `models/datatypes/*.py` file would have been silently invisible to the registry (and to the test meant to catch that). Now `pkgutil.iter_modules`, which actually walks the package.

## By task

- **Task 1 — packaging metadata.** PEP 639 SPDX license expression (`license = "EUPL-1.2"`, `License-Expression` verified in the built artefact). PEP 735 `[dependency-groups]` (`test`, `lint`, `typecheck`, `dev`) replacing the old extras, every entry carrying a version constraint. Floors added to `[build-system.requires]`. `MANIFEST.in` deleted — hatchling never read it — and replaced by an explicit `[tool.hatch.build.targets.sdist] include` allowlist; `[tool.check-manifest] ignore` mirrors it. The sdist drops from 108 to 80 files: CI workflows, `.github/`, `docs/`, `examples/`, internal notes and this repo's own `CLAUDE.md` stop shipping to PyPI. `src/` and `tests/` ship the same file set as before, verified by a file-list diff — only their contents changed, from Task 5's docstring work.
- **Task 2 — local tooling.** A `Makefile` (`help`, `venv`, `lint`, `reformat`, `test-local`, `test-integration`, `test-matrix`) and `prek` as the local hook runner, replacing ad hoc `tox -e format`/`tox -e lint` invocations.
- **Task 3 — `ty` as a real pre-commit hook.** Moved from a `local` hook pinned in an `entry:` string (stuck 49 releases behind, at 0.0.17) to `astral-sh/ty-pre-commit@v0.0.66`, which pre-commit.ci can autoupdate monthly. The resulting jump surfaced 248 diagnostics; all are now triaged, `src/` is completely clean, and the 102 that remain are all in `tests/` and held at `warn` in `[tool.ty.rules]` with the reasoning recorded there (mostly the `-> Model` return type `api.py`'s CRUD functions have to declare, since the concrete model class is only known at runtime). `ty` is **skipped on pre-commit.ci** — `[tool.ci] skip: [..., ty]` — for a measured reason, not caution: the upstream hook's `uv check` builds the project to resolve `[build-system.requires]` against PyPI, and pre-commit.ci disables network during hook execution. Observed directly on this PR: every other hook passed, `ty` failed with `dns error: Temporary failure in name resolution`. It still runs in CI's `lint` job (`tox -e lint`, verified green at v0.0.66), and locally via `make lint` and `prek run -a`; only the pre-commit.ci execution is skipped.
- **Python 3.10 support is deliberately not dropped.** Its end of life is 2026-10-31; narrowing `requires-python` now would be a breaking change unrelated to this branch's purpose. A dated marker in `pyproject.toml` lists ten places that need to change together when it does (target versions in `ruff`/`ty`/`tox`, three README/docs sentences, the CI Python matrix, and more), and `RELEASING.md` gained a checklist item so the day doesn't rely on memory.
- **Task 4 — `ruff`'s `B` (bugbear) and `S` (security) rules.** `B` found fifteen issues: eight `raise ... from` chains decided per site, one documented `functools.cache` `noqa` (a true process-lifetime singleton), an unused loop variable, and two test assertions. `S` is almost entirely `S101` in `tests/` — assert *is* the test framework there, ignored per-file rather than project-wide — plus three `S105` false positives in `src/` (a URL constant, two enum members) annotated individually so a real hardcoded secret would still be caught. The one `S101` in `src/` was bug #3 above.
- **Task 5 — `ruff`'s `D` (pydocstyle) rules, `convention = "pep257"`.** 508 findings down to 0 outside the `D1xx` "undocumented public …" group, which is deliberately still ignored — 144 findings, every one needing a docstring actually written rather than a mechanical fix, tracked by a comment next to `ignore = [...]` in `pyproject.toml`'s `[tool.ruff.lint]`. Nearly all of the D-rule fixes needed `--unsafe-fixes` (it rewrites docstring text, not just layout), so the diff was read rather than trusted; all of it turned out to be safe — collapsing already-single-sentence multi-line docstrings, adding missing periods, fixing capitalisation. Two docstrings were factually wrong and are now correct: `_get_fields_for_model`'s was copy-pasted from `_get_fields_for_name` and described the wrong parameter type, and `api.create()`'s said "Creates a Google Wallet items" (wrong grammar) where its async counterpart correctly said "item".
- **Task 6 — full verification.** `make lint`, `make test-local` and `make test-matrix` (the full `tox` matrix, `py310` through `py314` plus `lint`) all pass. Verifying the whole repository against the new `ruff` config — not just `src`/`tests`, which is all `make lint` scopes — turned up one docstring in `examples/` that Task 5's narrower check had never seen, and CLAUDE.md's own stale references to the removed extras (see "Breaking for developers" above); both are fixed on this branch.

## Renovate follow-up (not blocking this PR)

Every `[dependency-groups]` and `[build-system.requires]` entry now carries a version constraint. That is necessary for Renovate to act on them but not sufficient by itself — `chore/renovate` (PR #95)'s dry run found none of them actionable before this branch, and a floor alone doesn't change that: `pdbp>=1.7.1` was already floored on this branch from the start and still produced nothing in that dry run. Actionability needs `rangeStrategy: "bump"` on the matching rule in `renovate.json5` too. That change is blocked on PR #95 merging first, and **#95 is still open as of this writing** — the dependency version constraints landing here are a prerequisite for that follow-up, not a replacement for it.

`callback` — the one extra actually published in the wheel metadata — deliberately gets neither a floor nor `bump`: it is exactly as resolved-by-consumers as the six entries in `[project.dependencies]` below, so the same reasoning applies. `handlers/fastapi.py` needs nothing past FastAPI's earliest 0.x releases, so `fastapi` stays an unconstrained `callback = ["fastapi"]` rather than the `>=0.141.1` floor an earlier revision of this branch had added purely because that was the version resolving on the day it was written.

The six runtime dependencies in `[project.dependencies]` deliberately keep open floors rather than ceilings — an upper bound on a *library's* runtime dependency breaks resolution for every downstream consumer who needs a newer release for a reason of their own. `authlib`, `cryptography` and `pydantic-settings` carry security floors (from PR #93); `pydantic[email]>=2.0` is a major-version floor; `httpx>=0.15` picked up a feature floor on this branch as a side effect of bug #2 above; `joserfc` remains fully unconstrained. None of the six get a ceiling. See the design spec's Part 5 for the full reasoning.

## Review fixes (this update)

- `fastapi>=0.141.1` in `[project.optional-dependencies].callback` came down: that block is published wheel metadata every consumer of `edutap.wallet-google[callback]` resolves, unlike `[dependency-groups]`, and nothing in `handlers/fastapi.py` needed that floor. `callback` now follows `[project.dependencies]`'s rule instead — no constraint without a real code reason, never `bump` — and the design spec and plan are corrected to say so, including the parked `renovate.json5` step (Task 1, Step 12), which no longer pairs `bump` with `project.optional-dependencies`.
- Added `tests/test_tool_version_pins.py`, which fails if the `ruff`/`ty` pins in `pyproject.toml`'s dependency groups and `.pre-commit-config.yaml`'s hook `rev:` lines ever drift apart — previously only a comment's claim, not enforced.
- `docs/installation.md` now documents `make venv`/the `--group dev` install, replaces two `tox -e test` commands that named a tox environment that does not exist, and corrects "up to 3.13 is tested" to 3.14.
- `CLAUDE.md`'s remaining `pre-commit` invocations are now `prek`, matching this branch's own switch.
- `make lint`'s `ruff check` now covers the whole repository, matching CI (`prek run -a`) — commit `59620c2` already proved they could diverge on `examples/`. `ruff format --check` deliberately stays scoped to `src tests`: widening it would additionally format-check Markdown code blocks in `CLAUDE.md`, `README.md` and `docs/tutorials.md`, which the pre-commit hook's `types_or` never does, so `make lint` would become stricter than CI rather than equal to it.
- `handlers/validate.py`: split an 184-character single-line docstring summary into a summary plus a body, and fixed a pre-existing "from from" typo in the module docstring.
- Small corrections: a stray "(Step 2 above)" plan reference in `pyproject.toml`, the sdist's `Makefile`-inclusion rationale (`make test-local` itself needs network, so the real reason is that it documents the exact `pytest` invocation), and `RELEASING.md`'s `uv sync` troubleshooting line (no `uv.lock` is tracked, so `uv sync` would create one rather than use one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

