### PR TITLE
feat(batch): batch requests — update many passes in one API call

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -54,6 +54,32 @@ All functions use persistent, pooled HTTP clients managed by the `ClientPoolMana
 - `new()` is synchronous for both - it just creates model instances
 - `save_link()` is synchronous for both - it uses synchronous JWT signing and should not be awaited
 
+### Batch Requests
+
+`Batch` collects updates and sends them as a single `multipart/mixed` API call, so a
+hundred updates cost what one update costs against the Wallet API's per-call rate limit.
+`Batch`, `BatchResult` and `BatchError` are re-exported on the `api` module, so
+`api.Batch()`, `api.BatchResult` and `api.BatchError` work without a separate import.
+
+```python
+from edutap.wallet_google import api
+
+batch = api.Batch()
+batch.add_update("LoyaltyObject", {"id": "issuer.member-1", "state": "EXPIRED"})
+results = batch.execute()
+```
+
+```{eval-rst}
+.. currentmodule:: edutap.wallet_google.batch
+
+.. autosummary::
+   :toctree: _autosummary
+
+   Batch
+   BatchResult
+   BatchError
+```
+
 ## Models
 
 ### Base Models

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -56,8 +56,13 @@ All functions use persistent, pooled HTTP clients managed by the `ClientPoolMana
 
 ### Batch Requests
 
