### PR TITLE
ci: skip an existing file on the Test PyPI upload

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,6 +66,11 @@
             uses: pypa/gh-action-pypi-publish@release/v1
             with:
               repository-url: https://test.pypi.org/legacy/
+              # The version is static, so a commit on main that does not bump
+              # it rebuilds a filename Test PyPI already holds. Without this
+              # the upload is a hard error and main goes red for a reason that
+              # says nothing about the code.
+              skip-existing: true
 
       # Upload to real PyPI on GitHub Releases.
       release-pypi:


### PR DESCRIPTION
## Summary

One line in the Test PyPI upload step: `skip-existing: true`.

That job runs on every commit on `main`, but the version in `pyproject.toml` is static. A commit that does not bump it rebuilds a filename Test PyPI already holds, the upload fails, and `main` goes red for a reason that says nothing about the code — so the signal that should mean *something is broken* comes to mean *someone pushed twice*, and it stops being read.

The pypi.org job is deliberately untouched. There a duplicate filename means a release went wrong, and it should stop.

## Tests

The workflow parses, and the parsed `release-test-pypi` step carries both `repository-url` and `skip-existing`, while `release-pypi` still carries no `with:` block at all. Beyond that this is a GitHub Actions input — it can only really be exercised by the next commit on `main`.

## Risks

`skip-existing` also hides a genuine mistake: republishing an unchanged version after intentionally rebuilding it now passes silently instead of failing. On Test PyPI that is the trade worth making; on PyPI it would not be, which is why the change stops here.

## Context

Carried over from `edutap.heidi_api`, which hit exactly this on its first release. The same commit is going to all five sibling packages so the release workflows stay identical — they are worth reading side by side only as long as they actually match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)