-`Batch` collects updates and sends them as a single `multipart/mixed` API call, so a
-hundred updates cost what one update costs against the Wallet API's per-call rate limit.
+`Batch` collects updates and sends them as a single `multipart/mixed` API call, following
+the mechanism documented at
+[Google's performance tips](https://developers.google.com/wallet/generic/resources/performance-tips).
+A batch appears to count as a single call against the Wallet API's
+[per-call rate limit](https://developers.google.com/wallet/generic/resources/faq), so a
+hundred updates cost what one update costs. This is an operational finding from running
+the real system, not something Google documents or guarantees.
 `Batch`, `BatchResult` and `BatchError` are re-exported on the `api` module, so
 `api.Batch()`, `api.BatchResult` and `api.BatchError` work without a separate import.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -70,9 +70,20 @@ the real system, not something Google documents or guarantees.
 from edutap.wallet_google import api
 
 batch = api.Batch()
+batch.add_create(
+    "LoyaltyObject",
+    {"id": "issuer.member-3", "classId": "issuer.loyalty-class", "state": "ACTIVE"},
+)
 batch.add_update("LoyaltyObject", {"id": "issuer.member-1", "state": "EXPIRED"})
 results = batch.execute()
 ```
+
+`add_create()`/`add_creates()` add a `POST` for a new object and `add_update()`/
+`add_updates()` add a `PATCH` for an existing one; both fit in the same batch, since the
+HTTP method travels with each sub-request. The two validate differently: `add_create()`
+checks the payload against the **full** model, because a new object must supply its
+required fields, while `add_update()` relaxes that requirement, since a `PATCH` carrying
+two changed attributes has no reason to also supply `classId`.
 
 ```{eval-rst}
 .. currentmodule:: edutap.wallet_google.batch

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -246,6 +246,32 @@ print(f"sending {len(batch)} updates as one request")
 results = batch.execute()
 ```
 
+## Creating many passes at once
+
+`add_create` adds a `POST` for a new object instead of a `PATCH` for an existing one.
+Unlike `add_update`, it requires the **full** object: a new object must supply its
+required fields, since there is nothing on Google's side yet to fill in the gaps.
+`add_creates` adds a whole list, exactly like `add_updates`:
+
+```python
+batch = api.Batch()
+batch.add_create(
+    "GenericObject",
+    {"id": "issuer.new-member", "classId": "issuer.generic-class", "state": "ACTIVE"},
+)
+results = batch.execute()
+```
+
+Creates and updates fit in the same batch — the HTTP method travels with each
+sub-request:
+
+```python
+batch = api.Batch()
+batch.add_create("LoyaltyObject", new_member_data)
+batch.add_update("LoyaltyObject", {"id": "issuer.member-1", "state": "EXPIRED"})
+results = batch.execute()
+```
+
 A batch is **not** atomic: individual items can fail while the rest succeed, which is why
 failures come back as results rather than exceptions. There is one result per added
 sub-request, **in the order they were added** — the batch may group and reorder the

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -206,6 +206,55 @@ updated_object = api.update(
 )
 ```
 
+## Updating many passes at once
+
+A `Batch` collects updates and sends them as a single API call. Because the Google Wallet
+API is rate limited per call, a hundred updates in one batch cost what one update costs:
+
+```python
+from edutap.wallet_google import api
+
+batch = api.Batch()
+batch.add_update("LoyaltyObject", {"id": "issuer.member-1", "state": "EXPIRED"})
+batch.add_update("LoyaltyObject", {"id": "issuer.member-2", "state": "EXPIRED"})
+results = batch.execute()
+
+for result in results:
+    if not result.ok:
+        print(f"{result.resource_id} failed: {result.error.message}")
+```
+
+Only the attributes you set are sent, so a batch of small changes stays small on the wire.
+
+Pass types may be mixed in one batch — each sub-request carries its own path:
+
+```python
+batch = api.Batch()
+batch.add_update("LoyaltyObject", {"id": "issuer.member-1", "state": "EXPIRED"})
+batch.add_update("EventTicketObject", {"id": "issuer.ticket-9", "state": "COMPLETED"})
+```
+
+For the bulk case, add a whole list at once and use `len(batch)` to decide how much goes
+into one call:
+
+```python
+batch = api.Batch()
+batch.add_updates("LoyaltyObject", changed_members)
+print(f"sending {len(batch)} updates as one request")
+results = batch.execute()
+```
+
+A batch is **not** atomic: individual items can fail while the rest succeed, which is why
+failures come back as results rather than exceptions. There is one result per added
+sub-request, **in the order they were added** — the batch may group and reorder the
+sub-requests internally, but that never shows in the results.
+
+`execute()` does not split, throttle or retry. The Google Wallet API is rate limited to 20
+calls per second; deciding how many objects go into one batch, and how fast batches follow
+each other, is yours.
+
+The asynchronous twin is `await batch.aexecute()` and behaves identically.
+
 ## Send a notification to a pass
 
 You can send messages to passes to notify users about updates or important information:

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -208,8 +208,10 @@ updated_object = api.update(
 
 ## Updating many passes at once
 
-A `Batch` collects updates and sends them as a single API call. Because the Google Wallet
-API is rate limited per call, a hundred updates in one batch cost what one update costs:
+A `Batch` collects updates and sends them as a single `multipart/mixed` API call. A batch
+appears to count as a single call against the Google Wallet API's rate limit, so a hundred
+updates in one batch cost what one update costs. This is an operational finding from
+running the real system, not something Google documents or guarantees:
 
 ```python
 from edutap.wallet_google import api
@@ -249,9 +251,9 @@ failures come back as results rather than exceptions. There is one result per ad
 sub-request, **in the order they were added** — the batch may group and reorder the
 sub-requests internally, but that never shows in the results.
 
-`execute()` does not split, throttle or retry. The Google Wallet API is rate limited to 20
-calls per second; deciding how many objects go into one batch, and how fast batches follow
-each other, is yours.
+`execute()` does not split, throttle or retry. The Google Wallet API is rate limited to
+[20 calls per second](https://developers.google.com/wallet/generic/resources/faq); deciding
+how many objects go into one batch, and how fast batches follow each other, is yours.
 
 The asynchronous twin is `await batch.aexecute()` and behaves identically.
 

--- a/src/edutap/wallet_google/api.py
+++ b/src/edutap/wallet_google/api.py
@@ -29,6 +29,9 @@ link = api.save_link([my_pass])  # save_link is sync, not awaited
 ```
 """
 
+from .batch import Batch
+from .batch import BatchError
+from .batch import BatchResult
 from .clientpool import client_pool
 from .credentials import credentials_manager
 from .models.bases import make_partial_model
@@ -67,6 +70,9 @@ logger = logging.getLogger(__name__)
 
 
 __all__ = [
+    "Batch",
+    "BatchError",
+    "BatchResult",
     "new",
     "save_link",
     "create",

--- a/src/edutap/wallet_google/api.py
+++ b/src/edutap/wallet_google/api.py
@@ -27,6 +27,15 @@ my_pass = api.new("GenericObject", {...})
 result = await api.acreate(my_pass)
 link = api.save_link([my_pass])  # save_link is sync, not awaited
 ```
+
+Batch updates:
+```python
+from edutap.wallet_google import api
+
+batch = api.Batch()
+batch.add_update("LoyaltyObject", {"id": "issuer.member-1", "state": "EXPIRED"})
+results = batch.execute()  # or `await batch.aexecute()`
+```
 """
 
 from .batch import Batch

--- a/src/edutap/wallet_google/batch.py
+++ b/src/edutap/wallet_google/batch.py
@@ -1,0 +1,219 @@
+"""Batch requests against the Google Wallet API.
+
+A :class:`Batch` collects sub-requests and sends them as a single
+``multipart/mixed`` request. One Batch is one HTTP request — which is the point:
+the Google Wallet API is rate limited per call, so a hundred updates in one
+Batch cost what one update costs.
+
+See https://developers.google.com/wallet/generic/resources/performance-tips
+"""
+
+from .clientpool import client_pool
+from .models.bases import make_partial_model
+from .models.bases import Model
+from .multipart import decode_multipart
+from .multipart import encode_multipart
+from .multipart import make_boundary
+from .multipart import SubRequest
+from .multipart import SubResponse
+from .registry import lookup_metadata_by_name
+from .registry import raise_when_operation_not_allowed
+from .utils import handle_response_errors
+from pydantic import ValidationError as PydanticValidationError
+
+import typing
+import urllib.parse
+
+
+class BatchError(Model):
+    """The error Google reports for a single failed sub-request."""
+
+    code: int
+    message: str
+    status: str | None = None
+
+
+class BatchResult(Model):
+    """The outcome of one sub-request, correlated back to its input item."""
+
+    index: int
+    name: str
+    resource_id: str
+    status_code: int
+    body: dict | None = None
+    error: BatchError | None = None
+
+    @property
+    def ok(self) -> bool:
+        """True when Google accepted this sub-request."""
+        return self.error is None and 200 <= self.status_code < 300
+
+
+class Batch:
+    """Collects sub-requests and sends them as one API call.
+
+    Fill it, then execute it::
+
+        batch = Batch()
+        batch.add_update("LoyaltyObject", {"id": "issuer.m1", "state": "EXPIRED"})
+        results = batch.execute()
+
+    Pass types may be mixed freely — each sub-request carries its own path.
+    """
+
+    def __init__(self) -> None:
+        self._sub_requests: list[SubRequest] = []
+        # Parallel to _sub_requests: what each one was about, for the results.
+        self._items: list[tuple[str, str]] = []
+
+    def __len__(self) -> int:
+        """Number of sub-requests collected so far.
+
+        One Batch is one HTTP request, so this is the number the caller needs in
+        order to decide whether to send it or start a new one.
+        """
+        return len(self._sub_requests)
+
+    def add_update(self, name: str, data: dict[str, typing.Any]) -> None:
+        """Add a PATCH for one object.
+
+        Only the attributes present in ``data`` are sent. The payload is
+        validated here rather than at execute time, so a typo fails on the line
+        that caused it.
+
+        :param name: Registered model name, e.g. "LoyaltyObject".
+        :param data: The attributes to change, plus the resource id.
+        :raises ValueError: When the payload is invalid or carries no resource id.
+        """
+        metadata = lookup_metadata_by_name(name)
+        raise_when_operation_not_allowed(name, "update")
+        resource_id_key = metadata["resource_id"]
+
+        resource_id = data.get(resource_id_key)
+        if not resource_id:
+            raise ValueError(
+                f"Item for '{name}' has no '{resource_id_key}'; nothing to update."
+            )
+
+        partial_model = make_partial_model(metadata["model"])
+        try:
+            verified = partial_model.model_validate(data)
+        except PydanticValidationError as exc:
+            raise ValueError(
+                f"Item '{resource_id}' is invalid for '{name}': {exc}"
+            ) from exc
+
+        api_path = urllib.parse.urlparse(str(client_pool.settings.api_url)).path
+        self._sub_requests.append(
+            SubRequest(
+                method="PATCH",
+                path=f"{api_path}/{metadata['url_part']}/{resource_id}",
+                body=verified.model_dump_json(exclude_unset=True, by_alias=True),
+                content_id=f"item-{len(self._sub_requests)}",
+            )
+        )
+        self._items.append((name, resource_id))
+
+    def add_updates(
+        self,
+        name: str,
+        data: list[dict[str, typing.Any]],
+    ) -> None:
+        """Add a PATCH for each object in a list.
+
+        :param name: Registered model name, applied to every item.
+        :param data: One dict per object.
+        :raises ValueError: When any payload is invalid or carries no resource id.
+        """
+        for item in data:
+            self.add_update(name, item)
+
+    def _ordered_sub_requests(self) -> list[SubRequest]:
+        """Return the sub-requests in the order they should go on the wire.
+
+        Grouped by pass type. ``sorted`` is stable, so within a type the add
+        order survives. This is free to change: results are correlated by
+        Content-ID, not by position, so reordering here cannot affect what
+        :meth:`execute` returns.
+        """
+        order = sorted(
+            range(len(self._sub_requests)),
+            key=lambda index: self._items[index][0],
+        )
+        return [self._sub_requests[index] for index in order]
+
+    def _build_results(self, sub_responses: list[SubResponse]) -> list[BatchResult]:
+        """Correlate sub-responses back to the items that produced them.
+
+        Correlation is by Content-ID, not by position: the specification does not
+        promise the server answers in the order it was asked.
+        """
+        by_content_id = {r.content_id: r for r in sub_responses if r.content_id}
+        results: list[BatchResult] = []
+        for index, (name, resource_id) in enumerate(self._items):
+            sub_response = by_content_id.get(f"item-{index}")
+            if sub_response is None:
+                results.append(
+                    BatchResult(
+                        index=index,
+                        name=name,
+                        resource_id=resource_id,
+                        status_code=0,
+                        error=BatchError(
+                            code=0, message="No response part for this sub-request."
+                        ),
+                    )
+                )
+                continue
+            body = sub_response.body
+            error = None
+            if body is not None and "error" in body:
+                error = BatchError.model_validate(body["error"])
+                body = None
+            results.append(
+                BatchResult(
+                    index=index,
+                    name=name,
+                    resource_id=resource_id,
+                    status_code=sub_response.status_code,
+                    body=body,
+                    error=error,
+                )
+            )
+        return results
+
+    def execute(self, *, credentials: dict | None = None) -> list[BatchResult]:
+        """Send the collected sub-requests as one API call.
+
+        Individual sub-request failures do **not** raise; they come back as
+        results carrying an ``error``. Only the batch request itself failing
+        raises.
+
+        Sub-requests may be grouped and reordered on the wire. The results are
+        not: they come back in the order the items were added, correlated by
+        Content-ID.
+
+        This does not chunk, throttle or retry. The Google Wallet API is rate
+        limited to 20 calls per second; staying within it is the caller's
+        business. Parameters are keyword-only so that a later driver stage can
+        add ``chunk_size`` and friends without breaking existing calls.
+
+        :param credentials: Optional session credentials as dict.
+        :raises WalletException: When the batch request itself fails.
+        :return: One result per added sub-request, in the order they were added.
+        """
+        if not self._sub_requests:
+            return []
+        boundary = make_boundary()
+
+        client = client_pool.client(credentials=credentials)
+        response = client.post(
+            url=str(client_pool.settings.batch_url),
+            content=encode_multipart(self._ordered_sub_requests(), boundary),
+            headers={"Content-Type": f"multipart/mixed; boundary={boundary}"},
+        )
+        handle_response_errors(response, "batch", "Batch", f"{len(self)} items")
+
+        return self._build_results(
+            decode_multipart(response.content, response.headers.get("Content-Type", ""))
+        )

--- a/src/edutap/wallet_google/batch.py
+++ b/src/edutap/wallet_google/batch.py
@@ -217,3 +217,28 @@ class Batch:
         return self._build_results(
             decode_multipart(response.content, response.headers.get("Content-Type", ""))
         )
+
+    async def aexecute(self, *, credentials: dict | None = None) -> list[BatchResult]:
+        """Asynchronously send the collected sub-requests as one API call.
+
+        See :meth:`execute` for the full description; behaviour is identical.
+
+        :param credentials: Optional session credentials as dict.
+        :raises WalletException: When the batch request itself fails.
+        :return: One result per added sub-request, in the order they were added.
+        """
+        if not self._sub_requests:
+            return []
+        boundary = make_boundary()
+
+        client = client_pool.async_client(credentials=credentials)
+        response = await client.post(
+            url=str(client_pool.settings.batch_url),
+            content=encode_multipart(self._ordered_sub_requests(), boundary),
+            headers={"Content-Type": f"multipart/mixed; boundary={boundary}"},
+        )
+        handle_response_errors(response, "batch", "Batch", f"{len(self)} items")
+
+        return self._build_results(
+            decode_multipart(response.content, response.headers.get("Content-Type", ""))
+        )

--- a/src/edutap/wallet_google/batch.py
+++ b/src/edutap/wallet_google/batch.py
@@ -21,6 +21,7 @@ from .multipart import SubResponse
 from .registry import lookup_metadata_by_name
 from .registry import raise_when_operation_not_allowed
 from .utils import handle_response_errors
+from .utils import validate_data_and_convert_to_json
 from pydantic import ConfigDict
 from pydantic import ValidationError as PydanticValidationError
 
@@ -91,6 +92,34 @@ class Batch:
         """
         return len(self._sub_requests)
 
+    def _append_sub_request(
+        self,
+        *,
+        method: str,
+        path: str,
+        body: str,
+        name: str,
+        resource_id: str,
+    ) -> None:
+        """Build a SubRequest, append it, and record the item behind it.
+
+        Shared tail of ``add_update`` and ``add_create``: both differ in
+        method, path, validation and serialisation, but agree on everything
+        from here on. ``content_id`` is derived from the pre-append length of
+        ``_sub_requests``, so it stays stable and index-aligned with
+        ``_items`` -- ``_build_results`` correlates by it, and
+        ``_ordered_sub_requests`` may reorder the wire.
+        """
+        self._sub_requests.append(
+            SubRequest(
+                method=method,
+                path=path,
+                body=body,
+                content_id=f"item-{len(self._sub_requests)}",
+            )
+        )
+        self._items.append((name, resource_id))
+
     def add_update(self, name: str, data: dict[str, typing.Any]) -> None:
         """Add a PATCH for one object.
 
@@ -121,15 +150,13 @@ class Batch:
             ) from exc
 
         api_path = urllib.parse.urlparse(str(client_pool.settings.api_url)).path
-        self._sub_requests.append(
-            SubRequest(
-                method="PATCH",
-                path=f"{api_path}/{metadata['url_part']}/{resource_id}",
-                body=verified.model_dump_json(exclude_unset=True, by_alias=True),
-                content_id=f"item-{len(self._sub_requests)}",
-            )
+        self._append_sub_request(
+            method="PATCH",
+            path=f"{api_path}/{metadata['url_part']}/{resource_id}",
+            body=verified.model_dump_json(exclude_unset=True, by_alias=True),
+            name=name,
+            resource_id=resource_id,
         )
-        self._items.append((name, resource_id))
 
     def add_updates(
         self,
@@ -144,6 +171,60 @@ class Batch:
         """
         for item in data:
             self.add_update(name, item)
+
+    def add_create(self, name: str, data: dict[str, typing.Any]) -> None:
+        """Add a POST for one new object.
+
+        Unlike :meth:`add_update`, the payload is validated against the
+        **full** model, not a relaxed one: a new object must bring its
+        required fields, since there is nothing on Google's side yet to fill
+        the gaps from. This mirrors ``_prepare_create()`` in ``api.py``,
+        including the handling of models registered with
+        ``pass_resource_id_on_create=False`` (only ``Issuer`` today), whose
+        id must not be sent in the body.
+
+        :param name: Registered model name, e.g. "LoyaltyObject".
+        :param data: The full object to create.
+        :raises ValueError: When the payload is invalid, or carries a
+            resource id for a model that must not receive one on create.
+        """
+        metadata = lookup_metadata_by_name(name)
+        raise_when_operation_not_allowed(name, "create")
+        resource_id_key = metadata["resource_id"]
+        skip_resource_id = not metadata["pass_resource_id_on_create"]
+
+        try:
+            resource_id, body = validate_data_and_convert_to_json(
+                metadata["model"],
+                data,
+                skip_resource_id=skip_resource_id,
+                resource_id_key=resource_id_key,
+            )
+        except PydanticValidationError as exc:
+            raise ValueError(f"Item is invalid for '{name}': {exc}") from exc
+
+        api_path = urllib.parse.urlparse(str(client_pool.settings.api_url)).path
+        self._append_sub_request(
+            method="POST",
+            path=f"{api_path}/{metadata['url_part']}",
+            body=body,
+            name=name,
+            resource_id=resource_id or "",
+        )
+
+    def add_creates(
+        self,
+        name: str,
+        data: list[dict[str, typing.Any]],
+    ) -> None:
+        """Add a POST for each object in a list.
+
+        :param name: Registered model name, applied to every item.
+        :param data: One dict per object, each carrying its required fields.
+        :raises ValueError: When any payload is invalid.
+        """
+        for item in data:
+            self.add_create(name, item)
 
     def _ordered_sub_requests(self) -> list[SubRequest]:
         """Return the sub-requests in the order they should go on the wire.

--- a/src/edutap/wallet_google/batch.py
+++ b/src/edutap/wallet_google/batch.py
@@ -170,6 +170,23 @@ class Batch:
             if body is not None and "error" in body:
                 error = BatchError.model_validate(body["error"])
                 body = None
+            elif not (200 <= sub_response.status_code < 300):
+                # Invariant: BatchResult.ok is False implies BatchResult.error is
+                # not None. Google's protocol only guarantees an "error" key in
+                # the body for the errors it recognises; a non-2xx status can
+                # still arrive with no such key (or, per _parse_http_payload, a
+                # status line that could not even be parsed, degraded here to
+                # status_code=0). Without this branch, callers following the
+                # documented `if not result.ok: print(result.error.message)`
+                # pattern would hit AttributeError on error=None.
+                if sub_response.status_code == 0:
+                    message = "Sub-response status line could not be parsed."
+                else:
+                    message = (
+                        f"Sub-response returned status {sub_response.status_code} "
+                        "without an error body."
+                    )
+                error = BatchError(code=sub_response.status_code, message=message)
             results.append(
                 BatchResult(
                     index=index,

--- a/src/edutap/wallet_google/batch.py
+++ b/src/edutap/wallet_google/batch.py
@@ -1,11 +1,13 @@
 """Batch requests against the Google Wallet API.
 
 A :class:`Batch` collects sub-requests and sends them as a single
-``multipart/mixed`` request. One Batch is one HTTP request — which is the point:
-the Google Wallet API is rate limited per call, so a hundred updates in one
-Batch cost what one update costs.
+``multipart/mixed`` request, following the mechanism documented at
+https://developers.google.com/wallet/generic/resources/performance-tips.
 
-See https://developers.google.com/wallet/generic/resources/performance-tips
+A batch appears to count as a single call against the 20-calls-per-second rate
+limit (https://developers.google.com/wallet/generic/resources/faq), so a hundred
+updates in one Batch cost what one update costs. This is an operational finding
+from running the real system, not something Google documents or guarantees.
 """
 
 from .clientpool import client_pool
@@ -19,6 +21,7 @@ from .multipart import SubResponse
 from .registry import lookup_metadata_by_name
 from .registry import raise_when_operation_not_allowed
 from .utils import handle_response_errors
+from pydantic import ConfigDict
 from pydantic import ValidationError as PydanticValidationError
 
 import typing
@@ -26,7 +29,17 @@ import urllib.parse
 
 
 class BatchError(Model):
-    """The error Google reports for a single failed sub-request."""
+    """The error Google reports for a single failed sub-request.
+
+    Unlike the wallet models, this describes a *foreign* response payload, not
+    something of ours: Google's real error object carries fields beyond the three
+    modeled here (``details``, and in the classic error envelope, ``errors``).
+    ``extra="ignore"`` -- rather than the strict base's ``extra="forbid"`` -- keeps
+    those extra fields from turning an ordinary error response into a
+    ``ValidationError`` that would take the whole batch down with it.
+    """
+
+    model_config = ConfigDict(extra="ignore")
 
     code: int
     message: str
@@ -59,6 +72,10 @@ class Batch:
         results = batch.execute()
 
     Pass types may be mixed freely — each sub-request carries its own path.
+
+    A ``Batch`` is single-use: :meth:`execute` (and :meth:`aexecute`) neither clears
+    nor locks the collected sub-requests, so calling it a second time sends
+    everything again as a new request. Build a fresh ``Batch`` for the next call.
     """
 
     def __init__(self) -> None:
@@ -167,8 +184,19 @@ class Batch:
                 continue
             body = sub_response.body
             error = None
-            if body is not None and "error" in body:
-                error = BatchError.model_validate(body["error"])
+            if body is not None and isinstance(body.get("error"), dict):
+                # Total by construction: no future shape of Google's error object
+                # may raise out of here and take the rest of the batch down with
+                # it -- that is exactly the contract this whole class exists to
+                # keep. BatchError.model_config already ignores unknown fields
+                # (see its docstring); this except is the backstop for whatever
+                # that config does not anticipate, e.g. a field of the wrong type.
+                try:
+                    error = BatchError.model_validate(body["error"])
+                except PydanticValidationError:
+                    error = BatchError(
+                        code=sub_response.status_code, message=str(body["error"])
+                    )
                 body = None
             elif not (200 <= sub_response.status_code < 300):
                 # Invariant: BatchResult.ok is False implies BatchResult.error is

--- a/src/edutap/wallet_google/multipart.py
+++ b/src/edutap/wallet_google/multipart.py
@@ -1,0 +1,124 @@
+"""Encoding and decoding of ``multipart/mixed`` bodies.
+
+This module deliberately knows nothing about wallet models, settings or HTTP
+clients. It turns sub-requests into bytes and bytes back into sub-responses,
+which makes the fiddly format details testable without a network.
+
+See https://developers.google.com/wallet/generic/resources/performance-tips
+"""
+
+from dataclasses import dataclass
+from email.parser import BytesParser
+from email.policy import HTTP
+
+import json
+import uuid
+
+
+# Google's Wallet examples show the parts as application/json. Google's general
+# batch protocol uses application/http. The Wallet documentation is what we have,
+# so follow it — and keep it in one place so it is a one-line change if the
+# server turns out to want the other one.
+_PART_CONTENT_TYPE = "application/json"
+
+# multipart requires CRLF line endings (RFC 2046).
+_CRLF = "\r\n"
+
+
+@dataclass
+class SubRequest:
+    """A single HTTP request to be carried inside a multipart body."""
+
+    method: str
+    path: str
+    body: str | None
+    content_id: str
+
+
+@dataclass
+class SubResponse:
+    """A single HTTP response extracted from a multipart body."""
+
+    content_id: str | None
+    status_code: int
+    body: dict | None
+
+
+def make_boundary() -> str:
+    """Return a boundary that cannot collide with the payload."""
+    return f"batch_{uuid.uuid4().hex}"
+
+
+def encode_multipart(sub_requests: list[SubRequest], boundary: str) -> bytes:
+    """Encode sub-requests as a ``multipart/mixed`` body.
+
+    :param sub_requests: The requests to carry, in order.
+    :param boundary:     Delimiter between the parts, without leading dashes.
+    :return:             The encoded body, ready to be sent as request content.
+    """
+    lines: list[str] = []
+    for sub_request in sub_requests:
+        lines.append(f"--{boundary}")
+        lines.append(f"Content-Type: {_PART_CONTENT_TYPE}")
+        lines.append(f"Content-ID: <{sub_request.content_id}>")
+        lines.append("")
+        lines.append(f"{sub_request.method} {sub_request.path}")
+        if sub_request.body is not None:
+            lines.append("")
+            lines.append(sub_request.body)
+        lines.append("")
+    lines.append(f"--{boundary}--")
+    lines.append("")
+    return _CRLF.join(lines).encode("utf-8")
+
+
+def _parse_http_payload(payload: str) -> tuple[int, dict | None]:
+    """Parse an embedded HTTP response into status code and JSON body.
+
+    :param payload: A raw HTTP response: status line, headers, blank line, body.
+    :return:        Tuple of status code and decoded body (None when not JSON).
+    """
+    head, _, body = payload.partition(f"{_CRLF}{_CRLF}")
+    status_line = head.split(_CRLF, 1)[0]
+    # "HTTP/1.1 404 Not Found" -> 404
+    status_code = int(status_line.split(" ")[1])
+    body = body.strip()
+    if not body:
+        return status_code, None
+    try:
+        return status_code, json.loads(body)
+    except json.JSONDecodeError:
+        return status_code, None
+
+
+def decode_multipart(content: bytes, content_type: str) -> list[SubResponse]:
+    """Decode a ``multipart/mixed`` body into its sub-responses.
+
+    Order is preserved, but callers should correlate via ``content_id`` rather
+    than position — the specification does not promise the server answers in the
+    order it was asked.
+
+    :param content:      The raw response body.
+    :param content_type: The response Content-Type header, carrying the boundary.
+    :return:             One entry per part, in the order they appear.
+    """
+    message = BytesParser(policy=HTTP).parsebytes(
+        b"Content-Type: " + content_type.encode("utf-8") + b"\r\n\r\n" + content
+    )
+
+    sub_responses: list[SubResponse] = []
+    for part in message.iter_parts():
+        raw_content_id = part.get("Content-ID")
+        content_id = None
+        if raw_content_id:
+            # Google echoes "<response-item-0>" for our "<item-0>".
+            content_id = raw_content_id.strip("<>").removeprefix("response-")
+        status_code, body = _parse_http_payload(part.get_payload())
+        sub_responses.append(
+            SubResponse(
+                content_id=content_id,
+                status_code=status_code,
+                body=body,
+            )
+        )
+    return sub_responses

--- a/src/edutap/wallet_google/multipart.py
+++ b/src/edutap/wallet_google/multipart.py
@@ -80,8 +80,15 @@ def _parse_http_payload(payload: str) -> tuple[int, dict | None]:
     """
     head, _, body = payload.partition(f"{_CRLF}{_CRLF}")
     status_line = head.split(_CRLF, 1)[0]
-    # "HTTP/1.1 404 Not Found" -> 404
-    status_code = int(status_line.split(" ")[1])
+    try:
+        # "HTTP/1.1 404 Not Found" -> 404
+        status_code = int(status_line.split(" ")[1])
+    except (IndexError, ValueError):
+        # A single malformed part must not crash the whole batch decode: 0 is
+        # never a real HTTP status, and callers already treat any non-2xx
+        # status as not-ok, so this degrades gracefully into the existing
+        # error path.
+        status_code = 0
     body = body.strip()
     if not body:
         return status_code, None

--- a/src/edutap/wallet_google/multipart.py
+++ b/src/edutap/wallet_google/multipart.py
@@ -12,6 +12,7 @@ from email.parser import BytesParser
 from email.policy import HTTP
 
 import json
+import re
 import uuid
 
 
@@ -49,15 +50,38 @@ def make_boundary() -> str:
     return f"batch_{uuid.uuid4().hex}"
 
 
+def _reject_crlf(value: str, field: str) -> None:
+    """Raise if *value* contains a bare CR or LF.
+
+    A resource id (or, in principle, a method) is interpolated straight into the
+    request line. Nothing upstream constrains it: ``api.update()`` cannot carry a
+    CR/LF because httpx rejects it in the URL, but ``Batch.add_update()`` builds the
+    path itself with no equivalent guard. Left unchecked, a CR or LF injects extra
+    lines into the part and shifts the body -- surfacing later as an opaque error
+    from Google instead of a clear one from here.
+
+    :param value: The value to check.
+    :param field: Name of the field, for the error message.
+    :raises ValueError: When *value* contains ``\\r`` or ``\\n``.
+    """
+    if "\r" in value or "\n" in value:
+        raise ValueError(f"{field} must not contain CR or LF: {value!r}")
+
+
 def encode_multipart(sub_requests: list[SubRequest], boundary: str) -> bytes:
     """Encode sub-requests as a ``multipart/mixed`` body.
 
     :param sub_requests: The requests to carry, in order.
     :param boundary:     Delimiter between the parts, without leading dashes.
+    :raises ValueError:  When a sub-request's ``path``, ``method`` or ``content_id``
+                          contains a CR or LF, which would corrupt the framing.
     :return:             The encoded body, ready to be sent as request content.
     """
     lines: list[str] = []
     for sub_request in sub_requests:
+        _reject_crlf(sub_request.path, "path")
+        _reject_crlf(sub_request.method, "method")
+        _reject_crlf(sub_request.content_id, "content_id")
         lines.append(f"--{boundary}")
         lines.append(f"Content-Type: {_PART_CONTENT_TYPE}")
         lines.append(f"Content-ID: <{sub_request.content_id}>")
@@ -78,8 +102,12 @@ def _parse_http_payload(payload: str) -> tuple[int, dict | None]:
     :param payload: A raw HTTP response: status line, headers, blank line, body.
     :return:        Tuple of status code and decoded body (None when not JSON).
     """
-    head, _, body = payload.partition(f"{_CRLF}{_CRLF}")
-    status_line = head.split(_CRLF, 1)[0]
+    # Split on the blank line between headers and body. RFC 2046 requires CRLF,
+    # but tolerate a bare LF too: an LF-only sub-response must still surface its
+    # body rather than silently losing it.
+    head, *rest = re.split(r"\r?\n\r?\n", payload, maxsplit=1)
+    body = rest[0] if rest else ""
+    status_line = re.split(r"\r?\n", head, maxsplit=1)[0]
     try:
         # "HTTP/1.1 404 Not Found" -> 404
         status_code = int(status_line.split(" ")[1])
@@ -93,9 +121,13 @@ def _parse_http_payload(payload: str) -> tuple[int, dict | None]:
     if not body:
         return status_code, None
     try:
-        return status_code, json.loads(body)
+        parsed = json.loads(body)
     except json.JSONDecodeError:
         return status_code, None
+    # json.loads() may return a list or a scalar. SubResponse.body is typed
+    # ``dict | None``; a non-dict shape must degrade to None rather than being
+    # carried through into a strict pydantic model it was never declared for.
+    return status_code, parsed if isinstance(parsed, dict) else None
 
 
 def decode_multipart(content: bytes, content_type: str) -> list[SubResponse]:

--- a/src/edutap/wallet_google/settings.py
+++ b/src/edutap/wallet_google/settings.py
@@ -34,6 +34,11 @@ class Settings(BaseSettings):
     )
 
     api_url: AnyHttpUrl = AnyHttpUrl(API_URL)
+    # Must be overridden together with `api_url`: they point at two different hosts
+    # by default (`walletobjects.googleapis.com/walletobjects/v1` vs.
+    # `walletobjects.googleapis.com/batch`). Overriding `api_url` alone moves the
+    # sub-request paths that Batch builds but leaves the batch endpoint itself on
+    # Google's real host.
     batch_url: AnyHttpUrl = AnyHttpUrl(BATCH_URL)
     save_url: AnyHttpUrl = AnyHttpUrl(SAVE_URL)
 

--- a/src/edutap/wallet_google/settings.py
+++ b/src/edutap/wallet_google/settings.py
@@ -11,6 +11,7 @@ import json
 ENV_PREFIX = "EDUTAP_WALLET_GOOGLE_"
 ROOT_DIR = Path(__file__).parent.parent.parent.parent.resolve()
 API_URL = "https://walletobjects.googleapis.com/walletobjects/v1"
+BATCH_URL = "https://walletobjects.googleapis.com/batch"
 SAVE_URL = "https://pay.google.com/gp/v/save"
 SCOPES = ["https://www.googleapis.com/auth/wallet_object.issuer"]
 
@@ -33,6 +34,7 @@ class Settings(BaseSettings):
     )
 
     api_url: AnyHttpUrl = AnyHttpUrl(API_URL)
+    batch_url: AnyHttpUrl = AnyHttpUrl(BATCH_URL)
     save_url: AnyHttpUrl = AnyHttpUrl(SAVE_URL)
 
     handler_prefix: str = "/wallet/google"

--- a/superpowers/plans/2026-08-17-batch-update.md
+++ b/superpowers/plans/2026-08-17-batch-update.md
@@ -1317,6 +1317,203 @@ git commit -m "test(batch): add integration round-trip and record measured limit
 
 ---
 
+---
+
+### Task 6: `add_create()` — creating objects in a batch
+
+Added 2026-08-18, after Tasks 1-5 shipped. `SubRequest` already carries the method and
+`_build_results` does not care how a part was produced, so this is a method on the
+existing class rather than a new mechanism.
+
+**Files:**
+- Modify: `src/edutap/wallet_google/batch.py`
+- Modify: `tests/test_batch.py`
+- Modify: `docs/tutorials.md`, `docs/reference.md`
+
+**Interfaces:**
+- Consumes: `SubRequest`, `Batch._sub_requests`, `Batch._items` from Task 2.
+- Produces: `Batch.add_create(name: str, data: dict) -> None` and
+  `Batch.add_creates(name: str, data: list[dict]) -> None`.
+
+**How create differs from update.** Five things, all of them readable off the existing
+`_prepare_create()` in `api.py`. Getting any of them wrong produces a batch Google
+rejects, or worse, half-formed passes:
+
+| | `add_update()` | `add_create()` |
+| --- | --- | --- |
+| method | `PATCH` | `POST` |
+| path | `<api_path>/<url_part>/<resource_id>` | `<api_path>/<url_part>` — no id; it travels in the body |
+| validation | `make_partial_model(model)` | the **full** model |
+| serialisation | `exclude_none=False` | `exclude_none=True` |
+| permission check | `raise_when_operation_not_allowed(name, "update")` | `…(name, "create")` |
+
+**The validation difference is the one that matters.** `add_update()` relaxes required
+fields because a PATCH carrying two attributes has no reason to supply a `classId`. Doing
+the same for create would let an object without its required fields reach Google. Create
+therefore validates against the unrelaxed model — `add_create()` is stricter than its
+neighbour even though both take dicts.
+
+**Two registry facts to honour**, both already handled by `_prepare_create()`:
+
+- `Issuer` registers `pass_resource_id_on_create=False`: its id must be stripped from the
+  body on create. `validate_data_and_convert_to_json(..., skip_resource_id=True)` does
+  this, and it *raises* if the field is set — so the caller passing an id for such a model
+  gets a `ValueError`, like every other bad payload. `BatchResult.resource_id` is then the
+  empty string, because there is no id to report yet.
+- `can_create=False` exists in the registry, so the permission check is not decorative.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_batch.py`:
+
+```python
+@respx.mock
+def test_add_create_posts_to_the_collection_path(mock_session):
+    """Create is a POST to the type's collection, with no id in the path."""
+    route = _mock_batch_endpoint()
+
+    batch = Batch()
+    batch.add_create(
+        "GenericObject",
+        {"id": "issuer.new-one", "classId": "issuer.class", "state": "ACTIVE"},
+    )
+    batch.execute()
+
+    body = route.calls.last.request.content.decode("utf-8")
+    assert "POST /walletobjects/v1/genericObject" in body
+    # the id belongs in the payload, not the path
+    assert "POST /walletobjects/v1/genericObject/issuer.new-one" not in body
+    assert '"id":"issuer.new-one"' in body.replace(" ", "")
+
+
+def test_add_create_requires_the_models_required_fields():
+    """Unlike add_update, create does not relax required fields."""
+    batch = Batch()
+
+    with pytest.raises(ValueError) as exc_info:
+        batch.add_create("GenericObject", {"id": "issuer.new-one"})
+
+    assert "classId" in str(exc_info.value)
+
+
+@respx.mock
+def test_a_batch_may_mix_creates_and_updates(mock_session):
+    """Method is per sub-request, so both fit in one batch."""
+    route = _mock_batch_endpoint()
+
+    batch = Batch()
+    batch.add_create(
+        "GenericObject",
+        {"id": "issuer.new-one", "classId": "issuer.class", "state": "ACTIVE"},
+    )
+    batch.add_update("GenericObject", {"id": "issuer.old-one", "state": "EXPIRED"})
+    batch.execute()
+
+    body = route.calls.last.request.content.decode("utf-8")
+    assert "POST /walletobjects/v1/genericObject" in body
+    assert "PATCH /walletobjects/v1/genericObject/issuer.old-one" in body
+
+
+def test_add_creates_appends_a_whole_list():
+    """The bulk case must not need one call per object."""
+    batch = Batch()
+    batch.add_creates(
+        "GenericObject",
+        [
+            {"id": f"issuer.{n}", "classId": "issuer.class", "state": "ACTIVE"}
+            for n in range(5)
+        ],
+    )
+
+    assert len(batch) == 5
+
+
+@respx.mock
+def test_an_already_existing_object_comes_back_as_a_result(mock_session):
+    """409 is the common create failure and must not raise."""
+    conflict = (
+        "--rspboundary\r\n"
+        "Content-Type: application/http\r\n"
+        "Content-ID: <response-item-0>\r\n"
+        "\r\n"
+        "HTTP/1.1 409 Conflict\r\n"
+        "Content-Type: application/json\r\n"
+        "\r\n"
+        '{"error": {"code": 409, "message": "already exists", '
+        '"status": "ALREADY_EXISTS"}}\r\n'
+        "\r\n"
+        "--rspboundary--\r\n"
+    )
+    respx.post(str(Settings().batch_url)).mock(
+        return_value=httpx.Response(
+            200,
+            content=conflict.encode("utf-8"),
+            headers={"Content-Type": "multipart/mixed; boundary=rspboundary"},
+        )
+    )
+
+    batch = Batch()
+    batch.add_create(
+        "GenericObject",
+        {"id": "issuer.new-one", "classId": "issuer.class", "state": "ACTIVE"},
+    )
+    results = batch.execute()
+
+    assert results[0].ok is False
+    assert results[0].error is not None
+    assert results[0].error.code == 409
+```
+
+- [ ] **Step 2: Run them and watch them fail**
+
+Run: `uv run pytest tests/test_batch.py -k "create" -v`
+Expected: FAIL — `AttributeError: 'Batch' object has no attribute 'add_create'`
+
+- [ ] **Step 3: Implement**
+
+The two `add_*` methods share everything except method, path, validation and
+serialisation, so factor the common tail (build the `SubRequest`, append to
+`_sub_requests` and `_items`) rather than copying it — this is logic, not the
+sync/async boilerplate the codebase tolerates elsewhere.
+
+`add_create()` must:
+
+1. `metadata = lookup_metadata_by_name(name)`; `raise_when_operation_not_allowed(name, "create")`.
+2. Validate against `metadata["model"]` — **not** `make_partial_model(...)` — and serialise
+   with `exclude_none=True, by_alias=True`, mirroring `_prepare_create()`. Reuse
+   `validate_data_and_convert_to_json(model, data, skip_resource_id=..., resource_id_key=...)`
+   with `skip_resource_id = not metadata["pass_resource_id_on_create"]`; it returns
+   `(resource_id, json)` and already raises `ValueError` when an id is set on a model that
+   must not carry one.
+3. Wrap any `PydanticValidationError` into `ValueError`, so a bad create payload fails the
+   same way a bad update payload does.
+4. Build `SubRequest(method="POST", path=f"{api_path}/{metadata['url_part']}", body=…,
+   content_id=f"item-{len(self._sub_requests)}")`.
+5. Record `(name, resource_id or "")` in `_items`.
+
+`add_creates(name, data)` loops over `add_create`, exactly as `add_updates` does.
+
+- [ ] **Step 4: Run them and watch them pass**
+
+Run: `uv run pytest tests/test_batch.py -v`
+
+- [ ] **Step 5: Full suite and lint**
+
+Run: `uvx tox -e py313` then `uvx tox -e lint`
+
+- [ ] **Step 6: Document it**
+
+`docs/tutorials.md`: a short block showing `add_create` and a mixed create/update batch,
+and stating that create requires the full object while update does not. `docs/reference.md`:
+add both methods beside the update ones.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/edutap/wallet_google/batch.py tests/test_batch.py docs/
+git commit -m "feat(batch): add add_create() for creating objects in a batch"
+```
+
 ## Verification
 
 - [ ] `uvx tox -e py313` green.
@@ -1334,8 +1531,8 @@ Each of these is a plausible next stage, and none belongs in this one:
   today's meaning of one request, a set value splits transparently — so nothing in this
   plan has to be undone to get there. This is where a daily reconciliation over tens of thousands of objects
   actually gets decided, and it wants its own design once the measured ceiling is known.
-- **`add_create()` and other operations.** `SubRequest` already carries the method, and
-  `Batch` already mixes types, so adding create is a method on the existing class.
+- ~~**`add_create()` and other operations.**~~ Done in Task 6 (2026-08-18). Other
+  operations (delete, message) remain out of scope; Google Wallet has no delete.
 - **Parsing results into models.** `BatchResult.body` stays a dict; adding a parsed model
   later does not break the signature.
 - **Delta detection.** Writing only genuinely changed objects would cut the daily volume

--- a/superpowers/plans/2026-08-17-batch-update.md
+++ b/superpowers/plans/2026-08-17-batch-update.md
@@ -287,9 +287,13 @@ Expected: PASS
 
 - [ ] **Step 5: Write the failing decoder tests**
 
-Append to `tests/test_multipart.py`:
+Append to `tests/test_multipart.py` — but put the new import in the **top-of-file import
+block** beside the existing ones, not here. Ruff's `E402` is active in this project
+(`select = ["E", "F", "W", "I", "UP"]`, only `E501` ignored), so a mid-file import fails
+`tox -e lint`.
 
 ```python
+# this import belongs at the top of the file, with the others
 from edutap.wallet_google.multipart import decode_multipart
 
 
@@ -327,6 +331,9 @@ def test_decode_returns_one_sub_response_per_part():
     assert responses[0].status_code == 200
     assert responses[0].body == {"id": "issuer.one", "state": "EXPIRED"}
     assert responses[1].status_code == 404
+    # `body` is typed `dict | None`; the project's ty hook raises
+    # not-subscriptable without this narrowing.
+    assert responses[1].body is not None
     assert responses[1].body["error"]["code"] == 404
 
 
@@ -358,8 +365,15 @@ def _parse_http_payload(payload: str) -> tuple[int, dict | None]:
     """
     head, _, body = payload.partition(f"{_CRLF}{_CRLF}")
     status_line = head.split(_CRLF, 1)[0]
-    # "HTTP/1.1 404 Not Found" -> 404
-    status_code = int(status_line.split(" ")[1])
+    try:
+        # "HTTP/1.1 404 Not Found" -> 404
+        status_code = int(status_line.split(" ")[1])
+    except (IndexError, ValueError):
+        # A single malformed part must not crash the whole batch decode: 0 is
+        # never a real HTTP status, and callers already treat any non-2xx
+        # status as not-ok, so this degrades gracefully into the existing
+        # error path.
+        status_code = 0
     body = body.strip()
     if not body:
         return status_code, None
@@ -405,7 +419,16 @@ def decode_multipart(content: bytes, content_type: str) -> list[SubResponse]:
 - [ ] **Step 8: Run the whole file**
 
 Run: `uv run pytest tests/test_multipart.py -v`
-Expected: PASS, 3 tests
+Expected: PASS, 4 tests
+
+The fourth is `test_decode_returns_status_code_zero_for_malformed_status_line`, added
+during review: a part whose status line cannot be parsed must come back as a
+`SubResponse` with `status_code=0` rather than raising out of `decode_multipart`. It
+exists because the `try`/`except` above was missing from the first draft of this plan,
+and one malformed part would have destroyed every other result in the same response —
+against this feature's core commitment that partial failures come back as results. Note
+for anyone naming tests here: `codespell` runs in `tox -e lint` and rejects
+"unparseable".
 
 - [ ] **Step 9: Lint and commit**
 

--- a/superpowers/plans/2026-08-17-batch-update.md
+++ b/superpowers/plans/2026-08-17-batch-update.md
@@ -1152,7 +1152,7 @@ Pass types may be mixed in one batch — each sub-request carries its own path:
 ```python
 batch = api.Batch()
 batch.add_update("LoyaltyObject", {"id": "issuer.member-1", "state": "EXPIRED"})
-batch.add_update("EventTicketObject", {"id": "issuer.ticket-9", "state": "USED"})
+batch.add_update("EventTicketObject", {"id": "issuer.ticket-9", "state": "COMPLETED"})
 ```
 
 For the bulk case, add a whole list at once and use `len(batch)` to decide how much goes

--- a/superpowers/plans/2026-08-17-batch-update.md
+++ b/superpowers/plans/2026-08-17-batch-update.md
@@ -1,0 +1,1056 @@
+# Batch Update Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `batch_update(name, data)` and `abatch_update(name, data)` — one
+`multipart/mixed` request that PATCHes many wallet objects of any pass type in a single
+API call.
+
+**Architecture:** Three pieces, no more. A pure encoder/decoder for `multipart/mixed`
+that knows nothing about wallet models; two API functions that turn a list of plain dicts
+into sub-requests and return one result per input item in input order; and a new settings
+entry for the batch endpoint. No chunking, no throttling, no retry, no resume — those are
+a later stage and deliberately out of scope.
+
+**Tech Stack:** Python 3.12+, Pydantic v2, httpx, authlib, pytest, respx, the `email`
+module from the standard library for multipart parsing.
+
+**Spec:** None as a separate file. The design rationale lives in the *Design decisions*
+section below; it was settled in conversation on 2026-08-17 and the reasoning is short
+enough to travel with the plan.
+
+## Global Constraints
+
+- Branch: `feature/batch-update`, already created from `main`. Never commit to `main`.
+  Never `git push` — the user pushes.
+- Conventional Commits. Commit messages, comments, identifiers and docstrings in English.
+- No new runtime dependencies. `email` and `uuid` are standard library; everything else is
+  already required.
+- Public functions carry full type hints. The package ships `py.typed`.
+- Sync and async are both public and behave identically; async functions carry the `a`
+  prefix, matching every other function in `api.py`.
+- Rate limit for context: the Google Wallet API allows **20 calls per second**
+  ([FAQ](https://developers.google.com/wallet/generic/resources/faq)). Nothing in this
+  plan enforces it — the caller does.
+- Every task ends green on `uvx tox -e py313` and `uvx tox -e lint`.
+
+## What is known, and how well
+
+This matters because two of the numbers driving this design are not in Google's
+documentation, and the code should not pretend otherwise.
+
+- **Documented:** the batch endpoint is `POST https://walletobjects.googleapis.com/batch`
+  with a `multipart/mixed` body; the resource path inside each part is
+  `/walletobjects/v1/<url_part>`; the mechanism is identical across generic passes,
+  loyalty cards and event tickets (checked on all three pages). Rate limit 20 calls/s.
+- **Not documented anywhere:** the maximum number of sub-requests per batch, and whether
+  a batch counts as one call or as N against the rate limit. Searched for both; the
+  Wallet pages and the FAQ are silent.
+- **Supplied by the maintainer, 2026-08-17:** a batch counts as **one** request regardless
+  of how many sub-requests it carries. This is why batching is worth building at all — it
+  turns 70,000 daily updates from roughly an hour of wall-clock into minutes. Record it in
+  code comments as what it is: an operational finding, not a documented guarantee. Do not
+  cite a Google URL for it, because there isn't one.
+
+Consequence for the code: **no sub-request count is hard-coded anywhere.** The functions
+take whatever list they are given. If a ceiling exists, it will surface as an HTTP error
+from Google, and the caller decides what to do about it.
+
+## Design decisions
+
+**`batch_update` takes a `name` plus plain dicts, not model instances.** `update()` today
+derives the type from the instance via `lookup_metadata_by_model_instance()`, which is why
+it needs a real model. `read()` and `listing()` take `name` explicitly instead. Batch
+follows `read()`: the caller passes `"LoyaltyObject"` and a list of dicts. This removes
+the required-field problem entirely — a PATCH carrying two changed attributes does not
+need a `classId` just to satisfy the constructor.
+
+**Payloads are validated against a partial model.** `make_partial_model()` already exists
+(built for partial responses) and turns required fields optional while staying a subclass.
+Validating each dict through it catches typos and type errors *before* the network call,
+without demanding fields the caller has no reason to send. Serialisation then reuses the
+existing path, which already sets `exclude_unset=True` — so only the attributes the caller
+actually set go on the wire.
+
+**All pass types come for free.** Every registered model already carries a `url_part`
+(`genericObject`, `loyaltyObject`, `eventTicketObject`, …). The sub-request path is a
+registry lookup, so nothing is generic-pass-specific.
+
+**Results never raise on partial failure.** A batch is not atomic. `batch_update` returns
+one `BatchResult` per input item, in input order. Exceptions are reserved for the batch
+request itself failing.
+
+**Results carry raw dicts, not parsed models.** Parsing 1000 responses into full models
+costs time for information the caller of a bulk update rarely wants. `BatchResult.body`
+is the decoded JSON. Parsing can be added later without breaking the signature.
+
+## File Structure
+
+| File | Responsibility | Task |
+| --- | --- | --- |
+| `src/edutap/wallet_google/batch.py` | encode/decode `multipart/mixed`; knows nothing about wallet models (create) | 1 |
+| `tests/test_batch_multipart.py` | encoder/decoder tests, no network (create) | 1 |
+| `src/edutap/wallet_google/models/misc.py` | `BatchResult`, `BatchError` (modify) | 2 |
+| `src/edutap/wallet_google/settings.py` | `batch_url` setting (modify) | 2 |
+| `src/edutap/wallet_google/api.py` | `batch_update`, `abatch_update` (modify) | 2, 3 |
+| `tests/test_api_batch.py` | `batch_update` against respx (create) | 2 |
+| `tests/test_api_batch_async.py` | `abatch_update` against respx (create) | 3 |
+| `docs/tutorials.md`, `docs/reference.md` | document the new functions (modify) | 4 |
+
+---
+
+### Task 1: The multipart encoder and decoder
+
+Pure functions over bytes. No httpx, no models, no settings. This is the only part of the
+feature with fiddly format details, and it is fully testable without a network.
+
+**Files:**
+- Create: `src/edutap/wallet_google/batch.py`
+- Create: `tests/test_batch_multipart.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `BatchSubRequest` — dataclass with `method: str`, `path: str`, `body: str | None`,
+    `content_id: str`.
+  - `BatchSubResponse` — dataclass with `content_id: str | None`, `status_code: int`,
+    `body: dict | None`.
+  - `encode_batch_request(sub_requests: list[BatchSubRequest], boundary: str) -> bytes`
+  - `decode_batch_response(content: bytes, content_type: str) -> list[BatchSubResponse]`
+  - `make_boundary() -> str`
+
+**Format note, read before implementing.** Google's Wallet examples show each part with
+`Content-Type: application/json` followed by the request line. Google's general batch
+protocol uses `Content-Type: application/http` for the parts. The Wallet pages are what we
+have, so encode as they show, and keep the part content type in the module-level constant
+`_PART_CONTENT_TYPE` so switching it is a one-line change. Task 5's integration test is
+what settles which one the server actually accepts.
+
+- [ ] **Step 1: Write the failing encoder test**
+
+```python
+"""Tests for multipart/mixed encoding and decoding of batch requests."""
+
+from edutap.wallet_google.batch import BatchSubRequest
+from edutap.wallet_google.batch import encode_batch_request
+
+
+def test_encode_produces_one_part_per_sub_request():
+    """Each sub-request becomes a delimited part carrying method, path and body."""
+    sub_requests = [
+        BatchSubRequest(
+            method="PATCH",
+            path="/walletobjects/v1/genericObject/issuer.one",
+            body='{"state":"EXPIRED"}',
+            content_id="item-0",
+        ),
+        BatchSubRequest(
+            method="PATCH",
+            path="/walletobjects/v1/genericObject/issuer.two",
+            body='{"state":"ACTIVE"}',
+            content_id="item-1",
+        ),
+    ]
+
+    encoded = encode_batch_request(sub_requests, boundary="testboundary").decode("utf-8")
+
+    assert encoded.count("--testboundary\r\n") == 2
+    assert encoded.endswith("--testboundary--\r\n")
+    assert "Content-ID: <item-0>" in encoded
+    assert "Content-ID: <item-1>" in encoded
+    assert "PATCH /walletobjects/v1/genericObject/issuer.one" in encoded
+    assert '{"state":"EXPIRED"}' in encoded
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `uv run pytest tests/test_batch_multipart.py::test_encode_produces_one_part_per_sub_request -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'edutap.wallet_google.batch'`
+
+- [ ] **Step 3: Write the encoder**
+
+Create `src/edutap/wallet_google/batch.py`:
+
+```python
+"""Encoding and decoding of ``multipart/mixed`` batch requests.
+
+This module deliberately knows nothing about wallet models, settings or HTTP
+clients. It turns sub-requests into bytes and bytes back into sub-responses,
+which makes the fiddly format details testable without a network.
+
+See https://developers.google.com/wallet/generic/resources/performance-tips
+"""
+
+from dataclasses import dataclass
+
+import json
+import uuid
+
+
+# Google's Wallet examples show the parts as application/json. Google's general
+# batch protocol uses application/http. The Wallet documentation is what we have,
+# so follow it — and keep it in one place so it is a one-line change if the
+# server turns out to want the other one.
+_PART_CONTENT_TYPE = "application/json"
+
+# multipart requires CRLF line endings (RFC 2046).
+_CRLF = "\r\n"
+
+
+@dataclass
+class BatchSubRequest:
+    """A single HTTP request to be carried inside a batch."""
+
+    method: str
+    path: str
+    body: str | None
+    content_id: str
+
+
+@dataclass
+class BatchSubResponse:
+    """A single HTTP response extracted from a batch response."""
+
+    content_id: str | None
+    status_code: int
+    body: dict | None
+
+
+def make_boundary() -> str:
+    """Return a boundary that cannot collide with the payload."""
+    return f"batch_{uuid.uuid4().hex}"
+
+
+def encode_batch_request(
+    sub_requests: list[BatchSubRequest],
+    boundary: str,
+) -> bytes:
+    """Encode sub-requests as a ``multipart/mixed`` body.
+
+    :param sub_requests: The requests to carry, in order.
+    :param boundary:     Delimiter between the parts, without leading dashes.
+    :return:             The encoded body, ready to be sent as the request content.
+    """
+    lines: list[str] = []
+    for sub_request in sub_requests:
+        lines.append(f"--{boundary}")
+        lines.append(f"Content-Type: {_PART_CONTENT_TYPE}")
+        lines.append(f"Content-ID: <{sub_request.content_id}>")
+        lines.append("")
+        lines.append(f"{sub_request.method} {sub_request.path}")
+        if sub_request.body is not None:
+            lines.append("")
+            lines.append(sub_request.body)
+        lines.append("")
+    lines.append(f"--{boundary}--")
+    lines.append("")
+    return _CRLF.join(lines).encode("utf-8")
+```
+
+- [ ] **Step 4: Run it and watch it pass**
+
+Run: `uv run pytest tests/test_batch_multipart.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Write the failing decoder test**
+
+Append to `tests/test_batch_multipart.py`:
+
+```python
+from edutap.wallet_google.batch import decode_batch_response
+
+
+BATCH_RESPONSE = (
+    "--rspboundary\r\n"
+    "Content-Type: application/http\r\n"
+    "Content-ID: <response-item-0>\r\n"
+    "\r\n"
+    "HTTP/1.1 200 OK\r\n"
+    "Content-Type: application/json\r\n"
+    "\r\n"
+    '{"id": "issuer.one", "state": "EXPIRED"}\r\n'
+    "\r\n"
+    "--rspboundary\r\n"
+    "Content-Type: application/http\r\n"
+    "Content-ID: <response-item-1>\r\n"
+    "\r\n"
+    "HTTP/1.1 404 Not Found\r\n"
+    "Content-Type: application/json\r\n"
+    "\r\n"
+    '{"error": {"code": 404, "message": "not found", "status": "NOT_FOUND"}}\r\n'
+    "\r\n"
+    "--rspboundary--\r\n"
+)
+
+
+def test_decode_returns_one_sub_response_per_part():
+    """Status code, body and Content-ID are recovered from each part."""
+    responses = decode_batch_response(
+        BATCH_RESPONSE.encode("utf-8"),
+        "multipart/mixed; boundary=rspboundary",
+    )
+
+    assert len(responses) == 2
+    assert responses[0].status_code == 200
+    assert responses[0].content_id == "item-0"
+    assert responses[0].body == {"id": "issuer.one", "state": "EXPIRED"}
+    assert responses[1].status_code == 404
+    assert responses[1].content_id == "item-1"
+    assert responses[1].body["error"]["code"] == 404
+
+
+def test_decode_strips_the_response_prefix_from_content_id():
+    """Google echoes Content-ID with a 'response-' prefix; we map back to ours."""
+    responses = decode_batch_response(
+        BATCH_RESPONSE.encode("utf-8"),
+        "multipart/mixed; boundary=rspboundary",
+    )
+
+    assert [r.content_id for r in responses] == ["item-0", "item-1"]
+```
+
+- [ ] **Step 6: Run them and watch them fail**
+
+Run: `uv run pytest tests/test_batch_multipart.py -v`
+Expected: FAIL — `ImportError: cannot import name 'decode_batch_response'`
+
+- [ ] **Step 7: Write the decoder**
+
+Append to `src/edutap/wallet_google/batch.py`:
+
+```python
+def _parse_http_payload(payload: str) -> tuple[int, dict | None]:
+    """Parse an embedded HTTP response into status code and JSON body.
+
+    :param payload: A raw HTTP response: status line, headers, blank line, body.
+    :return:        Tuple of status code and decoded body (None when not JSON).
+    """
+    head, _, body = payload.partition(f"{_CRLF}{_CRLF}")
+    status_line = head.split(_CRLF, 1)[0]
+    # "HTTP/1.1 404 Not Found" -> 404
+    status_code = int(status_line.split(" ")[1])
+    body = body.strip()
+    if not body:
+        return status_code, None
+    try:
+        return status_code, json.loads(body)
+    except json.JSONDecodeError:
+        return status_code, None
+
+
+def decode_batch_response(content: bytes, content_type: str) -> list[BatchSubResponse]:
+    """Decode a ``multipart/mixed`` batch response into its sub-responses.
+
+    Order is preserved, but callers should correlate via ``content_id`` rather
+    than position — the specification does not promise the server answers in the
+    order it was asked.
+
+    :param content:      The raw response body.
+    :param content_type: The response Content-Type header, carrying the boundary.
+    :return:             One entry per part, in the order they appear.
+    """
+    from email.parser import BytesParser
+    from email.policy import HTTP
+
+    message = BytesParser(policy=HTTP).parsebytes(
+        b"Content-Type: " + content_type.encode("utf-8") + b"\r\n\r\n" + content
+    )
+
+    sub_responses: list[BatchSubResponse] = []
+    for part in message.iter_parts():
+        raw_content_id = part.get("Content-ID")
+        content_id = None
+        if raw_content_id:
+            # Google echoes "<response-item-0>" for our "<item-0>".
+            content_id = raw_content_id.strip("<>").removeprefix("response-")
+        status_code, body = _parse_http_payload(part.get_payload())
+        sub_responses.append(
+            BatchSubResponse(
+                content_id=content_id,
+                status_code=status_code,
+                body=body,
+            )
+        )
+    return sub_responses
+```
+
+Move the two `email` imports to the top of the module with the other imports before
+committing — they are inline here only to keep the diff readable.
+
+- [ ] **Step 8: Run the whole file**
+
+Run: `uv run pytest tests/test_batch_multipart.py -v`
+Expected: PASS, 3 tests
+
+- [ ] **Step 9: Lint and commit**
+
+```bash
+uvx ruff format src/edutap/wallet_google/batch.py tests/test_batch_multipart.py
+uvx ruff check src/edutap/wallet_google/batch.py tests/test_batch_multipart.py
+git add src/edutap/wallet_google/batch.py tests/test_batch_multipart.py
+git commit -m "feat(batch): add multipart/mixed encoder and decoder"
+```
+
+---
+
+### Task 2: `batch_update()` — the synchronous API function
+
+**Files:**
+- Modify: `src/edutap/wallet_google/settings.py`
+- Modify: `src/edutap/wallet_google/models/misc.py`
+- Modify: `src/edutap/wallet_google/api.py`
+- Create: `tests/test_api_batch.py`
+
+**Interfaces:**
+- Consumes: `BatchSubRequest`, `BatchSubResponse`, `encode_batch_request`,
+  `decode_batch_response`, `make_boundary` from Task 1.
+- Produces:
+  - `BatchError` — Pydantic model with `code: int`, `message: str`, `status: str | None`.
+  - `BatchResult` — Pydantic model with `index: int`, `resource_id: str`,
+    `status_code: int`, `body: dict | None`, `error: BatchError | None`, and a
+    property `ok: bool`.
+  - `batch_update(name: str, data: list[dict], *, credentials: dict | None = None) -> list[BatchResult]`
+  - `settings.batch_url`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_api_batch.py`:
+
+```python
+"""Tests for batch_update()."""
+
+from edutap.wallet_google.api import batch_update
+from edutap.wallet_google.settings import Settings
+
+import httpx
+import pytest
+import respx
+
+
+BATCH_RESPONSE = (
+    "--rspboundary\r\n"
+    "Content-Type: application/http\r\n"
+    "Content-ID: <response-item-0>\r\n"
+    "\r\n"
+    "HTTP/1.1 200 OK\r\n"
+    "Content-Type: application/json\r\n"
+    "\r\n"
+    '{"id": "issuer.one", "state": "EXPIRED"}\r\n'
+    "\r\n"
+    "--rspboundary\r\n"
+    "Content-Type: application/http\r\n"
+    "Content-ID: <response-item-1>\r\n"
+    "\r\n"
+    "HTTP/1.1 404 Not Found\r\n"
+    "Content-Type: application/json\r\n"
+    "\r\n"
+    '{"error": {"code": 404, "message": "not found", "status": "NOT_FOUND"}}\r\n'
+    "\r\n"
+    "--rspboundary--\r\n"
+)
+
+
+@respx.mock
+def test_batch_update_sends_one_request_and_returns_one_result_per_item(mock_session):
+    """Two updates go out as a single POST and come back as two results."""
+    route = respx.post(str(Settings().batch_url)).mock(
+        return_value=httpx.Response(
+            200,
+            content=BATCH_RESPONSE.encode("utf-8"),
+            headers={"Content-Type": "multipart/mixed; boundary=rspboundary"},
+        )
+    )
+
+    results = batch_update(
+        "GenericObject",
+        [
+            {"id": "issuer.one", "state": "EXPIRED"},
+            {"id": "issuer.two", "state": "ACTIVE"},
+        ],
+    )
+
+    assert route.call_count == 1
+    assert len(results) == 2
+    assert results[0].ok is True
+    assert results[0].resource_id == "issuer.one"
+    assert results[0].body["state"] == "EXPIRED"
+    assert results[1].ok is False
+    assert results[1].error.code == 404
+    assert results[1].error.message == "not found"
+
+
+@respx.mock
+def test_batch_update_sends_only_the_attributes_that_were_set(mock_session):
+    """A two-attribute PATCH must not carry the rest of the model."""
+    route = respx.post(str(Settings().batch_url)).mock(
+        return_value=httpx.Response(
+            200,
+            content=BATCH_RESPONSE.encode("utf-8"),
+            headers={"Content-Type": "multipart/mixed; boundary=rspboundary"},
+        )
+    )
+
+    batch_update("GenericObject", [{"id": "issuer.one", "state": "EXPIRED"}])
+
+    body = route.calls.last.request.content.decode("utf-8")
+    assert '"state"' in body
+    assert '"classId"' not in body
+    assert "PATCH /walletobjects/v1/genericObject/issuer.one" in body
+
+
+def test_batch_update_rejects_an_unknown_attribute(mock_session):
+    """Typos are caught before the network call, not by Google."""
+    with pytest.raises(ValueError) as exc_info:
+        batch_update("GenericObject", [{"id": "issuer.one", "notAField": 1}])
+
+    assert "notAField" in str(exc_info.value)
+
+
+def test_batch_update_requires_the_resource_id(mock_session):
+    """Without an id there is nothing to PATCH."""
+    with pytest.raises(ValueError) as exc_info:
+        batch_update("GenericObject", [{"state": "EXPIRED"}])
+
+    assert "id" in str(exc_info.value)
+```
+
+- [ ] **Step 2: Run and watch it fail**
+
+Run: `uv run pytest tests/test_api_batch.py -v`
+Expected: FAIL — `ImportError: cannot import name 'batch_update'`
+
+- [ ] **Step 3: Add the settings entry**
+
+In `src/edutap/wallet_google/settings.py`, beside `API_URL`:
+
+```python
+BATCH_URL = "https://walletobjects.googleapis.com/batch"
+```
+
+and in the `Settings` class, beside `api_url`:
+
+```python
+    batch_url: AnyHttpUrl = AnyHttpUrl(BATCH_URL)
+```
+
+Note it is *not* derived from `api_url`: the batch endpoint sits one level above
+`/walletobjects/v1`, so appending would produce the wrong URL.
+
+- [ ] **Step 4: Add the result models**
+
+Append to `src/edutap/wallet_google/models/misc.py`:
+
+```python
+class BatchError(Model):
+    """The error Google reports for a single failed sub-request."""
+
+    code: int
+    message: str
+    status: str | None = None
+
+
+class BatchResult(Model):
+    """The outcome of one sub-request, correlated back to its input item."""
+
+    index: int
+    resource_id: str
+    status_code: int
+    body: dict | None = None
+    error: BatchError | None = None
+
+    @property
+    def ok(self) -> bool:
+        """True when Google accepted this sub-request."""
+        return self.error is None and 200 <= self.status_code < 300
+```
+
+- [ ] **Step 5: Implement `batch_update`**
+
+Add to `src/edutap/wallet_google/api.py`, and add `"batch_update"` and `"abatch_update"`
+to `__all__`:
+
+```python
+def _prepare_batch_update(
+    name: str,
+    data: list[dict[str, typing.Any]],
+) -> tuple[list[BatchSubRequest], list[str]]:
+    """Turn dicts into batch sub-requests.
+
+    Payloads are validated against a partial model: field names and types are
+    checked, but required fields are not demanded — a PATCH carrying two changed
+    attributes has no reason to supply a classId.
+
+    :param name: Registered model name, e.g. "GenericObject" or "LoyaltyObject".
+    :param data: One dict per object, each carrying at least the resource id.
+    :return:     Tuple of sub-requests and their resource ids, in input order.
+    :raises ValueError: When a payload is invalid or carries no resource id.
+    """
+    metadata = lookup_metadata_by_name(name)
+    raise_when_operation_not_allowed(name, "update")
+    partial_model = make_partial_model(metadata["model"])
+    resource_id_key = metadata["resource_id"]
+    api_path = urllib.parse.urlparse(str(client_pool.settings.api_url)).path
+
+    sub_requests: list[BatchSubRequest] = []
+    resource_ids: list[str] = []
+    for index, item in enumerate(data):
+        resource_id = item.get(resource_id_key)
+        if not resource_id:
+            raise ValueError(
+                f"Item {index} has no '{resource_id_key}'; there is nothing to update."
+            )
+        try:
+            verified = partial_model.model_validate(item)
+        except PydanticValidationError as exc:
+            raise ValueError(f"Item {index} is not valid for '{name}': {exc}") from exc
+        body = verified.model_dump_json(exclude_unset=True, by_alias=True)
+        sub_requests.append(
+            BatchSubRequest(
+                method="PATCH",
+                path=f"{api_path}/{metadata['url_part']}/{resource_id}",
+                body=body,
+                content_id=f"item-{index}",
+            )
+        )
+        resource_ids.append(resource_id)
+    return sub_requests, resource_ids
+
+
+def _build_batch_results(
+    sub_responses: list[BatchSubResponse],
+    resource_ids: list[str],
+) -> list[BatchResult]:
+    """Correlate sub-responses back to their input items.
+
+    Correlation is by Content-ID, not by position: the batch specification does
+    not promise the server answers in the order it was asked.
+    """
+    by_content_id = {r.content_id: r for r in sub_responses if r.content_id}
+    results: list[BatchResult] = []
+    for index, resource_id in enumerate(resource_ids):
+        sub_response = by_content_id.get(f"item-{index}")
+        if sub_response is None:
+            # No part came back for this item at all.
+            results.append(
+                BatchResult(
+                    index=index,
+                    resource_id=resource_id,
+                    status_code=0,
+                    error=BatchError(
+                        code=0, message="No response part for this sub-request."
+                    ),
+                )
+            )
+            continue
+        body = sub_response.body
+        error = None
+        if body is not None and "error" in body:
+            error = BatchError.model_validate(body["error"])
+            body = None
+        results.append(
+            BatchResult(
+                index=index,
+                resource_id=resource_id,
+                status_code=sub_response.status_code,
+                body=body,
+                error=error,
+            )
+        )
+    return results
+
+
+def batch_update(
+    name: str,
+    data: list[dict[str, typing.Any]],
+    *,
+    credentials: dict | None = None,
+) -> list[BatchResult]:
+    """Update many wallet objects of one type in a single API call.
+
+    Sends one ``multipart/mixed`` request carrying a PATCH per item. Works for
+    every registered pass type — the path comes from the registry, so
+    "GenericObject", "LoyaltyObject", "EventTicketObject" and the rest behave
+    identically.
+
+    Only the attributes present in each dict are sent, so a batch of small
+    changes stays small on the wire.
+
+    This function does not chunk, throttle or retry. The Google Wallet API is
+    rate limited to 20 calls per second; staying within it is the caller's
+    business.
+
+    :param name:        Registered model name, e.g. "LoyaltyObject".
+    :param data:        One dict per object, each carrying at least the resource id.
+    :param credentials: Optional session credentials as dict.
+    :raises ValueError: When a payload is invalid or carries no resource id.
+    :raises WalletException: When the batch request itself fails. Individual
+                        sub-request failures do **not** raise — they come back
+                        as results with an ``error``.
+    :return:            One result per input item, in input order.
+    """
+    if not data:
+        return []
+    sub_requests, resource_ids = _prepare_batch_update(name, data)
+    boundary = make_boundary()
+
+    client = client_pool.client(credentials=credentials)
+    response = client.post(
+        url=str(client_pool.settings.batch_url),
+        content=encode_batch_request(sub_requests, boundary),
+        headers={"Content-Type": f"multipart/mixed; boundary={boundary}"},
+    )
+    handle_response_errors(response, "batch_update", name, f"{len(data)} items")
+
+    sub_responses = decode_batch_response(
+        response.content, response.headers.get("Content-Type", "")
+    )
+    return _build_batch_results(sub_responses, resource_ids)
+```
+
+Add these imports at the top of `api.py`:
+
+```python
+from .batch import BatchSubRequest
+from .batch import BatchSubResponse
+from .batch import decode_batch_response
+from .batch import encode_batch_request
+from .batch import make_boundary
+from .models.misc import BatchError
+from .models.misc import BatchResult
+from pydantic import ValidationError as PydanticValidationError
+
+import urllib.parse
+```
+
+- [ ] **Step 6: Run and watch it pass**
+
+Run: `uv run pytest tests/test_api_batch.py -v`
+Expected: PASS, 4 tests
+
+- [ ] **Step 7: Run the whole suite for regressions**
+
+Run: `uvx tox -e py313`
+Expected: PASS — `api.py` and `misc.py` both changed, so everything gets a look.
+
+- [ ] **Step 8: Lint and commit**
+
+```bash
+uvx ruff format src tests
+uvx ruff check src tests
+git add src/edutap/wallet_google/api.py src/edutap/wallet_google/models/misc.py src/edutap/wallet_google/settings.py tests/test_api_batch.py
+git commit -m "feat(batch): add batch_update() for all pass types"
+```
+
+---
+
+### Task 3: `abatch_update()` — the asynchronous twin
+
+**Files:**
+- Modify: `src/edutap/wallet_google/api.py`
+- Create: `tests/test_api_batch_async.py`
+
+**Interfaces:**
+- Consumes: `_prepare_batch_update`, `_build_batch_results`, `BatchResult` from Task 2.
+- Produces: `abatch_update(name: str, data: list[dict], *, credentials: dict | None = None) -> list[BatchResult]`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_api_batch_async.py` with the same `BATCH_RESPONSE` constant as
+`tests/test_api_batch.py` (repeat it — the two files are read independently), then:
+
+```python
+"""Tests for abatch_update()."""
+
+from edutap.wallet_google.api import abatch_update
+from edutap.wallet_google.settings import Settings
+
+import httpx
+import pytest
+import respx
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_abatch_update_matches_the_sync_behaviour(mock_async_session):
+    """One POST, one result per item, failures reported not raised."""
+    route = respx.post(str(Settings().batch_url)).mock(
+        return_value=httpx.Response(
+            200,
+            content=BATCH_RESPONSE.encode("utf-8"),
+            headers={"Content-Type": "multipart/mixed; boundary=rspboundary"},
+        )
+    )
+
+    results = await abatch_update(
+        "LoyaltyObject",
+        [
+            {"id": "issuer.one", "state": "EXPIRED"},
+            {"id": "issuer.two", "state": "ACTIVE"},
+        ],
+    )
+
+    assert route.call_count == 1
+    assert len(results) == 2
+    assert results[0].ok is True
+    assert results[1].ok is False
+    assert results[1].error.code == 404
+```
+
+The marker is `@pytest.mark.asyncio`, matching every async test in
+`tests/test_api_async.py`. The repository uses `pytest-asyncio`, not `anyio` — do not
+introduce a second convention here.
+
+- [ ] **Step 2: Run and watch it fail**
+
+Run: `uv run pytest tests/test_api_batch_async.py -v`
+Expected: FAIL — `ImportError: cannot import name 'abatch_update'`
+
+- [ ] **Step 3: Implement it**
+
+Add to `api.py`, in the asynchronous section beside the other `a`-prefixed functions:
+
+```python
+async def abatch_update(
+    name: str,
+    data: list[dict[str, typing.Any]],
+    *,
+    credentials: dict | None = None,
+) -> list[BatchResult]:
+    """Asynchronously update many wallet objects of one type in a single API call.
+
+    See :func:`batch_update` for the full description; behaviour is identical.
+
+    :param name:        Registered model name, e.g. "LoyaltyObject".
+    :param data:        One dict per object, each carrying at least the resource id.
+    :param credentials: Optional session credentials as dict.
+    :raises ValueError: When a payload is invalid or carries no resource id.
+    :raises WalletException: When the batch request itself fails.
+    :return:            One result per input item, in input order.
+    """
+    if not data:
+        return []
+    sub_requests, resource_ids = _prepare_batch_update(name, data)
+    boundary = make_boundary()
+
+    client = client_pool.async_client(credentials=credentials)
+    response = await client.post(
+        url=str(client_pool.settings.batch_url),
+        content=encode_batch_request(sub_requests, boundary),
+        headers={"Content-Type": f"multipart/mixed; boundary={boundary}"},
+    )
+    handle_response_errors(response, "batch_update", name, f"{len(data)} items")
+
+    sub_responses = decode_batch_response(
+        response.content, response.headers.get("Content-Type", "")
+    )
+    return _build_batch_results(sub_responses, resource_ids)
+```
+
+- [ ] **Step 4: Run and watch it pass**
+
+Run: `uv run pytest tests/test_api_batch_async.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+uvx ruff format src tests
+uvx ruff check src tests
+git add src/edutap/wallet_google/api.py tests/test_api_batch_async.py
+git commit -m "feat(batch): add abatch_update()"
+```
+
+---
+
+### Task 4: Prove it across every pass type, and document it
+
+The claim "works for all pass types" is currently an argument about the registry. This
+task turns it into a test, and writes the docs.
+
+**Files:**
+- Modify: `tests/test_api_batch.py`
+- Modify: `docs/tutorials.md`
+- Modify: `docs/reference.md`
+
+**Interfaces:**
+- Consumes: `batch_update` from Task 2.
+- Produces: no new code interfaces.
+
+- [ ] **Step 1: Write the parametrised failing test**
+
+Append to `tests/test_api_batch.py`:
+
+```python
+@pytest.mark.parametrize(
+    "name,url_part",
+    [
+        ("GenericObject", "genericObject"),
+        ("LoyaltyObject", "loyaltyObject"),
+        ("OfferObject", "offerObject"),
+        ("GiftCardObject", "giftCardObject"),
+        ("EventTicketObject", "eventTicketObject"),
+        ("TransitObject", "transitObject"),
+        ("FlightObject", "flightObject"),
+    ],
+)
+@respx.mock
+def test_batch_update_builds_the_right_path_for_every_pass_type(
+    mock_session, name, url_part
+):
+    """The sub-request path comes from the registry, so every type works."""
+    route = respx.post(str(Settings().batch_url)).mock(
+        return_value=httpx.Response(
+            200,
+            content=BATCH_RESPONSE.encode("utf-8"),
+            headers={"Content-Type": "multipart/mixed; boundary=rspboundary"},
+        )
+    )
+
+    batch_update(name, [{"id": "issuer.one", "state": "EXPIRED"}])
+
+    body = route.calls.last.request.content.decode("utf-8")
+    assert f"PATCH /walletobjects/v1/{url_part}/issuer.one" in body
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `uv run pytest tests/test_api_batch.py -k every_pass_type -v`
+Expected: PASS for all seven. If a type fails because `state` is not one of its fields,
+replace the payload for that type with an attribute it does have — do not weaken the
+assertion on the path.
+
+- [ ] **Step 3: Document it in the tutorial**
+
+Add a section to `docs/tutorials.md`, after the update section:
+
+````markdown
+## Updating many passes at once
+
+`batch_update()` sends one request carrying a PATCH per object. It works for every pass
+type, and only the attributes you set are sent:
+
+```python
+from edutap.wallet_google import api
+
+results = api.batch_update(
+    "LoyaltyObject",
+    [
+        {"id": "issuer.member-1", "state": "EXPIRED"},
+        {"id": "issuer.member-2", "state": "EXPIRED"},
+    ],
+)
+
+for result in results:
+    if not result.ok:
+        print(f"{result.resource_id} failed: {result.error.message}")
+```
+
+A batch is **not** atomic: individual items can fail while the rest succeed, which is why
+failures come back as results rather than exceptions. There is one result per input item,
+in input order.
+
+`batch_update()` does not split, throttle or retry. The Google Wallet API is rate limited
+to 20 calls per second; deciding how many objects go into one batch, and how fast batches
+follow each other, is yours.
+
+The asynchronous twin is `await api.abatch_update(...)` and behaves identically.
+````
+
+- [ ] **Step 4: Add the functions to the reference**
+
+Add `batch_update` and `abatch_update` to `docs/reference.md`, following whatever
+structure the surrounding entries use.
+
+- [ ] **Step 5: Check the Markdown renders**
+
+There is **no** documentation build in this repository — `docs/` holds plain Markdown and
+is built centrally for docs.edutap.eu. So there is no `tox -e docs` to run. Instead, read
+the two files back and check the fenced code blocks are balanced and the headings sit at
+the same level as their neighbours.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/test_api_batch.py docs/tutorials.md docs/reference.md
+git commit -m "docs(batch): document batch_update and cover all pass types"
+```
+
+---
+
+### Task 5: The integration test that settles the open format question
+
+Task 1 encodes the parts as `Content-Type: application/json` because that is what Google's
+Wallet examples show, while Google's general batch protocol uses `application/http`. Only
+the real endpoint can say which it accepts. This task is also the first measurement of how
+many sub-requests actually fit.
+
+**Files:**
+- Create: `tests/integration/test_batch.py`
+
+**Interfaces:**
+- Consumes: `batch_update` from Task 2.
+- Produces: no new code interfaces.
+
+- [ ] **Step 1: Read how the existing integration tests are set up**
+
+Read `tests/integration/test_CRULM.py`. Follow its credential handling, its
+`@pytest.mark.integration` marking and its issuer-id fixture exactly.
+
+- [ ] **Step 2: Write the round-trip test**
+
+Create `tests/integration/test_batch.py`. It must create two objects, batch-update one
+attribute on both, assert both results are `ok`, then read them back and assert the
+attribute actually changed. Reading back matters: a 200 in a batch part is not by itself
+proof the write landed.
+
+- [ ] **Step 3: Run it against the real API**
+
+Run: `uvx tox -e py313 -- tests/integration/test_batch.py -v --run-integration`
+
+If it fails with a 400 on the format, switch `_PART_CONTENT_TYPE` in `batch.py` to
+`"application/http"` and — because that content type means each part carries a full HTTP
+message — the request line then needs an HTTP version suffix (`PATCH <path> HTTP/1.1`) and
+its own `Content-Type: application/json` header before the body. Adjust the Task 1 tests
+to match, then re-run.
+
+- [ ] **Step 4: Measure the ceiling**
+
+Still in the integration environment, not as a committed test: run `batch_update` with
+growing item counts (50, 200, 500, 1000) and record where it starts failing, and with what
+error.
+
+- [ ] **Step 5: Write the measurement down**
+
+Add a short section to this plan file recording the numbers, dated, and labelled
+**measured** — what the endpoint did on the day we looked, not what Google guarantees.
+Anyone sizing a batch later needs to know which of those it is.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/integration/test_batch.py superpowers/plans/2026-08-17-batch-update.md
+git commit -m "test(batch): add integration round-trip and record measured limits"
+```
+
+---
+
+## Verification
+
+- [ ] `uvx tox -e py313` green.
+- [ ] `uvx tox -e lint` green.
+- [ ] Integration test green against the real API.
+- [ ] The measured sub-request ceiling is recorded in this file, labelled as measured.
+
+## Deliberately out of scope
+
+Each of these is a plausible next stage, and none belongs in this one:
+
+- **The driver** — chunking, throttling to 20 calls/s, retry, resume, progress reporting.
+  This is where a daily 70,000-object reconciliation actually gets decided, and it wants
+  its own design once the measured batch ceiling is known.
+- **`batch_create` and mixed-operation batches.** `BatchSubRequest` already carries the
+  method, so create is a small addition later; nothing here blocks it.
+- **Parsing results into models.** `BatchResult.body` stays a dict; adding a parsed model
+  later does not break the signature.
+- **Delta detection.** Writing only genuinely changed objects would cut the daily volume
+  far more than batching does, but it belongs in the calling system, not in this library.

--- a/superpowers/plans/2026-08-17-batch-update.md
+++ b/superpowers/plans/2026-08-17-batch-update.md
@@ -427,8 +427,9 @@ during review: a part whose status line cannot be parsed must come back as a
 exists because the `try`/`except` above was missing from the first draft of this plan,
 and one malformed part would have destroyed every other result in the same response —
 against this feature's core commitment that partial failures come back as results. Note
-for anyone naming tests here: `codespell` runs in `tox -e lint` and rejects
-"unparseable".
+for anyone naming tests here: `codespell` runs in `tox -e lint` and rejects the
+adjective formed from "un" + "parseable" — use "malformed" instead. (Spelling it out
+would fail this very file, as an earlier revision of this plan discovered.)
 
 - [ ] **Step 9: Lint and commit**
 

--- a/superpowers/plans/2026-08-17-batch-update.md
+++ b/superpowers/plans/2026-08-17-batch-update.md
@@ -88,6 +88,23 @@ path is a registry lookup.
 `BatchResult` per added sub-request, in the order they were added. Exceptions are reserved
 for the batch request itself failing.
 
+**Add order is the result order; wire order is an implementation detail.** `Batch` is free
+to group and sort its sub-requests internally before encoding — currently a stable group
+by pass type — and that freedom costs nothing, because results are correlated back by
+`Content-ID` rather than by position. The same correlation already had to exist for a
+different reason: the specification does not promise the server answers in the order it
+was asked. One mechanism, two problems solved.
+
+State the invariant plainly, because it is the thing that must not break as the internal
+ordering changes: **whatever `Batch` does to the order on the wire, `execute()` returns
+results in the order items were added.** Task 2 has a test that holds this down against a
+server answering in a deliberately shuffled order.
+
+Whether grouping actually makes Google faster is unmeasured and, honestly, unlikely to be
+dramatic — the reason to build it in now is that retrofitting reordering onto a design
+that had promised wire order would be a breaking change, while allowing it from the start
+costs three lines.
+
 **Results carry raw dicts, not parsed models.** Parsing 1000 responses into full models
 costs time for information a bulk update rarely wants. `BatchResult.body` is the decoded
 JSON. Parsing can be added later without breaking the signature.
@@ -566,6 +583,73 @@ def test_executing_an_empty_batch_makes_no_request():
     batch = Batch()
 
     assert batch.execute() == []
+
+
+@respx.mock
+def test_sub_requests_are_grouped_by_pass_type_on_the_wire(mock_session):
+    """Batch may reorder internally; interleaved types come out grouped."""
+    route = _mock_batch_endpoint()
+
+    batch = Batch()
+    batch.add_update("GenericObject", {"id": "issuer.g1", "state": "EXPIRED"})
+    batch.add_update("LoyaltyObject", {"id": "issuer.l1", "state": "EXPIRED"})
+    batch.add_update("GenericObject", {"id": "issuer.g2", "state": "EXPIRED"})
+    batch.execute()
+
+    body = route.calls.last.request.content.decode("utf-8")
+    positions = [
+        body.index("genericObject/issuer.g1"),
+        body.index("genericObject/issuer.g2"),
+        body.index("loyaltyObject/issuer.l1"),
+    ]
+    assert positions == sorted(positions), "the two genericObjects should be adjacent"
+
+
+@respx.mock
+def test_results_follow_add_order_even_when_the_server_shuffles(mock_session):
+    """The invariant: add order is result order, whatever happens in between.
+
+    The canned response deliberately returns item-1 before item-0, which is what
+    correlation by Content-ID is for.
+    """
+    shuffled = (
+        "--rspboundary\r\n"
+        "Content-Type: application/http\r\n"
+        "Content-ID: <response-item-1>\r\n"
+        "\r\n"
+        "HTTP/1.1 200 OK\r\n"
+        "Content-Type: application/json\r\n"
+        "\r\n"
+        '{"id": "issuer.two"}\r\n'
+        "\r\n"
+        "--rspboundary\r\n"
+        "Content-Type: application/http\r\n"
+        "Content-ID: <response-item-0>\r\n"
+        "\r\n"
+        "HTTP/1.1 200 OK\r\n"
+        "Content-Type: application/json\r\n"
+        "\r\n"
+        '{"id": "issuer.one"}\r\n'
+        "\r\n"
+        "--rspboundary--\r\n"
+    )
+    respx.post(str(Settings().batch_url)).mock(
+        return_value=httpx.Response(
+            200,
+            content=shuffled.encode("utf-8"),
+            headers={"Content-Type": "multipart/mixed; boundary=rspboundary"},
+        )
+    )
+
+    batch = Batch()
+    batch.add_update("GenericObject", {"id": "issuer.one", "state": "EXPIRED"})
+    batch.add_update("LoyaltyObject", {"id": "issuer.two", "state": "EXPIRED"})
+    results = batch.execute()
+
+    assert [r.resource_id for r in results] == ["issuer.one", "issuer.two"]
+    assert [r.index for r in results] == [0, 1]
+    assert results[0].body["id"] == "issuer.one"
+    assert results[1].body["id"] == "issuer.two"
 ```
 
 - [ ] **Step 2: Run and watch them fail**
@@ -723,6 +807,20 @@ class Batch:
         for item in data:
             self.add_update(name, item)
 
+    def _ordered_sub_requests(self) -> list[SubRequest]:
+        """Return the sub-requests in the order they should go on the wire.
+
+        Grouped by pass type. ``sorted`` is stable, so within a type the add
+        order survives. This is free to change: results are correlated by
+        Content-ID, not by position, so reordering here cannot affect what
+        :meth:`execute` returns.
+        """
+        order = sorted(
+            range(len(self._sub_requests)),
+            key=lambda index: self._items[index][0],
+        )
+        return [self._sub_requests[index] for index in order]
+
     def _build_results(self, sub_responses: list[SubResponse]) -> list[BatchResult]:
         """Correlate sub-responses back to the items that produced them.
 
@@ -770,6 +868,10 @@ class Batch:
         results carrying an ``error``. Only the batch request itself failing
         raises.
 
+        Sub-requests may be grouped and reordered on the wire. The results are
+        not: they come back in the order the items were added, correlated by
+        Content-ID.
+
         This does not chunk, throttle or retry. The Google Wallet API is rate
         limited to 20 calls per second; staying within it is the caller's
         business. Parameters are keyword-only so that a later driver stage can
@@ -786,7 +888,7 @@ class Batch:
         client = client_pool.client(credentials=credentials)
         response = client.post(
             url=str(client_pool.settings.batch_url),
-            content=encode_multipart(self._sub_requests, boundary),
+            content=encode_multipart(self._ordered_sub_requests(), boundary),
             headers={"Content-Type": f"multipart/mixed; boundary={boundary}"},
         )
         handle_response_errors(response, "batch", "Batch", f"{len(self)} items")
@@ -811,7 +913,7 @@ and add `"Batch"`, `"BatchError"` and `"BatchResult"` to `__all__`.
 - [ ] **Step 6: Run and watch them pass**
 
 Run: `uv run pytest tests/test_batch.py -v`
-Expected: PASS, 8 tests
+Expected: PASS, 10 tests
 
 - [ ] **Step 7: Run the whole suite for regressions**
 
@@ -919,7 +1021,7 @@ Add to the `Batch` class in `src/edutap/wallet_google/batch.py`, directly after
         client = client_pool.async_client(credentials=credentials)
         response = await client.post(
             url=str(client_pool.settings.batch_url),
-            content=encode_multipart(self._sub_requests, boundary),
+            content=encode_multipart(self._ordered_sub_requests(), boundary),
             headers={"Content-Type": f"multipart/mixed; boundary={boundary}"},
         )
         handle_response_errors(response, "batch", "Batch", f"{len(self)} items")
@@ -1041,7 +1143,8 @@ results = batch.execute()
 
 A batch is **not** atomic: individual items can fail while the rest succeed, which is why
 failures come back as results rather than exceptions. There is one result per added
-sub-request, in the order they were added.
+sub-request, **in the order they were added** — the batch may group and reorder the
+sub-requests internally, but that never shows in the results.
 
 `execute()` does not split, throttle or retry. The Google Wallet API is rate limited to 20
 calls per second; deciding how many objects go into one batch, and how fast batches follow

--- a/superpowers/plans/2026-08-17-batch-update.md
+++ b/superpowers/plans/2026-08-17-batch-update.md
@@ -2,22 +2,22 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Add `batch_update(name, data)` and `abatch_update(name, data)` — one
-`multipart/mixed` request that PATCHes many wallet objects of any pass type in a single
-API call.
+**Goal:** Add a `Batch` object that collects sub-requests and sends them as one
+`multipart/mixed` request, PATCHing many wallet objects — of any pass type, mixed freely —
+in a single API call.
 
-**Architecture:** Three pieces, no more. A pure encoder/decoder for `multipart/mixed`
-that knows nothing about wallet models; two API functions that turn a list of plain dicts
-into sub-requests and return one result per input item in input order; and a new settings
-entry for the batch endpoint. No chunking, no throttling, no retry, no resume — those are
-a later stage and deliberately out of scope.
+**Architecture:** Two modules and one class. `multipart.py` encodes and decodes
+`multipart/mixed` and knows nothing about wallet models. `batch.py` holds the public
+`Batch` class: you fill it with `add_update()` calls and then `execute()` it. One `Batch`
+is one HTTP request. No chunking, no throttling, no retry, no resume — those come later
+as keyword arguments to `execute()`.
 
 **Tech Stack:** Python 3.12+, Pydantic v2, httpx, authlib, pytest, respx, the `email`
 module from the standard library for multipart parsing.
 
 **Spec:** None as a separate file. The design rationale lives in the *Design decisions*
-section below; it was settled in conversation on 2026-08-17 and the reasoning is short
-enough to travel with the plan.
+section below; it was settled in conversation on 2026-08-17 and is short enough to travel
+with the plan.
 
 ## Global Constraints
 
@@ -26,9 +26,11 @@ enough to travel with the plan.
 - Conventional Commits. Commit messages, comments, identifiers and docstrings in English.
 - No new runtime dependencies. `email` and `uuid` are standard library; everything else is
   already required.
-- Public functions carry full type hints. The package ships `py.typed`.
-- Sync and async are both public and behave identically; async functions carry the `a`
-  prefix, matching every other function in `api.py`.
+- Public functions and methods carry full type hints. The package ships `py.typed`.
+- Sync and async are both public and behave identically; async carries the `a` prefix,
+  matching every other function in `api.py`.
+- Every parameter of `execute()` and `aexecute()` is **keyword-only**, so the later driver
+  stage can add `chunk_size` and friends without breaking existing calls.
 - Rate limit for context: the Google Wallet API allows **20 calls per second**
   ([FAQ](https://developers.google.com/wallet/generic/resources/faq)). Nothing in this
   plan enforces it — the caller does.
@@ -36,8 +38,8 @@ enough to travel with the plan.
 
 ## What is known, and how well
 
-This matters because two of the numbers driving this design are not in Google's
-documentation, and the code should not pretend otherwise.
+Two of the numbers driving this design are not in Google's documentation, and the code
+should not pretend otherwise.
 
 - **Documented:** the batch endpoint is `POST https://walletobjects.googleapis.com/batch`
   with a `multipart/mixed` body; the resource path inside each part is
@@ -46,56 +48,68 @@ documentation, and the code should not pretend otherwise.
 - **Not documented anywhere:** the maximum number of sub-requests per batch, and whether
   a batch counts as one call or as N against the rate limit. Searched for both; the
   Wallet pages and the FAQ are silent.
-- **Supplied by the maintainer, 2026-08-17:** a batch counts as **one** request regardless
-  of how many sub-requests it carries. This is why batching is worth building at all — it
-  turns 70,000 daily updates from roughly an hour of wall-clock into minutes. Record it in
-  code comments as what it is: an operational finding, not a documented guarantee. Do not
-  cite a Google URL for it, because there isn't one.
+- **Operational finding, not a documented guarantee** (maintainer, 2026-08-17): a batch
+  counts as **one** request regardless of how many sub-requests it carries. This is why
+  batching is worth building — it turns 70,000 daily updates from roughly an hour of
+  wall-clock into minutes. Task 5 verifies it against the Cloud Console. Do not cite a
+  Google URL for it; there isn't one.
 
-Consequence for the code: **no sub-request count is hard-coded anywhere.** The functions
-take whatever list they are given. If a ceiling exists, it will surface as an HTTP error
-from Google, and the caller decides what to do about it.
+Consequence for the code: **no sub-request count is hard-coded anywhere.** A `Batch` takes
+whatever it is given. If a ceiling exists, it surfaces as an HTTP error from Google, and
+the caller decides what to do about it.
 
 ## Design decisions
 
-**`batch_update` takes a `name` plus plain dicts, not model instances.** `update()` today
+**A `Batch` is an object you fill and then execute.** This mirrors the endpoint: every
+part of the multipart body carries its own method and path, so there is no technical
+reason for the parts to share a pass type. It also makes the boundary visible — filling a
+`Batch` and calling `execute()` makes it obvious that one HTTP request is being built,
+where a function taking a 70,000-item list would hide that it produces a single request
+running straight into a ceiling nobody has measured.
+
+**Sub-requests carry a `name` plus a plain dict, not a model instance.** `update()` today
 derives the type from the instance via `lookup_metadata_by_model_instance()`, which is why
-it needs a real model. `read()` and `listing()` take `name` explicitly instead. Batch
-follows `read()`: the caller passes `"LoyaltyObject"` and a list of dicts. This removes
-the required-field problem entirely — a PATCH carrying two changed attributes does not
-need a `classId` just to satisfy the constructor.
+it needs a real model. `read()` and `listing()` take `name` explicitly instead. `Batch`
+follows `read()`, which removes the required-field problem: a PATCH carrying two changed
+attributes does not need a `classId` just to satisfy the constructor.
 
-**Payloads are validated against a partial model.** `make_partial_model()` already exists
+**Validation happens in `add_update()`, not in `execute()`.** A typo then fails on the
+line that caused it, with the item's own name attached, rather than surfacing at the end
+of a 1000-item loop. Validation runs against `make_partial_model()`, which already exists
 (built for partial responses) and turns required fields optional while staying a subclass.
-Validating each dict through it catches typos and type errors *before* the network call,
-without demanding fields the caller has no reason to send. Serialisation then reuses the
-existing path, which already sets `exclude_unset=True` — so only the attributes the caller
-actually set go on the wire.
+Serialisation reuses the existing path, which already sets `exclude_unset=True` — so only
+the attributes the caller actually set go on the wire.
 
-**All pass types come for free.** Every registered model already carries a `url_part`
-(`genericObject`, `loyaltyObject`, `eventTicketObject`, …). The sub-request path is a
-registry lookup, so nothing is generic-pass-specific.
+**All pass types come for free, and may be mixed.** Every registered model carries a
+`url_part` (`genericObject`, `loyaltyObject`, `eventTicketObject`, …), so the sub-request
+path is a registry lookup.
 
-**Results never raise on partial failure.** A batch is not atomic. `batch_update` returns
-one `BatchResult` per input item, in input order. Exceptions are reserved for the batch
-request itself failing.
+**Results never raise on partial failure.** A batch is not atomic. `execute()` returns one
+`BatchResult` per added sub-request, in the order they were added. Exceptions are reserved
+for the batch request itself failing.
 
 **Results carry raw dicts, not parsed models.** Parsing 1000 responses into full models
-costs time for information the caller of a bulk update rarely wants. `BatchResult.body`
-is the decoded JSON. Parsing can be added later without breaking the signature.
+costs time for information a bulk update rarely wants. `BatchResult.body` is the decoded
+JSON. Parsing can be added later without breaking the signature.
+
+**`execute()` is a method, and every parameter is keyword-only.** The later driver stage
+adds `chunk_size`, rate limiting and retry as keyword arguments. `chunk_size=None` means
+one request, today and after that change — so the semantics stay stable as the feature
+grows.
 
 ## File Structure
 
 | File | Responsibility | Task |
 | --- | --- | --- |
-| `src/edutap/wallet_google/batch.py` | encode/decode `multipart/mixed`; knows nothing about wallet models (create) | 1 |
-| `tests/test_batch_multipart.py` | encoder/decoder tests, no network (create) | 1 |
-| `src/edutap/wallet_google/models/misc.py` | `BatchResult`, `BatchError` (modify) | 2 |
+| `src/edutap/wallet_google/multipart.py` | encode/decode `multipart/mixed`; knows nothing about wallet models (create) | 1 |
+| `tests/test_multipart.py` | encoder/decoder tests, no network (create) | 1 |
+| `src/edutap/wallet_google/batch.py` | the public `Batch` class plus `BatchResult` and `BatchError` (create) | 2, 3 |
 | `src/edutap/wallet_google/settings.py` | `batch_url` setting (modify) | 2 |
-| `src/edutap/wallet_google/api.py` | `batch_update`, `abatch_update` (modify) | 2, 3 |
-| `tests/test_api_batch.py` | `batch_update` against respx (create) | 2 |
-| `tests/test_api_batch_async.py` | `abatch_update` against respx (create) | 3 |
-| `docs/tutorials.md`, `docs/reference.md` | document the new functions (modify) | 4 |
+| `src/edutap/wallet_google/api.py` | re-export `Batch` so `api.Batch()` works (modify) | 2 |
+| `tests/test_batch.py` | building and executing a batch, against respx (create) | 2, 4 |
+| `tests/test_batch_async.py` | `aexecute()` against respx (create) | 3 |
+| `docs/tutorials.md`, `docs/reference.md` | document the new API (modify) | 4 |
+| `tests/integration/test_batch.py` | round-trip against the real API (create) | 5 |
 
 ---
 
@@ -105,74 +119,77 @@ Pure functions over bytes. No httpx, no models, no settings. This is the only pa
 feature with fiddly format details, and it is fully testable without a network.
 
 **Files:**
-- Create: `src/edutap/wallet_google/batch.py`
-- Create: `tests/test_batch_multipart.py`
+- Create: `src/edutap/wallet_google/multipart.py`
+- Create: `tests/test_multipart.py`
 
 **Interfaces:**
 - Consumes: nothing.
 - Produces:
-  - `BatchSubRequest` — dataclass with `method: str`, `path: str`, `body: str | None`,
+  - `SubRequest` — dataclass with `method: str`, `path: str`, `body: str | None`,
     `content_id: str`.
-  - `BatchSubResponse` — dataclass with `content_id: str | None`, `status_code: int`,
+  - `SubResponse` — dataclass with `content_id: str | None`, `status_code: int`,
     `body: dict | None`.
-  - `encode_batch_request(sub_requests: list[BatchSubRequest], boundary: str) -> bytes`
-  - `decode_batch_response(content: bytes, content_type: str) -> list[BatchSubResponse]`
+  - `encode_multipart(sub_requests: list[SubRequest], boundary: str) -> bytes`
+  - `decode_multipart(content: bytes, content_type: str) -> list[SubResponse]`
   - `make_boundary() -> str`
 
 **Format note, read before implementing.** Google's Wallet examples show each part with
 `Content-Type: application/json` followed by the request line. Google's general batch
 protocol uses `Content-Type: application/http` for the parts. The Wallet pages are what we
 have, so encode as they show, and keep the part content type in the module-level constant
-`_PART_CONTENT_TYPE` so switching it is a one-line change. Task 5's integration test is
-what settles which one the server actually accepts.
+`_PART_CONTENT_TYPE` so switching it is a one-line change. Task 5 settles which one the
+server actually accepts.
 
 - [ ] **Step 1: Write the failing encoder test**
 
-```python
-"""Tests for multipart/mixed encoding and decoding of batch requests."""
+Create `tests/test_multipart.py`:
 
-from edutap.wallet_google.batch import BatchSubRequest
-from edutap.wallet_google.batch import encode_batch_request
+```python
+"""Tests for multipart/mixed encoding and decoding."""
+
+from edutap.wallet_google.multipart import encode_multipart
+from edutap.wallet_google.multipart import SubRequest
 
 
 def test_encode_produces_one_part_per_sub_request():
     """Each sub-request becomes a delimited part carrying method, path and body."""
     sub_requests = [
-        BatchSubRequest(
+        SubRequest(
             method="PATCH",
             path="/walletobjects/v1/genericObject/issuer.one",
             body='{"state":"EXPIRED"}',
             content_id="item-0",
         ),
-        BatchSubRequest(
+        SubRequest(
             method="PATCH",
-            path="/walletobjects/v1/genericObject/issuer.two",
+            path="/walletobjects/v1/loyaltyObject/issuer.two",
             body='{"state":"ACTIVE"}',
             content_id="item-1",
         ),
     ]
 
-    encoded = encode_batch_request(sub_requests, boundary="testboundary").decode("utf-8")
+    encoded = encode_multipart(sub_requests, boundary="testboundary").decode("utf-8")
 
     assert encoded.count("--testboundary\r\n") == 2
     assert encoded.endswith("--testboundary--\r\n")
     assert "Content-ID: <item-0>" in encoded
     assert "Content-ID: <item-1>" in encoded
     assert "PATCH /walletobjects/v1/genericObject/issuer.one" in encoded
+    assert "PATCH /walletobjects/v1/loyaltyObject/issuer.two" in encoded
     assert '{"state":"EXPIRED"}' in encoded
 ```
 
 - [ ] **Step 2: Run it and watch it fail**
 
-Run: `uv run pytest tests/test_batch_multipart.py::test_encode_produces_one_part_per_sub_request -v`
-Expected: FAIL — `ModuleNotFoundError: No module named 'edutap.wallet_google.batch'`
+Run: `uv run pytest tests/test_multipart.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'edutap.wallet_google.multipart'`
 
 - [ ] **Step 3: Write the encoder**
 
-Create `src/edutap/wallet_google/batch.py`:
+Create `src/edutap/wallet_google/multipart.py`:
 
 ```python
-"""Encoding and decoding of ``multipart/mixed`` batch requests.
+"""Encoding and decoding of ``multipart/mixed`` bodies.
 
 This module deliberately knows nothing about wallet models, settings or HTTP
 clients. It turns sub-requests into bytes and bytes back into sub-responses,
@@ -182,6 +199,8 @@ See https://developers.google.com/wallet/generic/resources/performance-tips
 """
 
 from dataclasses import dataclass
+from email.parser import BytesParser
+from email.policy import HTTP
 
 import json
 import uuid
@@ -198,8 +217,8 @@ _CRLF = "\r\n"
 
 
 @dataclass
-class BatchSubRequest:
-    """A single HTTP request to be carried inside a batch."""
+class SubRequest:
+    """A single HTTP request to be carried inside a multipart body."""
 
     method: str
     path: str
@@ -208,8 +227,8 @@ class BatchSubRequest:
 
 
 @dataclass
-class BatchSubResponse:
-    """A single HTTP response extracted from a batch response."""
+class SubResponse:
+    """A single HTTP response extracted from a multipart body."""
 
     content_id: str | None
     status_code: int
@@ -221,15 +240,12 @@ def make_boundary() -> str:
     return f"batch_{uuid.uuid4().hex}"
 
 
-def encode_batch_request(
-    sub_requests: list[BatchSubRequest],
-    boundary: str,
-) -> bytes:
+def encode_multipart(sub_requests: list[SubRequest], boundary: str) -> bytes:
     """Encode sub-requests as a ``multipart/mixed`` body.
 
     :param sub_requests: The requests to carry, in order.
     :param boundary:     Delimiter between the parts, without leading dashes.
-    :return:             The encoded body, ready to be sent as the request content.
+    :return:             The encoded body, ready to be sent as request content.
     """
     lines: list[str] = []
     for sub_request in sub_requests:
@@ -249,18 +265,18 @@ def encode_batch_request(
 
 - [ ] **Step 4: Run it and watch it pass**
 
-Run: `uv run pytest tests/test_batch_multipart.py -v`
+Run: `uv run pytest tests/test_multipart.py -v`
 Expected: PASS
 
-- [ ] **Step 5: Write the failing decoder test**
+- [ ] **Step 5: Write the failing decoder tests**
 
-Append to `tests/test_batch_multipart.py`:
+Append to `tests/test_multipart.py`:
 
 ```python
-from edutap.wallet_google.batch import decode_batch_response
+from edutap.wallet_google.multipart import decode_multipart
 
 
-BATCH_RESPONSE = (
+MULTIPART_RESPONSE = (
     "--rspboundary\r\n"
     "Content-Type: application/http\r\n"
     "Content-ID: <response-item-0>\r\n"
@@ -285,24 +301,22 @@ BATCH_RESPONSE = (
 
 def test_decode_returns_one_sub_response_per_part():
     """Status code, body and Content-ID are recovered from each part."""
-    responses = decode_batch_response(
-        BATCH_RESPONSE.encode("utf-8"),
+    responses = decode_multipart(
+        MULTIPART_RESPONSE.encode("utf-8"),
         "multipart/mixed; boundary=rspboundary",
     )
 
     assert len(responses) == 2
     assert responses[0].status_code == 200
-    assert responses[0].content_id == "item-0"
     assert responses[0].body == {"id": "issuer.one", "state": "EXPIRED"}
     assert responses[1].status_code == 404
-    assert responses[1].content_id == "item-1"
     assert responses[1].body["error"]["code"] == 404
 
 
 def test_decode_strips_the_response_prefix_from_content_id():
     """Google echoes Content-ID with a 'response-' prefix; we map back to ours."""
-    responses = decode_batch_response(
-        BATCH_RESPONSE.encode("utf-8"),
+    responses = decode_multipart(
+        MULTIPART_RESPONSE.encode("utf-8"),
         "multipart/mixed; boundary=rspboundary",
     )
 
@@ -311,12 +325,12 @@ def test_decode_strips_the_response_prefix_from_content_id():
 
 - [ ] **Step 6: Run them and watch them fail**
 
-Run: `uv run pytest tests/test_batch_multipart.py -v`
-Expected: FAIL — `ImportError: cannot import name 'decode_batch_response'`
+Run: `uv run pytest tests/test_multipart.py -v`
+Expected: FAIL — `ImportError: cannot import name 'decode_multipart'`
 
 - [ ] **Step 7: Write the decoder**
 
-Append to `src/edutap/wallet_google/batch.py`:
+Append to `src/edutap/wallet_google/multipart.py`:
 
 ```python
 def _parse_http_payload(payload: str) -> tuple[int, dict | None]:
@@ -338,8 +352,8 @@ def _parse_http_payload(payload: str) -> tuple[int, dict | None]:
         return status_code, None
 
 
-def decode_batch_response(content: bytes, content_type: str) -> list[BatchSubResponse]:
-    """Decode a ``multipart/mixed`` batch response into its sub-responses.
+def decode_multipart(content: bytes, content_type: str) -> list[SubResponse]:
+    """Decode a ``multipart/mixed`` body into its sub-responses.
 
     Order is preserved, but callers should correlate via ``content_id`` rather
     than position — the specification does not promise the server answers in the
@@ -349,14 +363,11 @@ def decode_batch_response(content: bytes, content_type: str) -> list[BatchSubRes
     :param content_type: The response Content-Type header, carrying the boundary.
     :return:             One entry per part, in the order they appear.
     """
-    from email.parser import BytesParser
-    from email.policy import HTTP
-
     message = BytesParser(policy=HTTP).parsebytes(
         b"Content-Type: " + content_type.encode("utf-8") + b"\r\n\r\n" + content
     )
 
-    sub_responses: list[BatchSubResponse] = []
+    sub_responses: list[SubResponse] = []
     for part in message.iter_parts():
         raw_content_id = part.get("Content-ID")
         content_id = None
@@ -365,7 +376,7 @@ def decode_batch_response(content: bytes, content_type: str) -> list[BatchSubRes
             content_id = raw_content_id.strip("<>").removeprefix("response-")
         status_code, body = _parse_http_payload(part.get_payload())
         sub_responses.append(
-            BatchSubResponse(
+            SubResponse(
                 content_id=content_id,
                 status_code=status_code,
                 body=body,
@@ -374,52 +385,51 @@ def decode_batch_response(content: bytes, content_type: str) -> list[BatchSubRes
     return sub_responses
 ```
 
-Move the two `email` imports to the top of the module with the other imports before
-committing — they are inline here only to keep the diff readable.
-
 - [ ] **Step 8: Run the whole file**
 
-Run: `uv run pytest tests/test_batch_multipart.py -v`
+Run: `uv run pytest tests/test_multipart.py -v`
 Expected: PASS, 3 tests
 
 - [ ] **Step 9: Lint and commit**
 
 ```bash
-uvx ruff format src/edutap/wallet_google/batch.py tests/test_batch_multipart.py
-uvx ruff check src/edutap/wallet_google/batch.py tests/test_batch_multipart.py
-git add src/edutap/wallet_google/batch.py tests/test_batch_multipart.py
+uvx ruff format src/edutap/wallet_google/multipart.py tests/test_multipart.py
+uvx ruff check src/edutap/wallet_google/multipart.py tests/test_multipart.py
+git add src/edutap/wallet_google/multipart.py tests/test_multipart.py
 git commit -m "feat(batch): add multipart/mixed encoder and decoder"
 ```
 
 ---
 
-### Task 2: `batch_update()` — the synchronous API function
+### Task 2: The `Batch` class and `execute()`
 
 **Files:**
+- Create: `src/edutap/wallet_google/batch.py`
+- Create: `tests/test_batch.py`
 - Modify: `src/edutap/wallet_google/settings.py`
-- Modify: `src/edutap/wallet_google/models/misc.py`
 - Modify: `src/edutap/wallet_google/api.py`
-- Create: `tests/test_api_batch.py`
 
 **Interfaces:**
-- Consumes: `BatchSubRequest`, `BatchSubResponse`, `encode_batch_request`,
-  `decode_batch_response`, `make_boundary` from Task 1.
+- Consumes: `SubRequest`, `SubResponse`, `encode_multipart`, `decode_multipart`,
+  `make_boundary` from Task 1.
 - Produces:
   - `BatchError` — Pydantic model with `code: int`, `message: str`, `status: str | None`.
-  - `BatchResult` — Pydantic model with `index: int`, `resource_id: str`,
-    `status_code: int`, `body: dict | None`, `error: BatchError | None`, and a
-    property `ok: bool`.
-  - `batch_update(name: str, data: list[dict], *, credentials: dict | None = None) -> list[BatchResult]`
+  - `BatchResult` — Pydantic model with `index: int`, `name: str`, `resource_id: str`,
+    `status_code: int`, `body: dict | None`, `error: BatchError | None`, and a property
+    `ok: bool`.
+  - `Batch` — class with `add_update(name, data)`, `add_updates(name, data_list)`,
+    `__len__()`, and `execute(*, credentials=None) -> list[BatchResult]`.
   - `settings.batch_url`
+  - `api.Batch` — re-export, so `api.Batch()` works alongside `api.read()` etc.
 
-- [ ] **Step 1: Write the failing test**
+- [ ] **Step 1: Write the failing tests**
 
-Create `tests/test_api_batch.py`:
+Create `tests/test_batch.py`:
 
 ```python
-"""Tests for batch_update()."""
+"""Tests for building and executing a Batch."""
 
-from edutap.wallet_google.api import batch_update
+from edutap.wallet_google.batch import Batch
 from edutap.wallet_google.settings import Settings
 
 import httpx
@@ -427,7 +437,7 @@ import pytest
 import respx
 
 
-BATCH_RESPONSE = (
+MULTIPART_RESPONSE = (
     "--rspboundary\r\n"
     "Content-Type: application/http\r\n"
     "Content-ID: <response-item-0>\r\n"
@@ -450,24 +460,35 @@ BATCH_RESPONSE = (
 )
 
 
-@respx.mock
-def test_batch_update_sends_one_request_and_returns_one_result_per_item(mock_session):
-    """Two updates go out as a single POST and come back as two results."""
-    route = respx.post(str(Settings().batch_url)).mock(
+def _mock_batch_endpoint():
+    """Point the batch endpoint at a canned two-part response."""
+    return respx.post(str(Settings().batch_url)).mock(
         return_value=httpx.Response(
             200,
-            content=BATCH_RESPONSE.encode("utf-8"),
+            content=MULTIPART_RESPONSE.encode("utf-8"),
             headers={"Content-Type": "multipart/mixed; boundary=rspboundary"},
         )
     )
 
-    results = batch_update(
-        "GenericObject",
-        [
-            {"id": "issuer.one", "state": "EXPIRED"},
-            {"id": "issuer.two", "state": "ACTIVE"},
-        ],
-    )
+
+def test_len_counts_the_added_sub_requests():
+    """A Batch is one HTTP request; len() is how the caller sees its size."""
+    batch = Batch()
+    batch.add_update("GenericObject", {"id": "issuer.one", "state": "EXPIRED"})
+    batch.add_update("LoyaltyObject", {"id": "issuer.two", "state": "ACTIVE"})
+
+    assert len(batch) == 2
+
+
+@respx.mock
+def test_execute_sends_one_request_and_returns_one_result_per_item(mock_session):
+    """Two updates go out as a single POST and come back as two results."""
+    route = _mock_batch_endpoint()
+
+    batch = Batch()
+    batch.add_update("GenericObject", {"id": "issuer.one", "state": "EXPIRED"})
+    batch.add_update("GenericObject", {"id": "issuer.two", "state": "ACTIVE"})
+    results = batch.execute()
 
     assert route.call_count == 1
     assert len(results) == 2
@@ -480,44 +501,77 @@ def test_batch_update_sends_one_request_and_returns_one_result_per_item(mock_ses
 
 
 @respx.mock
-def test_batch_update_sends_only_the_attributes_that_were_set(mock_session):
-    """A two-attribute PATCH must not carry the rest of the model."""
-    route = respx.post(str(Settings().batch_url)).mock(
-        return_value=httpx.Response(
-            200,
-            content=BATCH_RESPONSE.encode("utf-8"),
-            headers={"Content-Type": "multipart/mixed; boundary=rspboundary"},
-        )
-    )
+def test_a_batch_may_mix_pass_types(mock_session):
+    """Each part carries its own path, so types need not match."""
+    route = _mock_batch_endpoint()
 
-    batch_update("GenericObject", [{"id": "issuer.one", "state": "EXPIRED"}])
+    batch = Batch()
+    batch.add_update("GenericObject", {"id": "issuer.one", "state": "EXPIRED"})
+    batch.add_update("EventTicketObject", {"id": "issuer.two", "state": "ACTIVE"})
+    results = batch.execute()
+
+    body = route.calls.last.request.content.decode("utf-8")
+    assert "PATCH /walletobjects/v1/genericObject/issuer.one" in body
+    assert "PATCH /walletobjects/v1/eventTicketObject/issuer.two" in body
+    assert [r.name for r in results] == ["GenericObject", "EventTicketObject"]
+
+
+@respx.mock
+def test_execute_sends_only_the_attributes_that_were_set(mock_session):
+    """A two-attribute PATCH must not carry the rest of the model."""
+    route = _mock_batch_endpoint()
+
+    batch = Batch()
+    batch.add_update("GenericObject", {"id": "issuer.one", "state": "EXPIRED"})
+    batch.execute()
 
     body = route.calls.last.request.content.decode("utf-8")
     assert '"state"' in body
     assert '"classId"' not in body
-    assert "PATCH /walletobjects/v1/genericObject/issuer.one" in body
 
 
-def test_batch_update_rejects_an_unknown_attribute(mock_session):
-    """Typos are caught before the network call, not by Google."""
+def test_add_updates_appends_a_whole_list():
+    """The bulk case must not need one call per object."""
+    batch = Batch()
+    batch.add_updates(
+        "LoyaltyObject",
+        [{"id": f"issuer.{n}", "state": "EXPIRED"} for n in range(5)],
+    )
+
+    assert len(batch) == 5
+
+
+def test_add_update_rejects_an_unknown_attribute():
+    """Typos fail on the line that caused them, not at execute() time."""
+    batch = Batch()
+
     with pytest.raises(ValueError) as exc_info:
-        batch_update("GenericObject", [{"id": "issuer.one", "notAField": 1}])
+        batch.add_update("GenericObject", {"id": "issuer.one", "notAField": 1})
 
     assert "notAField" in str(exc_info.value)
 
 
-def test_batch_update_requires_the_resource_id(mock_session):
+def test_add_update_requires_the_resource_id():
     """Without an id there is nothing to PATCH."""
+    batch = Batch()
+
     with pytest.raises(ValueError) as exc_info:
-        batch_update("GenericObject", [{"state": "EXPIRED"}])
+        batch.add_update("GenericObject", {"state": "EXPIRED"})
 
     assert "id" in str(exc_info.value)
+
+
+def test_executing_an_empty_batch_makes_no_request():
+    """Nothing added, nothing sent."""
+    batch = Batch()
+
+    assert batch.execute() == []
 ```
 
-- [ ] **Step 2: Run and watch it fail**
+- [ ] **Step 2: Run and watch them fail**
 
-Run: `uv run pytest tests/test_api_batch.py -v`
-Expected: FAIL — `ImportError: cannot import name 'batch_update'`
+Run: `uv run pytest tests/test_batch.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'edutap.wallet_google.batch'`
 
 - [ ] **Step 3: Add the settings entry**
 
@@ -533,14 +587,41 @@ and in the `Settings` class, beside `api_url`:
     batch_url: AnyHttpUrl = AnyHttpUrl(BATCH_URL)
 ```
 
-Note it is *not* derived from `api_url`: the batch endpoint sits one level above
+It is deliberately *not* derived from `api_url`: the batch endpoint sits one level above
 `/walletobjects/v1`, so appending would produce the wrong URL.
 
-- [ ] **Step 4: Add the result models**
+- [ ] **Step 4: Write the `Batch` class**
 
-Append to `src/edutap/wallet_google/models/misc.py`:
+Create `src/edutap/wallet_google/batch.py`:
 
 ```python
+"""Batch requests against the Google Wallet API.
+
+A :class:`Batch` collects sub-requests and sends them as a single
+``multipart/mixed`` request. One Batch is one HTTP request — which is the point:
+the Google Wallet API is rate limited per call, so a hundred updates in one
+Batch cost what one update costs.
+
+See https://developers.google.com/wallet/generic/resources/performance-tips
+"""
+
+from .clientpool import client_pool
+from .models.bases import make_partial_model
+from .models.bases import Model
+from .multipart import decode_multipart
+from .multipart import encode_multipart
+from .multipart import make_boundary
+from .multipart import SubRequest
+from .multipart import SubResponse
+from .registry import lookup_metadata_by_name
+from .registry import raise_when_operation_not_allowed
+from .utils import handle_response_errors
+from pydantic import ValidationError as PydanticValidationError
+
+import typing
+import urllib.parse
+
+
 class BatchError(Model):
     """The error Google reports for a single failed sub-request."""
 
@@ -553,6 +634,7 @@ class BatchResult(Model):
     """The outcome of one sub-request, correlated back to its input item."""
 
     index: int
+    name: str
     resource_id: str
     status_code: int
     body: dict | None = None
@@ -562,206 +644,213 @@ class BatchResult(Model):
     def ok(self) -> bool:
         """True when Google accepted this sub-request."""
         return self.error is None and 200 <= self.status_code < 300
-```
 
-- [ ] **Step 5: Implement `batch_update`**
 
-Add to `src/edutap/wallet_google/api.py`, and add `"batch_update"` and `"abatch_update"`
-to `__all__`:
+class Batch:
+    """Collects sub-requests and sends them as one API call.
 
-```python
-def _prepare_batch_update(
-    name: str,
-    data: list[dict[str, typing.Any]],
-) -> tuple[list[BatchSubRequest], list[str]]:
-    """Turn dicts into batch sub-requests.
+    Fill it, then execute it::
 
-    Payloads are validated against a partial model: field names and types are
-    checked, but required fields are not demanded — a PATCH carrying two changed
-    attributes has no reason to supply a classId.
+        batch = Batch()
+        batch.add_update("LoyaltyObject", {"id": "issuer.m1", "state": "EXPIRED"})
+        results = batch.execute()
 
-    :param name: Registered model name, e.g. "GenericObject" or "LoyaltyObject".
-    :param data: One dict per object, each carrying at least the resource id.
-    :return:     Tuple of sub-requests and their resource ids, in input order.
-    :raises ValueError: When a payload is invalid or carries no resource id.
+    Pass types may be mixed freely — each sub-request carries its own path.
     """
-    metadata = lookup_metadata_by_name(name)
-    raise_when_operation_not_allowed(name, "update")
-    partial_model = make_partial_model(metadata["model"])
-    resource_id_key = metadata["resource_id"]
-    api_path = urllib.parse.urlparse(str(client_pool.settings.api_url)).path
 
-    sub_requests: list[BatchSubRequest] = []
-    resource_ids: list[str] = []
-    for index, item in enumerate(data):
-        resource_id = item.get(resource_id_key)
+    def __init__(self) -> None:
+        self._sub_requests: list[SubRequest] = []
+        # Parallel to _sub_requests: what each one was about, for the results.
+        self._items: list[tuple[str, str]] = []
+
+    def __len__(self) -> int:
+        """Number of sub-requests collected so far.
+
+        One Batch is one HTTP request, so this is the number the caller needs in
+        order to decide whether to send it or start a new one.
+        """
+        return len(self._sub_requests)
+
+    def add_update(self, name: str, data: dict[str, typing.Any]) -> None:
+        """Add a PATCH for one object.
+
+        Only the attributes present in ``data`` are sent. The payload is
+        validated here rather than at execute time, so a typo fails on the line
+        that caused it.
+
+        :param name: Registered model name, e.g. "LoyaltyObject".
+        :param data: The attributes to change, plus the resource id.
+        :raises ValueError: When the payload is invalid or carries no resource id.
+        """
+        metadata = lookup_metadata_by_name(name)
+        raise_when_operation_not_allowed(name, "update")
+        resource_id_key = metadata["resource_id"]
+
+        resource_id = data.get(resource_id_key)
         if not resource_id:
             raise ValueError(
-                f"Item {index} has no '{resource_id_key}'; there is nothing to update."
+                f"Item for '{name}' has no '{resource_id_key}'; nothing to update."
             )
+
+        partial_model = make_partial_model(metadata["model"])
         try:
-            verified = partial_model.model_validate(item)
+            verified = partial_model.model_validate(data)
         except PydanticValidationError as exc:
-            raise ValueError(f"Item {index} is not valid for '{name}': {exc}") from exc
-        body = verified.model_dump_json(exclude_unset=True, by_alias=True)
-        sub_requests.append(
-            BatchSubRequest(
+            raise ValueError(f"Item '{resource_id}' is invalid for '{name}': {exc}") from exc
+
+        api_path = urllib.parse.urlparse(str(client_pool.settings.api_url)).path
+        self._sub_requests.append(
+            SubRequest(
                 method="PATCH",
                 path=f"{api_path}/{metadata['url_part']}/{resource_id}",
-                body=body,
-                content_id=f"item-{index}",
+                body=verified.model_dump_json(exclude_unset=True, by_alias=True),
+                content_id=f"item-{len(self._sub_requests)}",
             )
         )
-        resource_ids.append(resource_id)
-    return sub_requests, resource_ids
+        self._items.append((name, resource_id))
 
+    def add_updates(
+        self,
+        name: str,
+        data: list[dict[str, typing.Any]],
+    ) -> None:
+        """Add a PATCH for each object in a list.
 
-def _build_batch_results(
-    sub_responses: list[BatchSubResponse],
-    resource_ids: list[str],
-) -> list[BatchResult]:
-    """Correlate sub-responses back to their input items.
+        :param name: Registered model name, applied to every item.
+        :param data: One dict per object.
+        :raises ValueError: When any payload is invalid or carries no resource id.
+        """
+        for item in data:
+            self.add_update(name, item)
 
-    Correlation is by Content-ID, not by position: the batch specification does
-    not promise the server answers in the order it was asked.
-    """
-    by_content_id = {r.content_id: r for r in sub_responses if r.content_id}
-    results: list[BatchResult] = []
-    for index, resource_id in enumerate(resource_ids):
-        sub_response = by_content_id.get(f"item-{index}")
-        if sub_response is None:
-            # No part came back for this item at all.
+    def _build_results(self, sub_responses: list[SubResponse]) -> list[BatchResult]:
+        """Correlate sub-responses back to the items that produced them.
+
+        Correlation is by Content-ID, not by position: the specification does not
+        promise the server answers in the order it was asked.
+        """
+        by_content_id = {r.content_id: r for r in sub_responses if r.content_id}
+        results: list[BatchResult] = []
+        for index, (name, resource_id) in enumerate(self._items):
+            sub_response = by_content_id.get(f"item-{index}")
+            if sub_response is None:
+                results.append(
+                    BatchResult(
+                        index=index,
+                        name=name,
+                        resource_id=resource_id,
+                        status_code=0,
+                        error=BatchError(
+                            code=0, message="No response part for this sub-request."
+                        ),
+                    )
+                )
+                continue
+            body = sub_response.body
+            error = None
+            if body is not None and "error" in body:
+                error = BatchError.model_validate(body["error"])
+                body = None
             results.append(
                 BatchResult(
                     index=index,
+                    name=name,
                     resource_id=resource_id,
-                    status_code=0,
-                    error=BatchError(
-                        code=0, message="No response part for this sub-request."
-                    ),
+                    status_code=sub_response.status_code,
+                    body=body,
+                    error=error,
                 )
             )
-            continue
-        body = sub_response.body
-        error = None
-        if body is not None and "error" in body:
-            error = BatchError.model_validate(body["error"])
-            body = None
-        results.append(
-            BatchResult(
-                index=index,
-                resource_id=resource_id,
-                status_code=sub_response.status_code,
-                body=body,
-                error=error,
-            )
+        return results
+
+    def execute(self, *, credentials: dict | None = None) -> list[BatchResult]:
+        """Send the collected sub-requests as one API call.
+
+        Individual sub-request failures do **not** raise; they come back as
+        results carrying an ``error``. Only the batch request itself failing
+        raises.
+
+        This does not chunk, throttle or retry. The Google Wallet API is rate
+        limited to 20 calls per second; staying within it is the caller's
+        business. Parameters are keyword-only so that a later driver stage can
+        add ``chunk_size`` and friends without breaking existing calls.
+
+        :param credentials: Optional session credentials as dict.
+        :raises WalletException: When the batch request itself fails.
+        :return: One result per added sub-request, in the order they were added.
+        """
+        if not self._sub_requests:
+            return []
+        boundary = make_boundary()
+
+        client = client_pool.client(credentials=credentials)
+        response = client.post(
+            url=str(client_pool.settings.batch_url),
+            content=encode_multipart(self._sub_requests, boundary),
+            headers={"Content-Type": f"multipart/mixed; boundary={boundary}"},
         )
-    return results
+        handle_response_errors(response, "batch", "Batch", f"{len(self)} items")
 
-
-def batch_update(
-    name: str,
-    data: list[dict[str, typing.Any]],
-    *,
-    credentials: dict | None = None,
-) -> list[BatchResult]:
-    """Update many wallet objects of one type in a single API call.
-
-    Sends one ``multipart/mixed`` request carrying a PATCH per item. Works for
-    every registered pass type — the path comes from the registry, so
-    "GenericObject", "LoyaltyObject", "EventTicketObject" and the rest behave
-    identically.
-
-    Only the attributes present in each dict are sent, so a batch of small
-    changes stays small on the wire.
-
-    This function does not chunk, throttle or retry. The Google Wallet API is
-    rate limited to 20 calls per second; staying within it is the caller's
-    business.
-
-    :param name:        Registered model name, e.g. "LoyaltyObject".
-    :param data:        One dict per object, each carrying at least the resource id.
-    :param credentials: Optional session credentials as dict.
-    :raises ValueError: When a payload is invalid or carries no resource id.
-    :raises WalletException: When the batch request itself fails. Individual
-                        sub-request failures do **not** raise — they come back
-                        as results with an ``error``.
-    :return:            One result per input item, in input order.
-    """
-    if not data:
-        return []
-    sub_requests, resource_ids = _prepare_batch_update(name, data)
-    boundary = make_boundary()
-
-    client = client_pool.client(credentials=credentials)
-    response = client.post(
-        url=str(client_pool.settings.batch_url),
-        content=encode_batch_request(sub_requests, boundary),
-        headers={"Content-Type": f"multipart/mixed; boundary={boundary}"},
-    )
-    handle_response_errors(response, "batch_update", name, f"{len(data)} items")
-
-    sub_responses = decode_batch_response(
-        response.content, response.headers.get("Content-Type", "")
-    )
-    return _build_batch_results(sub_responses, resource_ids)
+        return self._build_results(
+            decode_multipart(response.content, response.headers.get("Content-Type", ""))
+        )
 ```
 
-Add these imports at the top of `api.py`:
+- [ ] **Step 5: Re-export from `api.py`**
+
+So that `Batch` sits beside the other public entry points. Add the import:
 
 ```python
-from .batch import BatchSubRequest
-from .batch import BatchSubResponse
-from .batch import decode_batch_response
-from .batch import encode_batch_request
-from .batch import make_boundary
-from .models.misc import BatchError
-from .models.misc import BatchResult
-from pydantic import ValidationError as PydanticValidationError
-
-import urllib.parse
+from .batch import Batch
+from .batch import BatchError
+from .batch import BatchResult
 ```
 
-- [ ] **Step 6: Run and watch it pass**
+and add `"Batch"`, `"BatchError"` and `"BatchResult"` to `__all__`.
 
-Run: `uv run pytest tests/test_api_batch.py -v`
-Expected: PASS, 4 tests
+- [ ] **Step 6: Run and watch them pass**
+
+Run: `uv run pytest tests/test_batch.py -v`
+Expected: PASS, 8 tests
 
 - [ ] **Step 7: Run the whole suite for regressions**
 
 Run: `uvx tox -e py313`
-Expected: PASS — `api.py` and `misc.py` both changed, so everything gets a look.
+Expected: PASS
 
 - [ ] **Step 8: Lint and commit**
 
 ```bash
 uvx ruff format src tests
 uvx ruff check src tests
-git add src/edutap/wallet_google/api.py src/edutap/wallet_google/models/misc.py src/edutap/wallet_google/settings.py tests/test_api_batch.py
-git commit -m "feat(batch): add batch_update() for all pass types"
+git add src/edutap/wallet_google/batch.py src/edutap/wallet_google/settings.py src/edutap/wallet_google/api.py tests/test_batch.py
+git commit -m "feat(batch): add Batch with add_update() and execute()"
 ```
 
 ---
 
-### Task 3: `abatch_update()` — the asynchronous twin
+### Task 3: `aexecute()` — the asynchronous twin
 
 **Files:**
-- Modify: `src/edutap/wallet_google/api.py`
-- Create: `tests/test_api_batch_async.py`
+- Modify: `src/edutap/wallet_google/batch.py`
+- Create: `tests/test_batch_async.py`
 
 **Interfaces:**
-- Consumes: `_prepare_batch_update`, `_build_batch_results`, `BatchResult` from Task 2.
-- Produces: `abatch_update(name: str, data: list[dict], *, credentials: dict | None = None) -> list[BatchResult]`
+- Consumes: `Batch`, `BatchResult` from Task 2.
+- Produces: `Batch.aexecute(*, credentials: dict | None = None) -> list[BatchResult]`
+
+Building a Batch has no I/O, so only execution needs an async variant. `add_update()` is
+shared between both.
 
 - [ ] **Step 1: Write the failing test**
 
-Create `tests/test_api_batch_async.py` with the same `BATCH_RESPONSE` constant as
-`tests/test_api_batch.py` (repeat it — the two files are read independently), then:
+Create `tests/test_batch_async.py`, repeating the `MULTIPART_RESPONSE` constant from
+`tests/test_batch.py` verbatim — the two files are read independently — then:
 
 ```python
-"""Tests for abatch_update()."""
+"""Tests for Batch.aexecute()."""
 
-from edutap.wallet_google.api import abatch_update
+from edutap.wallet_google.batch import Batch
 from edutap.wallet_google.settings import Settings
 
 import httpx
@@ -771,29 +860,32 @@ import respx
 
 @pytest.mark.asyncio
 @respx.mock
-async def test_abatch_update_matches_the_sync_behaviour(mock_async_session):
+async def test_aexecute_matches_the_sync_behaviour(mock_async_session):
     """One POST, one result per item, failures reported not raised."""
     route = respx.post(str(Settings().batch_url)).mock(
         return_value=httpx.Response(
             200,
-            content=BATCH_RESPONSE.encode("utf-8"),
+            content=MULTIPART_RESPONSE.encode("utf-8"),
             headers={"Content-Type": "multipart/mixed; boundary=rspboundary"},
         )
     )
 
-    results = await abatch_update(
-        "LoyaltyObject",
-        [
-            {"id": "issuer.one", "state": "EXPIRED"},
-            {"id": "issuer.two", "state": "ACTIVE"},
-        ],
-    )
+    batch = Batch()
+    batch.add_update("LoyaltyObject", {"id": "issuer.one", "state": "EXPIRED"})
+    batch.add_update("LoyaltyObject", {"id": "issuer.two", "state": "ACTIVE"})
+    results = await batch.aexecute()
 
     assert route.call_count == 1
     assert len(results) == 2
     assert results[0].ok is True
     assert results[1].ok is False
     assert results[1].error.code == 404
+
+
+@pytest.mark.asyncio
+async def test_aexecute_on_an_empty_batch_makes_no_request(mock_async_session):
+    """Nothing added, nothing sent."""
+    assert await Batch().aexecute() == []
 ```
 
 The marker is `@pytest.mark.asyncio`, matching every async test in
@@ -802,62 +894,53 @@ introduce a second convention here.
 
 - [ ] **Step 2: Run and watch it fail**
 
-Run: `uv run pytest tests/test_api_batch_async.py -v`
-Expected: FAIL — `ImportError: cannot import name 'abatch_update'`
+Run: `uv run pytest tests/test_batch_async.py -v`
+Expected: FAIL — `AttributeError: 'Batch' object has no attribute 'aexecute'`
 
 - [ ] **Step 3: Implement it**
 
-Add to `api.py`, in the asynchronous section beside the other `a`-prefixed functions:
+Add to the `Batch` class in `src/edutap/wallet_google/batch.py`, directly after
+`execute()`:
 
 ```python
-async def abatch_update(
-    name: str,
-    data: list[dict[str, typing.Any]],
-    *,
-    credentials: dict | None = None,
-) -> list[BatchResult]:
-    """Asynchronously update many wallet objects of one type in a single API call.
+    async def aexecute(self, *, credentials: dict | None = None) -> list[BatchResult]:
+        """Asynchronously send the collected sub-requests as one API call.
 
-    See :func:`batch_update` for the full description; behaviour is identical.
+        See :meth:`execute` for the full description; behaviour is identical.
 
-    :param name:        Registered model name, e.g. "LoyaltyObject".
-    :param data:        One dict per object, each carrying at least the resource id.
-    :param credentials: Optional session credentials as dict.
-    :raises ValueError: When a payload is invalid or carries no resource id.
-    :raises WalletException: When the batch request itself fails.
-    :return:            One result per input item, in input order.
-    """
-    if not data:
-        return []
-    sub_requests, resource_ids = _prepare_batch_update(name, data)
-    boundary = make_boundary()
+        :param credentials: Optional session credentials as dict.
+        :raises WalletException: When the batch request itself fails.
+        :return: One result per added sub-request, in the order they were added.
+        """
+        if not self._sub_requests:
+            return []
+        boundary = make_boundary()
 
-    client = client_pool.async_client(credentials=credentials)
-    response = await client.post(
-        url=str(client_pool.settings.batch_url),
-        content=encode_batch_request(sub_requests, boundary),
-        headers={"Content-Type": f"multipart/mixed; boundary={boundary}"},
-    )
-    handle_response_errors(response, "batch_update", name, f"{len(data)} items")
+        client = client_pool.async_client(credentials=credentials)
+        response = await client.post(
+            url=str(client_pool.settings.batch_url),
+            content=encode_multipart(self._sub_requests, boundary),
+            headers={"Content-Type": f"multipart/mixed; boundary={boundary}"},
+        )
+        handle_response_errors(response, "batch", "Batch", f"{len(self)} items")
 
-    sub_responses = decode_batch_response(
-        response.content, response.headers.get("Content-Type", "")
-    )
-    return _build_batch_results(sub_responses, resource_ids)
+        return self._build_results(
+            decode_multipart(response.content, response.headers.get("Content-Type", ""))
+        )
 ```
 
 - [ ] **Step 4: Run and watch it pass**
 
-Run: `uv run pytest tests/test_api_batch_async.py -v`
-Expected: PASS
+Run: `uv run pytest tests/test_batch_async.py -v`
+Expected: PASS, 2 tests
 
 - [ ] **Step 5: Commit**
 
 ```bash
 uvx ruff format src tests
 uvx ruff check src tests
-git add src/edutap/wallet_google/api.py tests/test_api_batch_async.py
-git commit -m "feat(batch): add abatch_update()"
+git add src/edutap/wallet_google/batch.py tests/test_batch_async.py
+git commit -m "feat(batch): add Batch.aexecute()"
 ```
 
 ---
@@ -868,17 +951,17 @@ The claim "works for all pass types" is currently an argument about the registry
 task turns it into a test, and writes the docs.
 
 **Files:**
-- Modify: `tests/test_api_batch.py`
+- Modify: `tests/test_batch.py`
 - Modify: `docs/tutorials.md`
 - Modify: `docs/reference.md`
 
 **Interfaces:**
-- Consumes: `batch_update` from Task 2.
+- Consumes: `Batch` from Task 2.
 - Produces: no new code interfaces.
 
 - [ ] **Step 1: Write the parametrised failing test**
 
-Append to `tests/test_api_batch.py`:
+Append to `tests/test_batch.py`:
 
 ```python
 @pytest.mark.parametrize(
@@ -894,19 +977,13 @@ Append to `tests/test_api_batch.py`:
     ],
 )
 @respx.mock
-def test_batch_update_builds_the_right_path_for_every_pass_type(
-    mock_session, name, url_part
-):
+def test_batch_builds_the_right_path_for_every_pass_type(mock_session, name, url_part):
     """The sub-request path comes from the registry, so every type works."""
-    route = respx.post(str(Settings().batch_url)).mock(
-        return_value=httpx.Response(
-            200,
-            content=BATCH_RESPONSE.encode("utf-8"),
-            headers={"Content-Type": "multipart/mixed; boundary=rspboundary"},
-        )
-    )
+    route = _mock_batch_endpoint()
 
-    batch_update(name, [{"id": "issuer.one", "state": "EXPIRED"}])
+    batch = Batch()
+    batch.add_update(name, {"id": "issuer.one", "state": "EXPIRED"})
+    batch.execute()
 
     body = route.calls.last.request.content.decode("utf-8")
     assert f"PATCH /walletobjects/v1/{url_part}/issuer.one" in body
@@ -914,7 +991,7 @@ def test_batch_update_builds_the_right_path_for_every_pass_type(
 
 - [ ] **Step 2: Run it**
 
-Run: `uv run pytest tests/test_api_batch.py -k every_pass_type -v`
+Run: `uv run pytest tests/test_batch.py -k every_pass_type -v`
 Expected: PASS for all seven. If a type fails because `state` is not one of its fields,
 replace the payload for that type with an attribute it does have — do not weaken the
 assertion on the path.
@@ -926,39 +1003,56 @@ Add a section to `docs/tutorials.md`, after the update section:
 ````markdown
 ## Updating many passes at once
 
-`batch_update()` sends one request carrying a PATCH per object. It works for every pass
-type, and only the attributes you set are sent:
+A `Batch` collects updates and sends them as a single API call. Because the Google Wallet
+API is rate limited per call, a hundred updates in one batch cost what one update costs:
 
 ```python
 from edutap.wallet_google import api
 
-results = api.batch_update(
-    "LoyaltyObject",
-    [
-        {"id": "issuer.member-1", "state": "EXPIRED"},
-        {"id": "issuer.member-2", "state": "EXPIRED"},
-    ],
-)
+batch = api.Batch()
+batch.add_update("LoyaltyObject", {"id": "issuer.member-1", "state": "EXPIRED"})
+batch.add_update("LoyaltyObject", {"id": "issuer.member-2", "state": "EXPIRED"})
+results = batch.execute()
 
 for result in results:
     if not result.ok:
         print(f"{result.resource_id} failed: {result.error.message}")
 ```
 
+Only the attributes you set are sent, so a batch of small changes stays small on the wire.
+
+Pass types may be mixed in one batch — each sub-request carries its own path:
+
+```python
+batch = api.Batch()
+batch.add_update("LoyaltyObject", {"id": "issuer.member-1", "state": "EXPIRED"})
+batch.add_update("EventTicketObject", {"id": "issuer.ticket-9", "state": "USED"})
+```
+
+For the bulk case, add a whole list at once and use `len(batch)` to decide how much goes
+into one call:
+
+```python
+batch = api.Batch()
+batch.add_updates("LoyaltyObject", changed_members)
+print(f"sending {len(batch)} updates as one request")
+results = batch.execute()
+```
+
 A batch is **not** atomic: individual items can fail while the rest succeed, which is why
-failures come back as results rather than exceptions. There is one result per input item,
-in input order.
+failures come back as results rather than exceptions. There is one result per added
+sub-request, in the order they were added.
 
-`batch_update()` does not split, throttle or retry. The Google Wallet API is rate limited
-to 20 calls per second; deciding how many objects go into one batch, and how fast batches
-follow each other, is yours.
+`execute()` does not split, throttle or retry. The Google Wallet API is rate limited to 20
+calls per second; deciding how many objects go into one batch, and how fast batches follow
+each other, is yours.
 
-The asynchronous twin is `await api.abatch_update(...)` and behaves identically.
+The asynchronous twin is `await batch.aexecute()` and behaves identically.
 ````
 
-- [ ] **Step 4: Add the functions to the reference**
+- [ ] **Step 4: Add the class to the reference**
 
-Add `batch_update` and `abatch_update` to `docs/reference.md`, following whatever
+Add `Batch`, `BatchResult` and `BatchError` to `docs/reference.md`, following whatever
 structure the surrounding entries use.
 
 - [ ] **Step 5: Check the Markdown renders**
@@ -971,24 +1065,25 @@ the same level as their neighbours.
 - [ ] **Step 6: Commit**
 
 ```bash
-git add tests/test_api_batch.py docs/tutorials.md docs/reference.md
-git commit -m "docs(batch): document batch_update and cover all pass types"
+git add tests/test_batch.py docs/tutorials.md docs/reference.md
+git commit -m "docs(batch): document Batch and cover all pass types"
 ```
 
 ---
 
-### Task 5: The integration test that settles the open format question
+### Task 5: The integration test, and the measurements
 
 Task 1 encodes the parts as `Content-Type: application/json` because that is what Google's
 Wallet examples show, while Google's general batch protocol uses `application/http`. Only
-the real endpoint can say which it accepts. This task is also the first measurement of how
-many sub-requests actually fit.
+the real endpoint can say which it accepts. This task also produces the two numbers nobody
+has: whether a batch counts as one call, and how many sub-requests fit.
 
 **Files:**
 - Create: `tests/integration/test_batch.py`
+- Modify: `superpowers/plans/2026-08-17-batch-update.md` (this file, Step 6)
 
 **Interfaces:**
-- Consumes: `batch_update` from Task 2.
+- Consumes: `Batch` from Task 2.
 - Produces: no new code interfaces.
 
 - [ ] **Step 1: Read how the existing integration tests are set up**
@@ -1007,7 +1102,7 @@ proof the write landed.
 
 Run: `uvx tox -e py313 -- tests/integration/test_batch.py -v --run-integration`
 
-If it fails with a 400 on the format, switch `_PART_CONTENT_TYPE` in `batch.py` to
+If it fails with a 400 on the format, switch `_PART_CONTENT_TYPE` in `multipart.py` to
 `"application/http"` and — because that content type means each part carries a full HTTP
 message — the request line then needs an HTTP version suffix (`PATCH <path> HTTP/1.1`) and
 its own `Content-Type: application/json` header before the body. Adjust the Task 1 tests
@@ -1026,16 +1121,16 @@ turn it into something read off a graph:
 2. Send exactly one batch carrying a known number of sub-requests — 100 is a good size:
    large enough that the two outcomes cannot be confused, small enough to be harmless.
 3. Wait for the graph to catch up, then read the increment. **+1 confirms the assumption;
-   +100 refutes it** and means this whole feature buys connection overhead only, at which
-   point the parallel-`aupdate()` route deserves reconsideration.
+   +100 refutes it** and means this feature buys connection overhead only, at which point
+   parallel `aupdate()` calls deserve reconsideration.
 
 While in the console, also check **Quotas & System Limits** for the name and value of the
 quota metric that actually governs this API, and whether a separate batch quota exists.
 
 - [ ] **Step 5: Measure the ceiling**
 
-Still in the integration environment, not as a committed test: run `batch_update` with
-growing item counts (50, 200, 500, 1000) and record where it starts failing, and with what
+Still in the integration environment, not as a committed test: execute batches with
+growing sizes (50, 200, 500, 1000) and record where they start failing, and with what
 error.
 
 - [ ] **Step 6: Write the measurements down**
@@ -1072,11 +1167,13 @@ git commit -m "test(batch): add integration round-trip and record measured limit
 
 Each of these is a plausible next stage, and none belongs in this one:
 
-- **The driver** — chunking, throttling to 20 calls/s, retry, resume, progress reporting.
-  This is where a daily 70,000-object reconciliation actually gets decided, and it wants
-  its own design once the measured batch ceiling is known.
-- **`batch_create` and mixed-operation batches.** `BatchSubRequest` already carries the
-  method, so create is a small addition later; nothing here blocks it.
+- **The driver.** Chunking, throttling to 20 calls/s, retry, resume and progress
+  reporting. It arrives as keyword arguments to `execute()` — `chunk_size=None` keeps
+  today's meaning of one request, a set value splits transparently — so nothing in this
+  plan has to be undone to get there. This is where a daily 70,000-object reconciliation
+  actually gets decided, and it wants its own design once the measured ceiling is known.
+- **`add_create()` and other operations.** `SubRequest` already carries the method, and
+  `Batch` already mixes types, so adding create is a method on the existing class.
 - **Parsing results into models.** `BatchResult.body` stays a dict; adding a parsed model
   later does not break the signature.
 - **Delta detection.** Writing only genuinely changed objects would cut the daily volume

--- a/superpowers/plans/2026-08-17-batch-update.md
+++ b/superpowers/plans/2026-08-17-batch-update.md
@@ -702,6 +702,13 @@ It is deliberately *not* derived from `api_url`: the batch endpoint sits one lev
 
 Create `src/edutap/wallet_google/batch.py`:
 
+The listing below is the **as-built** implementation, synced after the final review.
+It differs from what this task originally prescribed: the original had neither the
+`isinstance(...)`/`try` guard around `BatchError.model_validate` (an ordinary Google
+error carrying `details` would have raised out of `execute()` and destroyed every
+result in the batch) nor the `elif` establishing the `not ok implies error` invariant.
+Both were added during review. Do not reintroduce the shorter version.
+
 ```python
 """Batch requests against the Google Wallet API.
 
@@ -870,9 +877,37 @@ class Batch:
                 continue
             body = sub_response.body
             error = None
-            if body is not None and "error" in body:
-                error = BatchError.model_validate(body["error"])
+            if body is not None and isinstance(body.get("error"), dict):
+                # Total by construction: no future shape of Google's error object
+                # may raise out of here and take the rest of the batch down with
+                # it -- that is exactly the contract this whole class exists to
+                # keep. BatchError.model_config already ignores unknown fields
+                # (see its docstring); this except is the backstop for whatever
+                # that config does not anticipate, e.g. a field of the wrong type.
+                try:
+                    error = BatchError.model_validate(body["error"])
+                except PydanticValidationError:
+                    error = BatchError(
+                        code=sub_response.status_code, message=str(body["error"])
+                    )
                 body = None
+            elif not (200 <= sub_response.status_code < 300):
+                # Invariant: BatchResult.ok is False implies BatchResult.error is
+                # not None. Google's protocol only guarantees an "error" key in
+                # the body for the errors it recognises; a non-2xx status can
+                # still arrive with no such key (or, per _parse_http_payload, a
+                # status line that could not even be parsed, degraded here to
+                # status_code=0). Without this branch, callers following the
+                # documented `if not result.ok: print(result.error.message)`
+                # pattern would hit AttributeError on error=None.
+                if sub_response.status_code == 0:
+                    message = "Sub-response status line could not be parsed."
+                else:
+                    message = (
+                        f"Sub-response returned status {sub_response.status_code} "
+                        "without an error body."
+                    )
+                error = BatchError(code=sub_response.status_code, message=message)
             results.append(
                 BatchResult(
                     index=index,

--- a/superpowers/plans/2026-08-17-batch-update.md
+++ b/superpowers/plans/2026-08-17-batch-update.md
@@ -1013,19 +1013,45 @@ message — the request line then needs an HTTP version suffix (`PATCH <path> HT
 its own `Content-Type: application/json` header before the body. Adjust the Task 1 tests
 to match, then re-run.
 
-- [ ] **Step 4: Measure the ceiling**
+- [ ] **Step 4: Confirm the one-call assumption in the Cloud Console**
+
+This step needs a human with console access; an agent cannot do it.
+
+The whole design rests on a batch counting as **one** call against the 20/s limit, and
+that is an operational finding rather than something Google documents. The console can
+turn it into something read off a graph:
+
+1. Note the current request count for `walletobjects.googleapis.com` under
+   **APIs & Services → Google Wallet API → Metrics**.
+2. Send exactly one batch carrying a known number of sub-requests — 100 is a good size:
+   large enough that the two outcomes cannot be confused, small enough to be harmless.
+3. Wait for the graph to catch up, then read the increment. **+1 confirms the assumption;
+   +100 refutes it** and means this whole feature buys connection overhead only, at which
+   point the parallel-`aupdate()` route deserves reconsideration.
+
+While in the console, also check **Quotas & System Limits** for the name and value of the
+quota metric that actually governs this API, and whether a separate batch quota exists.
+
+- [ ] **Step 5: Measure the ceiling**
 
 Still in the integration environment, not as a committed test: run `batch_update` with
 growing item counts (50, 200, 500, 1000) and record where it starts failing, and with what
 error.
 
-- [ ] **Step 5: Write the measurement down**
+- [ ] **Step 6: Write the measurements down**
 
-Add a short section to this plan file recording the numbers, dated, and labelled
-**measured** — what the endpoint did on the day we looked, not what Google guarantees.
-Anyone sizing a batch later needs to know which of those it is.
+Add a short section to this plan file recording, dated and labelled **measured** — what
+the endpoint did on the day we looked, not what Google guarantees:
 
-- [ ] **Step 6: Commit**
+- the console increment from Step 4 (+1 or +N) and therefore whether the one-call finding
+  holds;
+- the name and value of the governing quota metric;
+- the sub-request count at which batches start failing, and the error.
+
+Anyone sizing a batch later needs to know which of these are measured and which are
+documented. As of this writing, none of them is documented.
+
+- [ ] **Step 7: Commit**
 
 ```bash
 git add tests/integration/test_batch.py superpowers/plans/2026-08-17-batch-update.md
@@ -1039,6 +1065,7 @@ git commit -m "test(batch): add integration round-trip and record measured limit
 - [ ] `uvx tox -e py313` green.
 - [ ] `uvx tox -e lint` green.
 - [ ] Integration test green against the real API.
+- [ ] The Cloud Console increment confirms a batch counts as one call.
 - [ ] The measured sub-request ceiling is recorded in this file, labelled as measured.
 
 ## Deliberately out of scope

--- a/superpowers/plans/2026-08-17-batch-update.md
+++ b/superpowers/plans/2026-08-17-batch-update.md
@@ -50,8 +50,8 @@ should not pretend otherwise.
   Wallet pages and the FAQ are silent.
 - **Operational finding, not a documented guarantee** (maintainer, 2026-08-17): a batch
   counts as **one** request regardless of how many sub-requests it carries. This is why
-  batching is worth building — it turns 70,000 daily updates from roughly an hour of
-  wall-clock into minutes. Task 5 verifies it against the Cloud Console. Do not cite a
+  batching is worth building — it turns a daily run over tens of thousands of
+  objects from roughly an hour of wall-clock into minutes. Task 5 verifies it against the Cloud Console. Do not cite a
   Google URL for it; there isn't one.
 
 Consequence for the code: **no sub-request count is hard-coded anywhere.** A `Batch` takes
@@ -64,7 +64,7 @@ the caller decides what to do about it.
 part of the multipart body carries its own method and path, so there is no technical
 reason for the parts to share a pass type. It also makes the boundary visible — filling a
 `Batch` and calling `execute()` makes it obvious that one HTTP request is being built,
-where a function taking a 70,000-item list would hide that it produces a single request
+where a function taking a list of tens of thousands would hide that it produces one request
 running straight into a ceiling nobody has measured.
 
 **Sub-requests carry a `name` plus a plain dict, not a model instance.** `update()` today
@@ -1332,7 +1332,7 @@ Each of these is a plausible next stage, and none belongs in this one:
 - **The driver.** Chunking, throttling to 20 calls/s, retry, resume and progress
   reporting. It arrives as keyword arguments to `execute()` — `chunk_size=None` keeps
   today's meaning of one request, a set value splits transparently — so nothing in this
-  plan has to be undone to get there. This is where a daily 70,000-object reconciliation
+  plan has to be undone to get there. This is where a daily reconciliation over tens of thousands of objects
   actually gets decided, and it wants its own design once the measured ceiling is known.
 - **`add_create()` and other operations.** `SubRequest` already carries the method, and
   `Batch` already mixes types, so adding create is a method on the existing class.

--- a/superpowers/plans/2026-08-17-batch-update.md
+++ b/superpowers/plans/2026-08-17-batch-update.md
@@ -126,7 +126,7 @@ grows.
 | `tests/test_batch.py` | building and executing a batch, against respx (create) | 2, 4 |
 | `tests/test_batch_async.py` | `aexecute()` against respx (create) | 3 |
 | `docs/tutorials.md`, `docs/reference.md` | document the new API (modify) | 4 |
-| `tests/integration/test_batch.py` | round-trip against the real API (create) | 5 |
+| `tests/integration/test_batch_integration.py` | round-trip against the real API (create); the name may NOT be `test_batch.py` — `tests/` has no `__init__.py` and pytest runs in its default `prepend` import mode, so a second file of that basename collides with `tests/test_batch.py` | 5 |
 
 ---
 
@@ -1206,7 +1206,7 @@ the real endpoint can say which it accepts. This task also produces the two numb
 has: whether a batch counts as one call, and how many sub-requests fit.
 
 **Files:**
-- Create: `tests/integration/test_batch.py`
+- Create: `tests/integration/test_batch_integration.py`
 - Modify: `superpowers/plans/2026-08-17-batch-update.md` (this file, Step 6)
 
 **Interfaces:**
@@ -1220,14 +1220,14 @@ Read `tests/integration/test_CRULM.py`. Follow its credential handling, its
 
 - [ ] **Step 2: Write the round-trip test**
 
-Create `tests/integration/test_batch.py`. It must create two objects, batch-update one
+Create `tests/integration/test_batch_integration.py`. It must create two objects, batch-update one
 attribute on both, assert both results are `ok`, then read them back and assert the
 attribute actually changed. Reading back matters: a 200 in a batch part is not by itself
 proof the write landed.
 
 - [ ] **Step 3: Run it against the real API**
 
-Run: `uvx tox -e py313 -- tests/integration/test_batch.py -v --run-integration`
+Run: `uvx tox -e py313 -- tests/integration/test_batch_integration.py -v --run-integration`
 
 If it fails with a 400 on the format, switch `_PART_CONTENT_TYPE` in `multipart.py` to
 `"application/http"` and — because that content type means each part carries a full HTTP
@@ -1276,7 +1276,7 @@ documented. As of this writing, none of them is documented.
 - [ ] **Step 7: Commit**
 
 ```bash
-git add tests/integration/test_batch.py superpowers/plans/2026-08-17-batch-update.md
+git add tests/integration/test_batch_integration.py superpowers/plans/2026-08-17-batch-update.md
 git commit -m "test(batch): add integration round-trip and record measured limits"
 ```
 

--- a/tests/integration/test_batch_integration.py
+++ b/tests/integration/test_batch_integration.py
@@ -1,0 +1,88 @@
+"""Integration test for Batch against the real Google Wallet API.
+
+A 200 status inside a batch part is not by itself proof that the write
+landed -- it only proves Google accepted the part. This test reads the
+objects back afterwards to prove the attribute actually changed server-side.
+
+Google Wallet objects cannot be deleted, so every id used here must be
+unique per run (see ``integration_test_id``) and nothing is torn down
+afterwards -- the created objects persist in the test issuer account.
+"""
+
+import pytest
+
+
+@pytest.mark.integration
+def test_batch_update_round_trip(integration_test_id):
+    """Batch-update one attribute on two objects, then read both back.
+
+    Creates a class and two GenericObjects (state=INACTIVE), sends one
+    Batch with an update for each object (state=ACTIVE), asserts both
+    results are ok, then reads both objects back and asserts the state
+    change actually landed.
+    """
+    from edutap.wallet_google import api
+    from edutap.wallet_google.clientpool import client_pool
+
+    import time
+
+    class_type = "GenericClass"
+    object_type = "GenericObject"
+
+    ############################
+    # class, required as classId for the objects
+    class_base = f"{integration_test_id}.{class_type}.test_batch.wallet_google.edutap"
+    class_id = f"{client_pool.settings.test_issuer_id}.{class_base}"
+    class_data = api.new(class_type, {"id": class_id})
+    api.create(class_data)
+
+    ############################
+    # two objects to batch-update
+    object_ids = [
+        f"{client_pool.settings.test_issuer_id}."
+        f"{integration_test_id}.{object_type}.test_batch.{n}.wallet_google.edutap"
+        for n in (1, 2)
+    ]
+    for object_id in object_ids:
+        object_data = api.new(
+            object_type,
+            {
+                "id": object_id,
+                "classId": class_id,
+                "state": "INACTIVE",
+            },
+        )
+        result_create = api.create(object_data)
+        assert result_create is not None
+        assert result_create.state == "INACTIVE"
+
+    ############################
+    # one batch request updating both objects' state
+    batch = api.Batch()
+    batch.add_updates(
+        object_type,
+        [{"id": object_id, "state": "ACTIVE"} for object_id in object_ids],
+    )
+    assert len(batch) == 2
+
+    results = batch.execute()
+
+    assert len(results) == 2
+    for object_id, result in zip(object_ids, results):
+        assert result.ok is True, (
+            f"Batch update for '{object_id}' failed: "
+            f"{result.error.message if result.error else 'unknown error'}"
+        )
+        assert result.resource_id == object_id
+        assert result.body is not None
+        assert result.body["state"] == "ACTIVE"
+
+    # relax - not sure if this is necessary
+    time.sleep(0.05)
+
+    ############################
+    # read both objects back -- the actual proof the write landed
+    for object_id in object_ids:
+        result_read = api.read(name=object_type, resource_id=object_id)
+        assert result_read is not None
+        assert result_read.state == "ACTIVE"

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -456,3 +456,100 @@ def test_execute_sends_matching_content_type_header_and_boundary(mock_session):
     boundary = content_type.split("boundary=", 1)[1]
     body = request.content.decode("utf-8")
     assert f"--{boundary}" in body
+
+
+@respx.mock
+def test_add_create_posts_to_the_collection_path(mock_session):
+    """Create is a POST to the type's collection, with no id in the path."""
+    route = _mock_batch_endpoint()
+
+    batch = Batch()
+    batch.add_create(
+        "GenericObject",
+        {"id": "issuer.new-one", "classId": "issuer.class", "state": "ACTIVE"},
+    )
+    batch.execute()
+
+    body = route.calls.last.request.content.decode("utf-8")
+    assert "POST /walletobjects/v1/genericObject" in body
+    # the id belongs in the payload, not the path
+    assert "POST /walletobjects/v1/genericObject/issuer.new-one" not in body
+    assert '"id":"issuer.new-one"' in body.replace(" ", "")
+
+
+def test_add_create_requires_the_models_required_fields():
+    """Unlike add_update, create does not relax required fields."""
+    batch = Batch()
+
+    with pytest.raises(ValueError) as exc_info:
+        batch.add_create("GenericObject", {"id": "issuer.new-one"})
+
+    assert "classId" in str(exc_info.value)
+
+
+@respx.mock
+def test_a_batch_may_mix_creates_and_updates(mock_session):
+    """Method is per sub-request, so both fit in one batch."""
+    route = _mock_batch_endpoint()
+
+    batch = Batch()
+    batch.add_create(
+        "GenericObject",
+        {"id": "issuer.new-one", "classId": "issuer.class", "state": "ACTIVE"},
+    )
+    batch.add_update("GenericObject", {"id": "issuer.old-one", "state": "EXPIRED"})
+    batch.execute()
+
+    body = route.calls.last.request.content.decode("utf-8")
+    assert "POST /walletobjects/v1/genericObject" in body
+    assert "PATCH /walletobjects/v1/genericObject/issuer.old-one" in body
+
+
+def test_add_creates_appends_a_whole_list():
+    """The bulk case must not need one call per object."""
+    batch = Batch()
+    batch.add_creates(
+        "GenericObject",
+        [
+            {"id": f"issuer.{n}", "classId": "issuer.class", "state": "ACTIVE"}
+            for n in range(5)
+        ],
+    )
+
+    assert len(batch) == 5
+
+
+@respx.mock
+def test_an_already_existing_object_comes_back_as_a_result(mock_session):
+    """409 is the common create failure and must not raise."""
+    conflict = (
+        "--rspboundary\r\n"
+        "Content-Type: application/http\r\n"
+        "Content-ID: <response-item-0>\r\n"
+        "\r\n"
+        "HTTP/1.1 409 Conflict\r\n"
+        "Content-Type: application/json\r\n"
+        "\r\n"
+        '{"error": {"code": 409, "message": "already exists", '
+        '"status": "ALREADY_EXISTS"}}\r\n'
+        "\r\n"
+        "--rspboundary--\r\n"
+    )
+    respx.post(str(Settings().batch_url)).mock(
+        return_value=httpx.Response(
+            200,
+            content=conflict.encode("utf-8"),
+            headers={"Content-Type": "multipart/mixed; boundary=rspboundary"},
+        )
+    )
+
+    batch = Batch()
+    batch.add_create(
+        "GenericObject",
+        {"id": "issuer.new-one", "classId": "issuer.class", "state": "ACTIVE"},
+    )
+    results = batch.execute()
+
+    assert results[0].ok is False
+    assert results[0].error is not None
+    assert results[0].error.code == 409

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,0 +1,209 @@
+"""Tests for building and executing a Batch."""
+
+from edutap.wallet_google.batch import Batch
+from edutap.wallet_google.settings import Settings
+
+import httpx
+import pytest
+import respx
+
+
+MULTIPART_RESPONSE = (
+    "--rspboundary\r\n"
+    "Content-Type: application/http\r\n"
+    "Content-ID: <response-item-0>\r\n"
+    "\r\n"
+    "HTTP/1.1 200 OK\r\n"
+    "Content-Type: application/json\r\n"
+    "\r\n"
+    '{"id": "issuer.one", "state": "EXPIRED"}\r\n'
+    "\r\n"
+    "--rspboundary\r\n"
+    "Content-Type: application/http\r\n"
+    "Content-ID: <response-item-1>\r\n"
+    "\r\n"
+    "HTTP/1.1 404 Not Found\r\n"
+    "Content-Type: application/json\r\n"
+    "\r\n"
+    '{"error": {"code": 404, "message": "not found", "status": "NOT_FOUND"}}\r\n'
+    "\r\n"
+    "--rspboundary--\r\n"
+)
+
+
+def _mock_batch_endpoint():
+    """Point the batch endpoint at a canned two-part response."""
+    return respx.post(str(Settings().batch_url)).mock(
+        return_value=httpx.Response(
+            200,
+            content=MULTIPART_RESPONSE.encode("utf-8"),
+            headers={"Content-Type": "multipart/mixed; boundary=rspboundary"},
+        )
+    )
+
+
+def test_len_counts_the_added_sub_requests():
+    """A Batch is one HTTP request; len() is how the caller sees its size."""
+    batch = Batch()
+    batch.add_update("GenericObject", {"id": "issuer.one", "state": "EXPIRED"})
+    batch.add_update("LoyaltyObject", {"id": "issuer.two", "state": "ACTIVE"})
+
+    assert len(batch) == 2
+
+
+@respx.mock
+def test_execute_sends_one_request_and_returns_one_result_per_item(mock_session):
+    """Two updates go out as a single POST and come back as two results."""
+    route = _mock_batch_endpoint()
+
+    batch = Batch()
+    batch.add_update("GenericObject", {"id": "issuer.one", "state": "EXPIRED"})
+    batch.add_update("GenericObject", {"id": "issuer.two", "state": "ACTIVE"})
+    results = batch.execute()
+
+    assert route.call_count == 1
+    assert len(results) == 2
+    assert results[0].ok is True
+    assert results[0].resource_id == "issuer.one"
+    assert results[0].body is not None
+    assert results[0].body["state"] == "EXPIRED"
+    assert results[1].ok is False
+    assert results[1].error.code == 404
+    assert results[1].error.message == "not found"
+
+
+@respx.mock
+def test_a_batch_may_mix_pass_types(mock_session):
+    """Each part carries its own path, so types need not match."""
+    route = _mock_batch_endpoint()
+
+    batch = Batch()
+    batch.add_update("GenericObject", {"id": "issuer.one", "state": "EXPIRED"})
+    batch.add_update("EventTicketObject", {"id": "issuer.two", "state": "ACTIVE"})
+    results = batch.execute()
+
+    body = route.calls.last.request.content.decode("utf-8")
+    assert "PATCH /walletobjects/v1/genericObject/issuer.one" in body
+    assert "PATCH /walletobjects/v1/eventTicketObject/issuer.two" in body
+    assert [r.name for r in results] == ["GenericObject", "EventTicketObject"]
+
+
+@respx.mock
+def test_execute_sends_only_the_attributes_that_were_set(mock_session):
+    """A two-attribute PATCH must not carry the rest of the model."""
+    route = _mock_batch_endpoint()
+
+    batch = Batch()
+    batch.add_update("GenericObject", {"id": "issuer.one", "state": "EXPIRED"})
+    batch.execute()
+
+    body = route.calls.last.request.content.decode("utf-8")
+    assert '"state"' in body
+    assert '"classId"' not in body
+
+
+def test_add_updates_appends_a_whole_list():
+    """The bulk case must not need one call per object."""
+    batch = Batch()
+    batch.add_updates(
+        "LoyaltyObject",
+        [{"id": f"issuer.{n}", "state": "EXPIRED"} for n in range(5)],
+    )
+
+    assert len(batch) == 5
+
+
+def test_add_update_rejects_an_unknown_attribute():
+    """Typos fail on the line that caused them, not at execute() time."""
+    batch = Batch()
+
+    with pytest.raises(ValueError) as exc_info:
+        batch.add_update("GenericObject", {"id": "issuer.one", "notAField": 1})
+
+    assert "notAField" in str(exc_info.value)
+
+
+def test_add_update_requires_the_resource_id():
+    """Without an id there is nothing to PATCH."""
+    batch = Batch()
+
+    with pytest.raises(ValueError) as exc_info:
+        batch.add_update("GenericObject", {"state": "EXPIRED"})
+
+    assert "id" in str(exc_info.value)
+
+
+def test_executing_an_empty_batch_makes_no_request():
+    """Nothing added, nothing sent."""
+    batch = Batch()
+
+    assert batch.execute() == []
+
+
+@respx.mock
+def test_sub_requests_are_grouped_by_pass_type_on_the_wire(mock_session):
+    """Batch may reorder internally; interleaved types come out grouped."""
+    route = _mock_batch_endpoint()
+
+    batch = Batch()
+    batch.add_update("GenericObject", {"id": "issuer.g1", "state": "EXPIRED"})
+    batch.add_update("LoyaltyObject", {"id": "issuer.l1", "state": "EXPIRED"})
+    batch.add_update("GenericObject", {"id": "issuer.g2", "state": "EXPIRED"})
+    batch.execute()
+
+    body = route.calls.last.request.content.decode("utf-8")
+    positions = [
+        body.index("genericObject/issuer.g1"),
+        body.index("genericObject/issuer.g2"),
+        body.index("loyaltyObject/issuer.l1"),
+    ]
+    assert positions == sorted(positions), "the two genericObjects should be adjacent"
+
+
+@respx.mock
+def test_results_follow_add_order_even_when_the_server_shuffles(mock_session):
+    """The invariant: add order is result order, whatever happens in between.
+
+    The canned response deliberately returns item-1 before item-0, which is what
+    correlation by Content-ID is for.
+    """
+    shuffled = (
+        "--rspboundary\r\n"
+        "Content-Type: application/http\r\n"
+        "Content-ID: <response-item-1>\r\n"
+        "\r\n"
+        "HTTP/1.1 200 OK\r\n"
+        "Content-Type: application/json\r\n"
+        "\r\n"
+        '{"id": "issuer.two"}\r\n'
+        "\r\n"
+        "--rspboundary\r\n"
+        "Content-Type: application/http\r\n"
+        "Content-ID: <response-item-0>\r\n"
+        "\r\n"
+        "HTTP/1.1 200 OK\r\n"
+        "Content-Type: application/json\r\n"
+        "\r\n"
+        '{"id": "issuer.one"}\r\n'
+        "\r\n"
+        "--rspboundary--\r\n"
+    )
+    respx.post(str(Settings().batch_url)).mock(
+        return_value=httpx.Response(
+            200,
+            content=shuffled.encode("utf-8"),
+            headers={"Content-Type": "multipart/mixed; boundary=rspboundary"},
+        )
+    )
+
+    batch = Batch()
+    batch.add_update("GenericObject", {"id": "issuer.one", "state": "EXPIRED"})
+    batch.add_update("LoyaltyObject", {"id": "issuer.two", "state": "EXPIRED"})
+    results = batch.execute()
+
+    assert [r.resource_id for r in results] == ["issuer.one", "issuer.two"]
+    assert [r.index for r in results] == [0, 1]
+    assert results[0].body is not None
+    assert results[1].body is not None
+    assert results[0].body["id"] == "issuer.one"
+    assert results[1].body["id"] == "issuer.two"

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -207,3 +207,28 @@ def test_results_follow_add_order_even_when_the_server_shuffles(mock_session):
     assert results[1].body is not None
     assert results[0].body["id"] == "issuer.one"
     assert results[1].body["id"] == "issuer.two"
+
+
+@pytest.mark.parametrize(
+    "name,url_part",
+    [
+        ("GenericObject", "genericObject"),
+        ("LoyaltyObject", "loyaltyObject"),
+        ("OfferObject", "offerObject"),
+        ("GiftCardObject", "giftCardObject"),
+        ("EventTicketObject", "eventTicketObject"),
+        ("TransitObject", "transitObject"),
+        ("FlightObject", "flightObject"),
+    ],
+)
+@respx.mock
+def test_batch_builds_the_right_path_for_every_pass_type(mock_session, name, url_part):
+    """The sub-request path comes from the registry, so every type works."""
+    route = _mock_batch_endpoint()
+
+    batch = Batch()
+    batch.add_update(name, {"id": "issuer.one", "state": "EXPIRED"})
+    batch.execute()
+
+    body = route.calls.last.request.content.decode("utf-8")
+    assert f"PATCH /walletobjects/v1/{url_part}/issuer.one" in body

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -388,12 +388,19 @@ def test_results_correlate_correctly_when_wire_order_differs_from_add_order(
 ):
     """Reordering (grouping by pass type) and correlation must work together: each
     result's body must match its own resource_id, not the one that happened to land
-    in the same wire position.
+    in the same wire position. A create is mixed in with the updates, since
+    add_create shares the same _append_sub_request tail and must stay just as
+    index-aligned.
     """
     batch = Batch()
-    # Add order: Loyalty, Generic, Loyalty -- wire order groups by type, so this
-    # differs from add order for at least one item.
-    batch.add_update("LoyaltyObject", {"id": "issuer.l1", "state": "EXPIRED"})
+    # Add order: Loyalty create, Generic update, Loyalty update -- wire order
+    # groups by type, so the Loyalty create (added first) lands on the wire
+    # after the Generic update, genuinely moving it away from its add-order
+    # position.
+    batch.add_create(
+        "LoyaltyObject",
+        {"id": "issuer.l1", "classId": "issuer.loyalty-class", "state": "ACTIVE"},
+    )
     batch.add_update("GenericObject", {"id": "issuer.g1", "state": "ACTIVE"})
     batch.add_update("LoyaltyObject", {"id": "issuer.l2", "state": "EXPIRED"})
 
@@ -402,6 +409,12 @@ def test_results_correlate_correctly_when_wire_order_differs_from_add_order(
     def _respond(request: httpx.Request) -> httpx.Response:
         nonlocal body
         body = request.content.decode("utf-8")
+        # Confirm the reordering actually happened before trusting the rest of
+        # the test: the Loyalty create must be grouped with the Loyalty update,
+        # after the Generic update.
+        assert body.index("POST /walletobjects/v1/loyaltyObject") > body.index(
+            "PATCH /walletobjects/v1/genericObject/issuer.g1"
+        )
         # Build a response whose Content-IDs correlate by content, not by wire
         # position, and whose part order does not match request part order either.
         parts = []

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,6 +1,7 @@
 """Tests for building and executing a Batch."""
 
 from edutap.wallet_google.batch import Batch
+from edutap.wallet_google.exceptions import QuotaExceededException
 from edutap.wallet_google.settings import Settings
 
 import httpx
@@ -298,3 +299,160 @@ def test_result_has_an_error_when_the_status_line_could_not_be_parsed(mock_sessi
     assert results[0].ok is False
     assert results[0].error is not None
     assert results[0].error.message  # must not raise, must not be empty
+
+
+@respx.mock
+def test_a_normally_shaped_google_error_does_not_destroy_the_whole_batch(mock_session):
+    """A real Google error body carries `details` (and sometimes `errors`); it must not
+    make BatchError.model_validate() raise and discard every result in the batch,
+    including the successful ones sitting right next to it.
+    """
+    realistic_error_and_a_success = (
+        "--rspboundary\r\n"
+        "Content-Type: application/http\r\n"
+        "Content-ID: <response-item-0>\r\n"
+        "\r\n"
+        "HTTP/1.1 400 Bad Request\r\n"
+        "Content-Type: application/json\r\n"
+        "\r\n"
+        '{"error": {"code": 400, "message": "bad", "status": "INVALID_ARGUMENT", '
+        '"details": [{"@type": "type.googleapis.com/google.rpc.BadRequest"}], '
+        '"errors": [{"message": "bad", "domain": "global", "reason": "invalid"}]}}\r\n'
+        "\r\n"
+        "--rspboundary\r\n"
+        "Content-Type: application/http\r\n"
+        "Content-ID: <response-item-1>\r\n"
+        "\r\n"
+        "HTTP/1.1 200 OK\r\n"
+        "Content-Type: application/json\r\n"
+        "\r\n"
+        '{"id": "issuer.two", "state": "EXPIRED"}\r\n'
+        "\r\n"
+        "--rspboundary--\r\n"
+    )
+    respx.post(str(Settings().batch_url)).mock(
+        return_value=httpx.Response(
+            200,
+            content=realistic_error_and_a_success.encode("utf-8"),
+            headers={"Content-Type": "multipart/mixed; boundary=rspboundary"},
+        )
+    )
+
+    batch = Batch()
+    batch.add_update("GenericObject", {"id": "issuer.one", "state": "EXPIRED"})
+    batch.add_update("GenericObject", {"id": "issuer.two", "state": "EXPIRED"})
+    results = batch.execute()
+
+    assert results[0].ok is False
+    assert results[0].error is not None
+    assert results[0].error.code == 400
+    assert results[0].error.message == "bad"
+    # The point: a realistically-shaped error must not take the successful
+    # sub-request down with it.
+    assert results[1].ok is True
+    assert results[1].body is not None
+    assert results[1].body["id"] == "issuer.two"
+
+
+@respx.mock
+def test_batch_post_failure_raises_instead_of_returning_results(mock_session):
+    """A 403 quota response to the batch POST itself must raise, not be handed to
+    decode_multipart as if it were a multipart body.
+    """
+    respx.post(str(Settings().batch_url)).mock(
+        return_value=httpx.Response(
+            403,
+            json={
+                "error": {
+                    "code": 403,
+                    "message": (
+                        "Quota exceeded for quota metric 'Write requests' and "
+                        "limit 'Write requests per day'"
+                    ),
+                    "status": "RESOURCE_EXHAUSTED",
+                }
+            },
+        )
+    )
+
+    batch = Batch()
+    batch.add_update("GenericObject", {"id": "issuer.one", "state": "EXPIRED"})
+
+    with pytest.raises(QuotaExceededException):
+        batch.execute()
+
+
+@respx.mock
+def test_results_correlate_correctly_when_wire_order_differs_from_add_order(
+    mock_session,
+):
+    """Reordering (grouping by pass type) and correlation must work together: each
+    result's body must match its own resource_id, not the one that happened to land
+    in the same wire position.
+    """
+    batch = Batch()
+    # Add order: Loyalty, Generic, Loyalty -- wire order groups by type, so this
+    # differs from add order for at least one item.
+    batch.add_update("LoyaltyObject", {"id": "issuer.l1", "state": "EXPIRED"})
+    batch.add_update("GenericObject", {"id": "issuer.g1", "state": "ACTIVE"})
+    batch.add_update("LoyaltyObject", {"id": "issuer.l2", "state": "EXPIRED"})
+
+    body = None
+
+    def _respond(request: httpx.Request) -> httpx.Response:
+        nonlocal body
+        body = request.content.decode("utf-8")
+        # Build a response whose Content-IDs correlate by content, not by wire
+        # position, and whose part order does not match request part order either.
+        parts = []
+        for content_id, resource_id in [
+            ("item-2", "issuer.l2"),
+            ("item-0", "issuer.l1"),
+            ("item-1", "issuer.g1"),
+        ]:
+            parts.append(
+                "--rspboundary\r\n"
+                "Content-Type: application/http\r\n"
+                f"Content-ID: <response-{content_id}>\r\n"
+                "\r\n"
+                "HTTP/1.1 200 OK\r\n"
+                "Content-Type: application/json\r\n"
+                "\r\n"
+                f'{{"id": "{resource_id}"}}\r\n'
+                "\r\n"
+            )
+        parts.append("--rspboundary--\r\n")
+        return httpx.Response(
+            200,
+            content="".join(parts).encode("utf-8"),
+            headers={"Content-Type": "multipart/mixed; boundary=rspboundary"},
+        )
+
+    respx.post(str(Settings().batch_url)).mock(side_effect=_respond)
+
+    results = batch.execute()
+
+    assert [r.resource_id for r in results] == ["issuer.l1", "issuer.g1", "issuer.l2"]
+    for result in results:
+        assert result.body is not None
+        assert result.body["id"] == result.resource_id
+
+
+@respx.mock
+def test_execute_sends_matching_content_type_header_and_boundary(mock_session):
+    """The Content-Type header must announce multipart/mixed with a boundary that
+    matches the one actually used in the body -- a mismatch here would leave the
+    suite green while making every real request fail.
+    """
+    _mock_batch_endpoint()
+
+    batch = Batch()
+    batch.add_update("GenericObject", {"id": "issuer.one", "state": "EXPIRED"})
+    batch.execute()
+
+    request = respx.calls.last.request
+    content_type = request.headers["Content-Type"]
+    assert content_type.startswith("multipart/mixed; boundary=")
+    boundary = content_type.split("boundary=", 1)[1]
+    body = request.content.decode("utf-8")
+    assert f"--{boundary}" in body

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -232,3 +232,69 @@ def test_batch_builds_the_right_path_for_every_pass_type(mock_session, name, url
 
     body = route.calls.last.request.content.decode("utf-8")
     assert f"PATCH /walletobjects/v1/{url_part}/issuer.one" in body
+
+
+@respx.mock
+def test_result_has_an_error_when_the_server_returns_non_2xx_without_an_error_body(
+    mock_session,
+):
+    """ok is False must never leave error as None; callers read error.message."""
+    no_error_body = (
+        "--rspboundary\r\n"
+        "Content-Type: application/http\r\n"
+        "Content-ID: <response-item-0>\r\n"
+        "\r\n"
+        "HTTP/1.1 500 Internal Server Error\r\n"
+        "Content-Type: application/json\r\n"
+        "\r\n"
+        '{"unexpected": "shape"}\r\n'
+        "\r\n"
+        "--rspboundary--\r\n"
+    )
+    respx.post(str(Settings().batch_url)).mock(
+        return_value=httpx.Response(
+            200,
+            content=no_error_body.encode("utf-8"),
+            headers={"Content-Type": "multipart/mixed; boundary=rspboundary"},
+        )
+    )
+
+    batch = Batch()
+    batch.add_update("GenericObject", {"id": "issuer.one", "state": "EXPIRED"})
+    results = batch.execute()
+
+    assert results[0].ok is False
+    assert results[0].error is not None
+    assert results[0].error.message  # must not raise, must not be empty
+
+
+@respx.mock
+def test_result_has_an_error_when_the_status_line_could_not_be_parsed(mock_session):
+    """A malformed status line degrades to status_code=0, not to error=None."""
+    malformed_status_line = (
+        "--rspboundary\r\n"
+        "Content-Type: application/http\r\n"
+        "Content-ID: <response-item-0>\r\n"
+        "\r\n"
+        "GARBAGE NOT A STATUS LINE\r\n"
+        "Content-Type: application/json\r\n"
+        "\r\n"
+        "\r\n"
+        "--rspboundary--\r\n"
+    )
+    respx.post(str(Settings().batch_url)).mock(
+        return_value=httpx.Response(
+            200,
+            content=malformed_status_line.encode("utf-8"),
+            headers={"Content-Type": "multipart/mixed; boundary=rspboundary"},
+        )
+    )
+
+    batch = Batch()
+    batch.add_update("GenericObject", {"id": "issuer.one", "state": "EXPIRED"})
+    results = batch.execute()
+
+    assert results[0].status_code == 0
+    assert results[0].ok is False
+    assert results[0].error is not None
+    assert results[0].error.message  # must not raise, must not be empty

--- a/tests/test_batch_async.py
+++ b/tests/test_batch_async.py
@@ -1,0 +1,61 @@
+"""Tests for Batch.aexecute()."""
+
+from edutap.wallet_google.batch import Batch
+from edutap.wallet_google.settings import Settings
+
+import httpx
+import pytest
+import respx
+
+
+MULTIPART_RESPONSE = (
+    "--rspboundary\r\n"
+    "Content-Type: application/http\r\n"
+    "Content-ID: <response-item-0>\r\n"
+    "\r\n"
+    "HTTP/1.1 200 OK\r\n"
+    "Content-Type: application/json\r\n"
+    "\r\n"
+    '{"id": "issuer.one", "state": "EXPIRED"}\r\n'
+    "\r\n"
+    "--rspboundary\r\n"
+    "Content-Type: application/http\r\n"
+    "Content-ID: <response-item-1>\r\n"
+    "\r\n"
+    "HTTP/1.1 404 Not Found\r\n"
+    "Content-Type: application/json\r\n"
+    "\r\n"
+    '{"error": {"code": 404, "message": "not found", "status": "NOT_FOUND"}}\r\n'
+    "\r\n"
+    "--rspboundary--\r\n"
+)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_aexecute_matches_the_sync_behaviour(mock_async_session):
+    """One POST, one result per item, failures reported not raised."""
+    route = respx.post(str(Settings().batch_url)).mock(
+        return_value=httpx.Response(
+            200,
+            content=MULTIPART_RESPONSE.encode("utf-8"),
+            headers={"Content-Type": "multipart/mixed; boundary=rspboundary"},
+        )
+    )
+
+    batch = Batch()
+    batch.add_update("LoyaltyObject", {"id": "issuer.one", "state": "EXPIRED"})
+    batch.add_update("LoyaltyObject", {"id": "issuer.two", "state": "ACTIVE"})
+    results = await batch.aexecute()
+
+    assert route.call_count == 1
+    assert len(results) == 2
+    assert results[0].ok is True
+    assert results[1].ok is False
+    assert results[1].error.code == 404
+
+
+@pytest.mark.asyncio
+async def test_aexecute_on_an_empty_batch_makes_no_request(mock_async_session):
+    """Nothing added, nothing sent."""
+    assert await Batch().aexecute() == []

--- a/tests/test_batch_async.py
+++ b/tests/test_batch_async.py
@@ -1,6 +1,7 @@
 """Tests for Batch.aexecute()."""
 
 from edutap.wallet_google.batch import Batch
+from edutap.wallet_google.exceptions import QuotaExceededException
 from edutap.wallet_google.settings import Settings
 
 import httpx
@@ -59,3 +60,34 @@ async def test_aexecute_matches_the_sync_behaviour(mock_async_session):
 async def test_aexecute_on_an_empty_batch_makes_no_request(mock_async_session):
     """Nothing added, nothing sent."""
     assert await Batch().aexecute() == []
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_aexecute_batch_post_failure_raises_instead_of_returning_results(
+    mock_async_session,
+):
+    """A 403 quota response to the batch POST itself must raise, not be handed to
+    decode_multipart as if it were a multipart body.
+    """
+    respx.post(str(Settings().batch_url)).mock(
+        return_value=httpx.Response(
+            403,
+            json={
+                "error": {
+                    "code": 403,
+                    "message": (
+                        "Quota exceeded for quota metric 'Write requests' and "
+                        "limit 'Write requests per day'"
+                    ),
+                    "status": "RESOURCE_EXHAUSTED",
+                }
+            },
+        )
+    )
+
+    batch = Batch()
+    batch.add_update("GenericObject", {"id": "issuer.one", "state": "EXPIRED"})
+
+    with pytest.raises(QuotaExceededException):
+        await batch.aexecute()

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -1,0 +1,81 @@
+"""Tests for multipart/mixed encoding and decoding."""
+
+from edutap.wallet_google.multipart import decode_multipart
+from edutap.wallet_google.multipart import encode_multipart
+from edutap.wallet_google.multipart import SubRequest
+
+
+def test_encode_produces_one_part_per_sub_request():
+    """Each sub-request becomes a delimited part carrying method, path and body."""
+    sub_requests = [
+        SubRequest(
+            method="PATCH",
+            path="/walletobjects/v1/genericObject/issuer.one",
+            body='{"state":"EXPIRED"}',
+            content_id="item-0",
+        ),
+        SubRequest(
+            method="PATCH",
+            path="/walletobjects/v1/loyaltyObject/issuer.two",
+            body='{"state":"ACTIVE"}',
+            content_id="item-1",
+        ),
+    ]
+
+    encoded = encode_multipart(sub_requests, boundary="testboundary").decode("utf-8")
+
+    assert encoded.count("--testboundary\r\n") == 2
+    assert encoded.endswith("--testboundary--\r\n")
+    assert "Content-ID: <item-0>" in encoded
+    assert "Content-ID: <item-1>" in encoded
+    assert "PATCH /walletobjects/v1/genericObject/issuer.one" in encoded
+    assert "PATCH /walletobjects/v1/loyaltyObject/issuer.two" in encoded
+    assert '{"state":"EXPIRED"}' in encoded
+
+
+MULTIPART_RESPONSE = (
+    "--rspboundary\r\n"
+    "Content-Type: application/http\r\n"
+    "Content-ID: <response-item-0>\r\n"
+    "\r\n"
+    "HTTP/1.1 200 OK\r\n"
+    "Content-Type: application/json\r\n"
+    "\r\n"
+    '{"id": "issuer.one", "state": "EXPIRED"}\r\n'
+    "\r\n"
+    "--rspboundary\r\n"
+    "Content-Type: application/http\r\n"
+    "Content-ID: <response-item-1>\r\n"
+    "\r\n"
+    "HTTP/1.1 404 Not Found\r\n"
+    "Content-Type: application/json\r\n"
+    "\r\n"
+    '{"error": {"code": 404, "message": "not found", "status": "NOT_FOUND"}}\r\n'
+    "\r\n"
+    "--rspboundary--\r\n"
+)
+
+
+def test_decode_returns_one_sub_response_per_part():
+    """Status code, body and Content-ID are recovered from each part."""
+    responses = decode_multipart(
+        MULTIPART_RESPONSE.encode("utf-8"),
+        "multipart/mixed; boundary=rspboundary",
+    )
+
+    assert len(responses) == 2
+    assert responses[0].status_code == 200
+    assert responses[0].body == {"id": "issuer.one", "state": "EXPIRED"}
+    assert responses[1].status_code == 404
+    assert responses[1].body is not None
+    assert responses[1].body["error"]["code"] == 404
+
+
+def test_decode_strips_the_response_prefix_from_content_id():
+    """Google echoes Content-ID with a 'response-' prefix; we map back to ours."""
+    responses = decode_multipart(
+        MULTIPART_RESPONSE.encode("utf-8"),
+        "multipart/mixed; boundary=rspboundary",
+    )
+
+    assert [r.content_id for r in responses] == ["item-0", "item-1"]

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -79,3 +79,32 @@ def test_decode_strips_the_response_prefix_from_content_id():
     )
 
     assert [r.content_id for r in responses] == ["item-0", "item-1"]
+
+
+MALFORMED_STATUS_LINE_RESPONSE = (
+    "--rspboundary\r\n"
+    "Content-Type: application/http\r\n"
+    "Content-ID: <response-item-0>\r\n"
+    "\r\n"
+    "not a valid status line\r\n"
+    "Content-Type: application/json\r\n"
+    "\r\n"
+    '{"id": "issuer.one"}\r\n'
+    "\r\n"
+    "--rspboundary--\r\n"
+)
+
+
+def test_decode_returns_status_code_zero_for_malformed_status_line():
+    """A part with a malformed status line must not crash the whole decode.
+
+    One malformed part in a batch of hundreds must degrade to a result,
+    not blow up the entire ``decode_multipart`` call.
+    """
+    responses = decode_multipart(
+        MALFORMED_STATUS_LINE_RESPONSE.encode("utf-8"),
+        "multipart/mixed; boundary=rspboundary",
+    )
+
+    assert len(responses) == 1
+    assert responses[0].status_code == 0

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -1,5 +1,6 @@
 """Tests for multipart/mixed encoding and decoding."""
 
+from edutap.wallet_google.multipart import _PART_CONTENT_TYPE
 from edutap.wallet_google.multipart import decode_multipart
 from edutap.wallet_google.multipart import encode_multipart
 from edutap.wallet_google.multipart import SubRequest
@@ -108,3 +109,130 @@ def test_decode_returns_status_code_zero_for_malformed_status_line():
 
     assert len(responses) == 1
     assert responses[0].status_code == 0
+
+
+NON_DICT_JSON_BODY_RESPONSE = (
+    "--rspboundary\r\n"
+    "Content-Type: application/http\r\n"
+    "Content-ID: <response-item-0>\r\n"
+    "\r\n"
+    "HTTP/1.1 200 OK\r\n"
+    "Content-Type: application/json\r\n"
+    "\r\n"
+    "[1, 2, 3]\r\n"
+    "\r\n"
+    "--rspboundary--\r\n"
+)
+
+
+def test_decode_degrades_a_non_dict_json_body_to_none():
+    """json.loads() may return a list or scalar. SubResponse.body is typed
+    ``dict | None``; a list must degrade to None rather than being carried
+    through and later exploding a strict pydantic model with a shape it never
+    declared.
+    """
+    responses = decode_multipart(
+        NON_DICT_JSON_BODY_RESPONSE.encode("utf-8"),
+        "multipart/mixed; boundary=rspboundary",
+    )
+
+    assert len(responses) == 1
+    assert responses[0].status_code == 200
+    assert responses[0].body is None
+
+
+def test_encode_rejects_a_path_with_a_bare_cr_or_lf():
+    """A CR or LF inside a resource id would inject lines into the part and shift
+    the body -- api.update() cannot do this because httpx rejects it, but
+    add_update() builds the path itself with no equivalent guard.
+    """
+    sub_requests = [
+        SubRequest(
+            method="PATCH",
+            path="/walletobjects/v1/genericObject/issuer.one\r\nEvil-Header: x",
+            body='{"state":"EXPIRED"}',
+            content_id="item-0",
+        )
+    ]
+
+    try:
+        encode_multipart(sub_requests, boundary="testboundary")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError for a path containing CRLF")
+
+
+def test_encode_rejects_a_content_id_with_a_bare_lf():
+    """Same injection risk via content_id."""
+    sub_requests = [
+        SubRequest(
+            method="PATCH",
+            path="/walletobjects/v1/genericObject/issuer.one",
+            body='{"state":"EXPIRED"}',
+            content_id="item-0\nContent-Type: text/evil",
+        )
+    ]
+
+    try:
+        encode_multipart(sub_requests, boundary="testboundary")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError for a content_id containing LF")
+
+
+def test_encode_rejects_a_method_with_a_bare_cr():
+    """Same injection risk via method, for completeness."""
+    sub_requests = [
+        SubRequest(
+            method="PATCH\rEvil: x",
+            path="/walletobjects/v1/genericObject/issuer.one",
+            body='{"state":"EXPIRED"}',
+            content_id="item-0",
+        )
+    ]
+
+    try:
+        encode_multipart(sub_requests, boundary="testboundary")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError for a method containing CR")
+
+
+LF_ONLY_RESPONSE = (
+    "--rspboundary\r\n"
+    "Content-Type: application/http\r\n"
+    "Content-ID: <response-item-0>\r\n"
+    "\r\n"
+    "HTTP/1.1 200 OK\n"
+    "Content-Type: application/json\n"
+    "\n"
+    '{"id": "issuer.one"}\r\n'
+    "\r\n"
+    "--rspboundary--\r\n"
+)
+
+
+def test_decode_finds_the_body_when_the_part_uses_lf_only_headers():
+    """_parse_http_payload splits on CRLFCRLF; an LF-only sub-response must still
+    surface its body rather than silently losing it (ok=True, body=None, no error).
+    """
+    responses = decode_multipart(
+        LF_ONLY_RESPONSE.encode("utf-8"),
+        "multipart/mixed; boundary=rspboundary",
+    )
+
+    assert len(responses) == 1
+    assert responses[0].status_code == 200
+    assert responses[0].body == {"id": "issuer.one"}
+
+
+def test_part_content_type_is_pinned_to_application_json():
+    """_PART_CONTENT_TYPE's whole purpose is that flipping it to application/http is
+    a deliberate, larger change (it also needs an HTTP-version suffix on the request
+    line and a per-part Content-Type header). Pin the current value so a bare flip
+    announces itself as a broken test rather than passing silently.
+    """
+    assert _PART_CONTENT_TYPE == "application/json"


### PR DESCRIPTION
## Summary

Adds batch request support. A `Batch` collects PATCH sub-requests and sends them as a
single `multipart/mixed` request, so updating many passes costs one API call instead of
one per pass.

```python
from edutap.wallet_google import api

batch = api.Batch()
batch.add_update("LoyaltyObject", {"id": "issuer.member-1", "state": "EXPIRED"})
batch.add_update("EventTicketObject", {"id": "issuer.ticket-9", "state": "COMPLETED"})
batch.add_create("GenericObject", {"id": "issuer.new-1",
                                   "classId": "issuer.class",
                                   "state": "ACTIVE"})
results = batch.execute()          # or: await batch.aexecute()

for result in results:
    if not result.ok:
        print(f"{result.resource_id}: {result.error.message}")
```

Three design points worth knowing:

- **`Batch` takes a registered name plus plain dicts**, the way `read()` and `listing()`
  do, rather than model instances the way `update()` does. That removes the required-field
  problem: a PATCH carrying two changed attributes does not need a `classId` just to
  satisfy a constructor. Payloads are validated against a partial model, so typos still
  fail at `add_update()` time rather than at Google.
- **All pass types work, and may be mixed in one batch.** The sub-request path is a
  registry lookup on `url_part`, so nothing is specific to generic passes.
- **Create and update may be mixed, and create validates more strictly.** `add_create()`
  takes the same plain dicts as `add_update()`, but checks them against the *full* model
  rather than a relaxed one: a PATCH carrying two attributes has no reason to supply a
  `classId`, whereas a new object must. This mirrors the existing `create()`/`update()`
  pair, so the batch API is strict exactly where the single-object API already is.
- **A batch is not atomic.** Individual sub-request failures come back as `BatchResult`s
  carrying an `error`; only the batch request itself failing raises. There is a guaranteed
  invariant: if `result.ok` is `False`, then `result.error` is not `None`.

Results are returned in the order items were added. Internally `Batch` groups sub-requests
by pass type before encoding, which is safe because results are correlated by `Content-ID`
rather than by position — the specification does not promise the server answers in the
order it was asked.

## What is deliberately not here

No chunking, throttling, retry or resume. `execute()` takes keyword-only parameters so a
later driver stage can add `chunk_size` and friends without breaking callers;
`chunk_size=None` will keep meaning "one request". Also absent: deletion (the Wallet API
has none) and parsing results into models — `BatchResult.body` stays a `dict`, which
does not foreclose adding a parsed model later.

## Structure

| File | Responsibility |
| --- | --- |
| `src/edutap/wallet_google/multipart.py` | encode/decode `multipart/mixed`; knows nothing about wallet models, settings, HTTP or the registry |
| `src/edutap/wallet_google/batch.py` | the public `Batch`, plus `BatchResult` and `BatchError` |
| `settings.batch_url` | the batch endpoint; deliberately not derived from `api_url`, which sits one path level below it |

## Tests

`tox -e py313`: **176 passed, 9 skipped** (the skips are integration tests, gated behind
`--run-integration`). `tox -e lint` green.

Unit tests cover the encoder and decoder without a network, the `Batch` API against
`respx`, all seven object types, the ordering invariant against a deliberately shuffled
server response (for creates and updates alike), batch-level failures (403 quota → `QuotaExceededException`), and the
partial-failure contract.

## Risks and what is not verified

**The integration test has never been run against the real Google API.** It is written and
ready (`tests/integration/test_batch_integration.py`) but needs credentials. Three things
therefore remain genuinely open:

1. **Part content type.** Google's Wallet examples show each part as
   `Content-Type: application/json`; Google's general batch protocol uses
   `application/http`. This implementation follows the Wallet pages and keeps the value in
   a single module-level constant, `_PART_CONTENT_TYPE`, so switching is a one-line change
   (plus a request-line suffix and a per-part header, noted in the plan). A test pins the
   current value so a half-done switch cannot pass silently.
2. **Maximum sub-requests per batch.** Google documents no ceiling. Nothing here hard-codes
   one — a `Batch` takes whatever it is given, and a ceiling would surface as an HTTP error.
3. **Whether a batch counts as one call or as N** against the documented
   [20 calls per second](https://developers.google.com/wallet/generic/resources/faq).
   Google does not document this. The code and docs state the one-call behaviour as an
   operational finding from running the real system, explicitly *not* as something Google
   guarantees, and no Google URL is cited for it.

Two further known gaps, both deliberate: the fallback branch that synthesises a
`BatchError` when Google's error object cannot be parsed at all has no test forcing it
(it guards a shape we cannot currently name), and `docs/reference.md` attaches its FAQ
link to the phrase "per-call rate limit" rather than to the documented figure, which is
honest but vaguer than the equivalent passages elsewhere.

## Review notes

Two defects were found late, by a review of the whole branch rather than of any single
change, and both would have broken the partial-failure contract in the situation it exists
for:

- `BatchError` inherited `extra="forbid"`, so an ordinary Google error object carrying
  `details` raised a `ValidationError` out of `execute()` and discarded **every** result in
  the batch, including the successful ones.
- `json.loads` can return a list or scalar, while `body` was typed `dict | None` — same
  failure, same blast radius.

Both are fixed and covered by tests that assert the *other*, successful sub-request in the
same batch still comes back.
