### PR TITLE
fix: check models against the discovery document for enums, types and deprecations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,25 @@ If work is ready, remove the draft status from the PR to signalize readiness for
 
 On of the core contributors will review, comment and - if all is fine - merge it.
 
+## Staying in sync with the Google Wallet API
+
+The models are held against Google's machine readable schema, not against the
+HTML documentation. `tests/test_check_models.py` fetches
+
+* `https://walletobjects.googleapis.com/$discovery/rest?version=v1` and
+* `https://discovery.googleapis.com/discovery/v1/apis?name=walletobjects`
+
+and compares the set of schemas, the property names, their JSON types, their
+deprecations and every enum value against what we declare. It therefore needs
+network access; both endpoints are reachable without authentication.
+
+When Google adds something, that test is where it shows up first. Whatever it
+cannot know belongs in one of the named lists at the top of the file, together
+with the reason - never as a silent exception.
+
+The API revision is deliberately not pinned: Google turns it over almost daily,
+which would make the test red without telling us anything.
+
 ## Dependency updates
 
 Dependency updates arrive as pull requests from up to three bots, none of

--- a/src/edutap/wallet_google/models/bases.py
+++ b/src/edutap/wallet_google/models/bases.py
@@ -69,22 +69,41 @@ class CamelCaseAliasEnum(Enum):
 
     FooExample("fooBarBaz")
 
+    Google also publishes deprecated legacy spellings that follow no rule at
+    all - ``EAN13`` for ``EAN_13``, ``qrcode`` for ``QR_CODE``. Those cannot be
+    derived and are spelled out after the canonical value:
+
+    class FooExample(CamelCaseAliasEnum):
+        FOO_BAR_BAZ = "FOO_BAR_BAZ", "foobarbaz"
+
+    The canonical value stays the member's value; the extra spellings are only
+    accepted as input.
     """
 
-    def __new__(cls: type["CamelCaseAliasEnum"], value: str) -> "CamelCaseAliasEnum":
+    def __new__(
+        cls: type["CamelCaseAliasEnum"], value: str, *extra_aliases: str
+    ) -> "CamelCaseAliasEnum":
         obj: CamelCaseAliasEnum = object.__new__(cls)
+        # Set explicitly: with extra aliases given, Enum would otherwise make
+        # the whole argument tuple the member's value.
+        obj._value_ = value
         obj._name_ = f"{cls.__name__} snake case literal"
-        camel = _snake_to_camel(value)
 
-        # create a second object with the camelcase name
+        # create a second object per alias
         # creating an alias only does not work out since
         # pydantic checks for the value in the enum and not only the name
-        camel_obj = object.__new__(cls)
-        camel_obj._value_ = camel
-        camel_obj._name_ = f"{cls.__name__} camel case alias"
-        cls._value2member_map_[camel] = camel_obj
-        cls._member_map_[camel] = camel_obj
-        cls._member_names_.append(camel)
+        for alias, kind in [
+            (_snake_to_camel(value), "camel case alias"),
+            *[(alias, "legacy alias") for alias in extra_aliases],
+        ]:
+            if alias in cls._value2member_map_:
+                continue
+            alias_obj = object.__new__(cls)
+            alias_obj._value_ = alias
+            alias_obj._name_ = f"{cls.__name__} {kind}"
+            cls._value2member_map_[alias] = alias_obj
+            cls._member_map_[alias] = alias_obj
+            cls._member_names_.append(alias)
         return obj
 
     def __eq__(self, other: typing.Any | Enum) -> bool:

--- a/src/edutap/wallet_google/models/datatypes/barcode.py
+++ b/src/edutap/wallet_google/models/datatypes/barcode.py
@@ -7,7 +7,7 @@ from .localized_string import LocalizedString
 
 
 # Attribute order as in Google's documentation to make future updates easier!
-# last check: 2025-01-22
+# Parity with the API is checked by tests/test_check_models.py
 
 
 class Barcode(DeprecatedKindFieldMixin, Model):

--- a/src/edutap/wallet_google/models/datatypes/class_template_info.py
+++ b/src/edutap/wallet_google/models/datatypes/class_template_info.py
@@ -8,7 +8,7 @@ from typing_extensions import deprecated
 
 
 # Attribute order as in Google's documentation to make future updates easier!
-# last check: 2025-01-22
+# Parity with the API is checked by tests/test_check_models.py
 
 
 class FieldReference(Model):

--- a/src/edutap/wallet_google/models/datatypes/data.py
+++ b/src/edutap/wallet_google/models/datatypes/data.py
@@ -8,7 +8,7 @@ from typing_extensions import deprecated
 
 
 # Attribute order as in Google's documentation to make future updates easier!
-# last check: 2025-01-22
+# Parity with the API is checked by tests/test_check_models.py
 
 
 class TextModuleData(Model):

--- a/src/edutap/wallet_google/models/datatypes/datetime.py
+++ b/src/edutap/wallet_google/models/datatypes/datetime.py
@@ -6,7 +6,7 @@ import datetime
 
 
 # Attribute order as in Google's documentation to make future updates easier!
-# last check: 2025-01-22
+# Parity with the API is checked by tests/test_check_models.py
 
 
 class DateTime(Model):

--- a/src/edutap/wallet_google/models/datatypes/enums.py
+++ b/src/edutap/wallet_google/models/datatypes/enums.py
@@ -174,6 +174,16 @@ class GateLabel(CamelCaseAliasEnum):
 class GenericType(CamelCaseAliasEnum):
     """
     see: https://developers.google.com/wallet/generic/rest/v1/genericobject#generictype
+
+    Careful: that reference page lists 14 of the 20 values. The six marked
+    below appear only in the machine readable schema, which is where we take
+    them from - they entered it on 2026-03-28 with revision 20260327:
+    https://github.com/googleapis/discovery-artifact-manager/commit/b1b6100bbf443745a0ca80be074a78bc924346f5
+
+    They are modelled so that reading a pass carrying one of them does not fail
+    validation. Whether the API accepts them on write has not been tested, and
+    five months without an entry in the reference is reason enough not to
+    assume it - check against your own issuer before using one.
     """
 
     GENERIC_TYPE_UNSPECIFIED = "GENERIC_TYPE_UNSPECIFIED"  # Unspecified generic type.
@@ -193,13 +203,13 @@ class GenericType(CamelCaseAliasEnum):
     # Prefer the dedicated LoyaltyObject over this one: the dedicated pass type
     # offers more features than a generic pass can.
     GENERIC_LOYALTY_CARD = "GENERIC_LOYALTY_CARD"  # Loyalty cards
-    GENERIC_BUSINESS_CARD = "GENERIC_BUSINESS_CARD"  # Business cards
-    GENERIC_BARCODE_PASS = "GENERIC_BARCODE_PASS"  # Barcode passes
-    GENERIC_MEMBERSHIP_CARD = "GENERIC_MEMBERSHIP_CARD"  # Membership cards
-    GENERIC_STUDENT_CARD = "GENERIC_STUDENT_CARD"  # Student cards
-    GENERIC_TRANSIT_PASS = "GENERIC_TRANSIT_PASS"  # Transit passes
+    GENERIC_BUSINESS_CARD = "GENERIC_BUSINESS_CARD"  # Business cards, schema only
+    GENERIC_BARCODE_PASS = "GENERIC_BARCODE_PASS"  # Barcode passes, schema only
+    GENERIC_MEMBERSHIP_CARD = "GENERIC_MEMBERSHIP_CARD"  # Membership cards, schema only
+    GENERIC_STUDENT_CARD = "GENERIC_STUDENT_CARD"  # Student cards, schema only
+    GENERIC_TRANSIT_PASS = "GENERIC_TRANSIT_PASS"  # Transit passes, schema only
     GENERIC_VEHICLE_REGISTRATION = (
-        "GENERIC_VEHICLE_REGISTRATION"  # Vehicle registrations
+        "GENERIC_VEHICLE_REGISTRATION"  # Vehicle registrations, schema only
     )
     GENERIC_OTHER = "GENERIC_OTHER"  # Other type
 

--- a/src/edutap/wallet_google/models/datatypes/enums.py
+++ b/src/edutap/wallet_google/models/datatypes/enums.py
@@ -21,7 +21,8 @@ class ActivationState(CamelCaseAliasEnum):
     """
 
     UNKNOWN_STATE = "UNKNOWN_STATE"
-    NOT_ACTIVATED = "NOT_ACTIVATED"
+    # Google's deprecated legacy spelling is "not_activated", not "notActivated".
+    NOT_ACTIVATED = "NOT_ACTIVATED", "not_activated"
     ACTIVATED = "ACTIVATED"
 
 
@@ -55,10 +56,12 @@ class BarcodeType(CamelCaseAliasEnum):
     CODABAR = "CODABAR"
     DATA_MATRIX = "DATA_MATRIX"
     EAN_8 = "EAN_8"
-    EAN_13 = "EAN_13"
+    # Google carries two deprecated legacy spellings for these three, and the
+    # second one is not the camelCase form that gets generated automatically.
+    EAN_13 = "EAN_13", "EAN13"
     ITF_14 = "ITF_14"
-    PDF_417 = "PDF_417"
-    QR_CODE = "QR_CODE"
+    PDF_417 = "PDF_417", "PDF417"
+    QR_CODE = "QR_CODE", "qrcode"
     UPC_A = "UPC_A"
     TEXT_ONLY = "TEXT_ONLY"
 
@@ -118,6 +121,8 @@ class DateFormat(CamelCaseAliasEnum):
     TIME_ONLY = "TIME_ONLY"
     DATE_TIME_YEAR = "DATE_TIME_YEAR"
     DATE_YEAR = "DATE_YEAR"
+    YEAR_MONTH = "YEAR_MONTH"  # renders 2018-12-14T13:00:00 as 2018-12
+    YEAR_MONTH_DAY = "YEAR_MONTH_DAY"  # renders 2018-12-14T13:00:00 as 2018-12-14
 
 
 class DoorsOpenLabel(CamelCaseAliasEnum):
@@ -185,6 +190,17 @@ class GenericType(CamelCaseAliasEnum):
     GENERIC_HOME_INSURANCE = "GENERIC_HOME_INSURANCE"  # Home-insurance cards
     GENERIC_ENTRY_TICKET = "GENERIC_ENTRY_TICKET"  # Entry tickets
     GENERIC_RECEIPT = "GENERIC_RECEIPT"  # Receipts
+    # Prefer the dedicated LoyaltyObject over this one: the dedicated pass type
+    # offers more features than a generic pass can.
+    GENERIC_LOYALTY_CARD = "GENERIC_LOYALTY_CARD"  # Loyalty cards
+    GENERIC_BUSINESS_CARD = "GENERIC_BUSINESS_CARD"  # Business cards
+    GENERIC_BARCODE_PASS = "GENERIC_BARCODE_PASS"  # Barcode passes
+    GENERIC_MEMBERSHIP_CARD = "GENERIC_MEMBERSHIP_CARD"  # Membership cards
+    GENERIC_STUDENT_CARD = "GENERIC_STUDENT_CARD"  # Student cards
+    GENERIC_TRANSIT_PASS = "GENERIC_TRANSIT_PASS"  # Transit passes
+    GENERIC_VEHICLE_REGISTRATION = (
+        "GENERIC_VEHICLE_REGISTRATION"  # Vehicle registrations
+    )
     GENERIC_OTHER = "GENERIC_OTHER"  # Other type
 
 

--- a/src/edutap/wallet_google/models/datatypes/enums.py
+++ b/src/edutap/wallet_google/models/datatypes/enums.py
@@ -2,7 +2,7 @@ from ..bases import CamelCaseAliasEnum
 
 
 # Attribute order as in Google's documentation to make future updates easier!
-# last check: 2025-01-22
+# Parity with the API is checked by tests/test_check_models.py
 
 
 class Action(CamelCaseAliasEnum):

--- a/src/edutap/wallet_google/models/datatypes/event.py
+++ b/src/edutap/wallet_google/models/datatypes/event.py
@@ -7,7 +7,7 @@ import datetime
 
 
 # Attribute order as in Google's documentation to make future updates easier!
-# last check: 2025-01-22
+# Parity with the API is checked by tests/test_check_models.py
 
 
 class EventVenue(DeprecatedKindFieldMixin, Model):

--- a/src/edutap/wallet_google/models/datatypes/flight.py
+++ b/src/edutap/wallet_google/models/datatypes/flight.py
@@ -9,7 +9,7 @@ from pydantic import Field
 
 
 # Attribute order as in Google's documentation to make future updates easier!
-# last check: 2025-01-22
+# Parity with the API is checked by tests/test_check_models.py
 
 
 class BoardingAndSeatingInfo(DeprecatedKindFieldMixin, Model):

--- a/src/edutap/wallet_google/models/datatypes/general.py
+++ b/src/edutap/wallet_google/models/datatypes/general.py
@@ -12,7 +12,7 @@ from typing_extensions import deprecated
 
 
 # Attribute order as in Google's documentation to make future updates easier!
-# last check: 2025-01-22
+# Parity with the API is checked by tests/test_check_models.py
 
 
 class Uri(DeprecatedKindFieldMixin, Model):

--- a/src/edutap/wallet_google/models/datatypes/jwt.py
+++ b/src/edutap/wallet_google/models/datatypes/jwt.py
@@ -11,7 +11,7 @@ from datetime import datetime
 
 
 # Attribute order as in Google's documentation to make future updates easier!
-# last check: 2025-01-22
+# Parity with the API is checked by tests/test_check_models.py
 
 
 class JWTPayload(Model):

--- a/src/edutap/wallet_google/models/datatypes/localized_string.py
+++ b/src/edutap/wallet_google/models/datatypes/localized_string.py
@@ -4,7 +4,7 @@ from pydantic import Field
 
 
 # Attribute order as in Google's documentation to make future updates easier!
-# last check: 2025-01-22
+# Parity with the API is checked by tests/test_check_models.py
 
 
 class TranslatedString(DeprecatedKindFieldMixin, Model):

--- a/src/edutap/wallet_google/models/datatypes/location.py
+++ b/src/edutap/wallet_google/models/datatypes/location.py
@@ -4,7 +4,7 @@ from pydantic import Field
 
 
 # Attribute order as in Google's documentation to make future updates easier!
-# last check: 2025-06-19
+# Parity with the API is checked by tests/test_check_models.py
 
 
 class LatLongPoint(DeprecatedKindFieldMixin, Model):

--- a/src/edutap/wallet_google/models/datatypes/loyalty.py
+++ b/src/edutap/wallet_google/models/datatypes/loyalty.py
@@ -6,7 +6,7 @@ from pydantic import model_validator
 
 
 # Attribute order as in Google's documentation to make future updates easier!
-# last check: 2025-01-22
+# Parity with the API is checked by tests/test_check_models.py
 
 
 class LoyaltyPointsBalance(Model):

--- a/src/edutap/wallet_google/models/datatypes/message.py
+++ b/src/edutap/wallet_google/models/datatypes/message.py
@@ -6,7 +6,7 @@ from .localized_string import LocalizedString
 
 
 # Attribute order as in Google's documentation to make future updates easier!
-# last check: 2025-01-22
+# Parity with the API is checked by tests/test_check_models.py
 
 
 class Message(DeprecatedKindFieldMixin, Model):

--- a/src/edutap/wallet_google/models/datatypes/moduledata.py
+++ b/src/edutap/wallet_google/models/datatypes/moduledata.py
@@ -5,7 +5,7 @@ from .localized_string import LocalizedString
 
 
 # Attribute order as in Google's documentation to make future updates easier!
-# last check: 2025-01-22
+# Parity with the API is checked by tests/test_check_models.py
 
 
 class ModuleViewConstraints(Model):

--- a/src/edutap/wallet_google/models/datatypes/money.py
+++ b/src/edutap/wallet_google/models/datatypes/money.py
@@ -3,7 +3,7 @@ from ..deprecated import DeprecatedKindFieldMixin
 
 
 # Attribute order as in Google's documentation to make future updates easier!
-# last check: 2025-01-22
+# Parity with the API is checked by tests/test_check_models.py
 
 
 class Money(DeprecatedKindFieldMixin, Model):

--- a/src/edutap/wallet_google/models/datatypes/notification.py
+++ b/src/edutap/wallet_google/models/datatypes/notification.py
@@ -2,7 +2,7 @@ from ..bases import Model
 
 
 # Attribute order as in Google's documentation to make future updates easier!
-# last check: 2025-01-22
+# Parity with the API is checked by tests/test_check_models.py
 
 
 class ExpiryNotification(Model):

--- a/src/edutap/wallet_google/models/datatypes/retail.py
+++ b/src/edutap/wallet_google/models/datatypes/retail.py
@@ -5,7 +5,7 @@ from .general import Uri
 
 
 # Attribute order as in Google's documentation to make future updates easier!
-# last check: 2025-01-22
+# Parity with the API is checked by tests/test_check_models.py
 
 
 class DiscoverableProgramMerchantSignupInfo(Model):

--- a/src/edutap/wallet_google/models/datatypes/review.py
+++ b/src/edutap/wallet_google/models/datatypes/review.py
@@ -2,7 +2,7 @@ from ..bases import Model
 
 
 # Attribute order as in Google's documentation to make future updates easier!
-# last check: 2025-01-22
+# Parity with the API is checked by tests/test_check_models.py
 
 
 class Review(Model):

--- a/src/edutap/wallet_google/models/datatypes/smarttap.py
+++ b/src/edutap/wallet_google/models/datatypes/smarttap.py
@@ -7,7 +7,7 @@ from pydantic import Field
 
 
 # Attribute order as in Google's documentation to make future updates easier!
-# last check: 2025-01-22
+# Parity with the API is checked by tests/test_check_models.py
 
 
 class Permission(Model):

--- a/src/edutap/wallet_google/models/datatypes/transit.py
+++ b/src/edutap/wallet_google/models/datatypes/transit.py
@@ -8,7 +8,7 @@ from pydantic import model_validator
 
 
 # Attribute order as in Google's documentation to make future updates easier!
-# last check: 2025-01-22
+# Parity with the API is checked by tests/test_check_models.py
 
 
 class ActivationOptions(Model):

--- a/src/edutap/wallet_google/models/deprecated.py
+++ b/src/edutap/wallet_google/models/deprecated.py
@@ -245,7 +245,7 @@ class DeprecatedWordMarkFieldMixin:
     """
 
     wordMark: Annotated[
-        list[Image] | None,
+        Image | None,
         Field(
             deprecated=deprecated(
                 'Attribute "wordMark" was used in the past to specify the word mark but is now deprecated.'

--- a/src/edutap/wallet_google/models/misc.py
+++ b/src/edutap/wallet_google/models/misc.py
@@ -20,7 +20,7 @@ from pydantic import Field
 
 
 # Attribute order as in Google's documentation to make future updates easier!
-# last check: 2025-01-22
+# Parity with the API is checked by tests/test_check_models.py
 
 
 @register_model(

--- a/src/edutap/wallet_google/models/passes/bases.py
+++ b/src/edutap/wallet_google/models/passes/bases.py
@@ -70,7 +70,7 @@ class ClassModel(WithIdModel):
     """
 
     # Attribute order as in Google's documentation to make future updates easier!
-    # last check: 2024-12-02
+    # Parity with the API is checked by tests/test_check_models.py
 
     # inherits id
     classTemplateInfo: ClassTemplateInfo | None = None

--- a/src/edutap/wallet_google/models/passes/generic.py
+++ b/src/edutap/wallet_google/models/passes/generic.py
@@ -10,7 +10,7 @@ from .bases import StyleableMixin
 
 
 # Attribute order as in Google's documentation to make future updates easier!
-# last check: 2025-01-22
+# Parity with the API is checked by tests/test_check_models.py
 
 
 @register_model(

--- a/src/edutap/wallet_google/models/passes/retail.py
+++ b/src/edutap/wallet_google/models/passes/retail.py
@@ -25,7 +25,7 @@ from .bases import StyleableMixin
 
 
 # Attribute order as in Google's documentation to make future updates easier!
-# last check: 2025-06-19
+# Parity with the API is checked by tests/test_check_models.py
 
 
 @register_model("GiftCardClass", url_part="giftCardClass", plural="giftCardClasses")

--- a/src/edutap/wallet_google/models/passes/tickets_and_transit.py
+++ b/src/edutap/wallet_google/models/passes/tickets_and_transit.py
@@ -48,7 +48,7 @@ from pydantic import model_validator
 
 
 # Attribute order as in Google's documentation to make future updates easier!
-# last check: 2025-01-22
+# Parity with the API is checked by tests/test_check_models.py
 
 
 @register_model(

--- a/superpowers/handoffs/2026-08-18-jwt-insert-validate.md
+++ b/superpowers/handoffs/2026-08-18-jwt-insert-validate.md
@@ -1,7 +1,7 @@
 # Handoff: the `jwt.insert` and `jwt.validate` endpoints
 
-**Written:** 2026-08-18 · **Status:** investigation, not decided · **Language:** English
-(this is an eduTAP package on GitHub)
+**Written:** 2026-08-18 · **Status:** `insert` decided against, `validate` open ·
+**Language:** English (this is an eduTAP package on GitHub)
 
 ## Where this comes from
 
@@ -40,20 +40,46 @@ Both need the scope `https://www.googleapis.com/auth/wallet_object.issuer`, whic
 package already requests. `JwtValidateResponse` is empty by design: valid means an empty
 body, invalid means an error response.
 
-### What the package has today
+### Which models exist
 
-`api.save_link()` builds the same `savetowallet` JWT **locally** and returns
-`{settings.save_url}/{jwt}` without ever calling Google. `jwt.insert` is the server side
-of the same idea, and the two are not interchangeable — see "Why bother" below.
+`JwtResource`, `Resources` and `JwtResponse` (`{saveUri, resources}`) exist in
+`models/misc.py` and match the API. Missing, all three only needed for `validate`:
+`JsonResource` (`{json: str}`), `JwtValidateRequest`, `JwtValidateResponse`.
 
-`JwtResource` is **already registered**, with `url_part="jwt"` and `can_create=True`
-(`src/edutap/wallet_google/models/misc.py:89`). `JwtResponse` — `{saveUri, resources}` —
-exists right below it and is referenced from nowhere but `docs/reference.md`.
+## `jwt.insert` — decided against
 
-**That combination is a latent bug, not just a gap.** `api.create()` parses the response
-with the same model it sent, so `api.create(JwtResource(jwt="..."))` posts to the correct
-URL and then fails on the response. Verified by constructing the objects rather than by
-reading the code:
+**Do not build this.** The decision is Alexander's, taken 2026-08-18, and the reasoning
+is recorded here so nobody proposes it a third time.
+
+The endpoint solves exactly one problem: `save_link()` puts the entire JWT into the URL,
+and `api.py:235` warns past 1800 bytes, which is Google's documented recommendation.
+`jwt.insert` posts the JWT once, creates the resources server-side and returns a short
+`saveUri` instead.
+
+**We do hit that ceiling — regularly.** It is not a theoretical concern. Measured with a
+plausible student card (title, header, subheader, logo, hero image, QR barcode, three
+text modules):
+
+```
+Vollobjekt im JWT    claims JSON 1252 B  ->  JWT ~2029 B   over the recommendation
+Reference im JWT     claims JSON  212 B  ->  JWT  ~642 B   comfortably under
+```
+
+And that is the point: **the ceiling was already solved another way.** Class and object
+are created up front through the CRUD API, and the JWT carries only the id. The package
+supports this directly — `JWTPayload` accepts `Model | Reference`, `save_link()` takes
+`list[ClassModel | ObjectModel | Reference]`, and `_create_payload()` (`api.py:107`)
+sorts a `Reference` into the right list by `model_name` or `model_type`.
+
+So `jwt.insert` would buy a second route to a problem that has a working first route,
+at the cost of a network round trip `save_link()` does not need today. Not worth it.
+
+### The loose end it leaves — worth fixing on its own
+
+`JwtResource` is registered with `url_part="jwt"` and `can_create=True`
+(`models/misc.py:89`), and `create()` parses the response with the same model it sent.
+So `api.create(JwtResource(jwt="..."))` posts to the correct URL and then fails on the
+response. Verified by constructing the objects, not by reading the code:
 
 ```python
 >>> from edutap.wallet_google.models.misc import JwtResource, JwtResponse
@@ -64,126 +90,109 @@ ValidationError: 3 validation errors for JwtResource
 >>> JwtResponse.model_validate(body)   # parses fine
 ```
 
-So whoever picks this up is not starting from zero, and is not starting from something
-that works either.
+`JwtResponse` is referenced from nowhere but `docs/reference.md`.
 
-### Which models are missing
+Now that `insert` is off the table, the honest fix is small: **set `can_create=False` on
+`JwtResource`**. `_prepare_create()` then raises through
+`raise_when_operation_not_allowed()` — a clear "not allowed" instead of a confusing
+`ValidationError` three fields deep.
 
-`Resources` and `JwtResponse` exist and match the API. Missing for `validate`:
-`JsonResource` (`{json: str}`), `JwtValidateRequest`, `JwtValidateResponse`.
+`JwtResource` itself has to stay either way: the API declares that schema, and
+`is_envelope()` does not drop it — "Resource" is not "Response". Whether `JwtResponse`
+stays as documentation of the endpoint or goes is free; `is_envelope()` does drop that
+one, so `test_known_schemas` does not care. Checked, not assumed.
 
-## Why bother — the case for `insert`
+While in there: `MODEL_ALIAS_DICT` in `tests/test_check_models.py` maps `"Jwt"` to
+`"JwtResource"`, and no class named `Jwt` exists in the package. The entry predates PR #99
+and is harmless — the map is only ever read with `.get()` — but it is dead and can go.
 
-`save_link()` puts the entire JWT in the URL. `api.py:235` already logs a warning past
-1800 bytes, which is Google's documented recommendation. A pass with several objects, or
-one carrying full class definitions instead of `Reference`s, runs into that ceiling, and
-there is nothing `save_link()` can do about it: the payload *is* the link.
+This is a one-line change plus a test. It does not belong in PR #99 and was deliberately
+not smuggled in there.
 
-`jwt.insert` posts the JWT once, creates the resources server-side and hands back a short
-`saveUri`. The length problem disappears. That, and not convenience, is the reason to
-have it.
+## `jwt.validate` — open
 
-The case for `validate` is weaker but real: it is a pre-flight check that costs one call
-and tells you a pass is well formed before you hand a link to a user.
+This is the part still worth thinking about, and it has **not** been decided.
 
-**Neither has been tested against the real API.** The whole section above describes what
-Google *declares*, not what it does.
+### What it might buy us
 
-## What the work is
+Our models validate structure: Pydantic with `extra="forbid"` catches unknown fields,
+wrong types and — since PR #99 — wrong enum values. What it cannot catch is everything
+that depends on state at Google:
 
-Roughly in order of value. Each step small and verifiable, test first.
+* does the referenced `classId` exist, and is it `LIVE` rather than `DRAFT`?
+* does our issuer own it?
+* whatever semantic rules Google applies that are documented nowhere
 
-### 1. Decide how a differing response type is expressed
+Given that we hand save links to students, a pre-flight check that catches a broken pass
+before the user sees a failure page is plausibly worth one call. **Plausibly** — nobody
+has measured what `validate` actually rejects that we do not.
 
-This is the design decision everything else hangs off, and it should be made before any
-code is written.
+### What to find out first
 
-`RegistryMetadataDict` (`registry.py:16`) has no notion of "the response has a different
-shape than the request". Every registered model is assumed to round-trip. `jwt` is the
-first endpoint where that does not hold.
+**Do not implement anything before this is answered**, because the answer decides whether
+there is a feature here at all:
 
-Two directions, and they are genuinely different in spirit:
+1. Feed `validate` a pass our models accept but that is broken at Google — a `classId`
+   that does not exist, a class in `DRAFT`, an id belonging to another issuer. Does it
+   reject them? With a usable error?
+2. Feed it something our models already reject. If `validate` only catches what Pydantic
+   catches, there is no feature here.
 
-* **(a) Teach the registry a `response_model`.** `create()` then parses with it when
-  present. Small change, keeps `jwt.insert` inside the CRUD machinery, and any future
-  endpoint with an asymmetric response gets it for free. Risk: `create()` grows a special
-  case, and `JwtResource` keeps pretending to be a CRUD resource when it is not one —
-  there is nothing to read, update or list.
-* **(b) A dedicated function in `api.py`, outside CRUD.** Something like
-  `insert_jwt(models, ...) -> JwtResponse` (plus `ainsert_jwt`), sitting next to
-  `save_link()` because that is what it is related to, and unregistering `JwtResource`
-  from the CRUD registry. Honest about the shape of the endpoint. Risk: a second path
-  that has to repeat client handling and error handling.
+That needs real credentials and an integration test. `tests/integration/` and
+`--run-integration` are the place; there is no way to answer it from the discovery
+document.
 
-My reading is that (b) fits the endpoint better — `jwt.insert` is not "create a JWT", it
-is "create everything named in this JWT" — but (a) is the smaller diff and I have not
-weighed it against how the maintainers want the registry to evolve. **Ask before
-choosing.**
+### If it turns out to be worth it
 
-Whichever wins, `can_create=True` on `JwtResource` must stop meaning what it means today.
+Small, verifiable steps, test first.
 
-### 2. `jwt.insert`
+**Shape.** `validate` is not a CRUD operation — nothing is created, read, updated or
+listed, and the response has no body. Do not try to bend it into the registry; a
+dedicated pair in `api.py` next to `save_link()` fits what it is. Something like
+`validate_pass(...)` / `avalidate_pass(...)`, sync and async, because every other call
+here has both.
 
-Test first, with `respx`, the way `test_api_sync.py` and `test_api_async.py` mock the
-other endpoints. Sync and async, since every other call has both.
+Note the contrast with `insert`: that one *would* have raised the question of whether
+`RegistryMetadataDict` (`registry.py:16`) needs a `response_model`, since it has no notion
+of a response shape differing from the request. With `insert` out, that question is moot —
+do not reopen it for `validate`.
 
-Watch out for:
+**Models.** `JsonResource`, `JwtValidateRequest`, `JwtValidateResponse`. The request takes
+**either** `jwtResource` **or** `jsonResource` — Google's own wording is "Either this or
+json_resource should be provided" — so a `model_validator` enforcing exactly-one belongs
+there. `JsonResource.json` is the *unencoded* JWT payload as a JSON string, which means a
+pass can be validated without signing it first; that is the more useful of the two inputs
+for a pre-flight check.
 
-* the JWT is built by the existing `_create_claims()` / `_create_payload()`; do not write
-  a second JWT builder
-* `JwtResponse.saveUri` is `AnyHttpUrl` while the API declares a plain string — that is a
-  deliberate refinement and `test_property_types` accepts it
-* `Resources` holds the *created* objects, so the return value is worth surfacing, not
-  discarding
+Careful: `json` is a field name that shadows nothing in Pydantic v2 but reads badly. Keep
+the API name — `test_known_schemas` compares property names and would fail otherwise.
 
-### 3. `jwt.validate`
+**Return value.** `JwtValidateResponse` has no properties. Decide deliberately between
+returning `None`, returning `True`, and raising only on the error path, and say why in the
+docstring — a model with no fields will look like a mistake to the next reader.
 
-Needs the three models from above. Note the request takes **either** `jwtResource` **or**
-`jsonResource`; Google's description says "Either this or json_resource should be
-provided", so a validator enforcing exactly-one is appropriate.
+**Ignore list.** Once modelled, delete `JsonResource` from
+`UNIMPLEMENTED_ENDPOINT_SCHEMAS` (`tests/test_check_models.py:41`). The schema-set
+assertion then covers it, and `test_property_types` and `test_deprecated_properties` pick
+it up automatically. `ModifyLinkedOfferObjects` stays.
 
-The empty response needs a decision of its own: return `None`, return `True`, or raise on
-the error path only. Whatever is chosen, `JwtValidateResponse` is a model with no fields,
-which will look odd to a reader — say why in the docstring.
-
-### 4. Remove them from the ignore list
-
-Once modelled, delete `JsonResource` from `UNIMPLEMENTED_ENDPOINT_SCHEMAS` in
-`tests/test_check_models.py`. The schema-set assertion then covers them, and
-`test_property_types` and `test_deprecated_properties` pick them up automatically.
-`ModifyLinkedOfferObjects` stays until someone does that separately.
-
-Also revisit `test_methods`: it silently skips resources with no registered model of the
-same name, which is why `jwt` never showed up as missing. After this, `jwt` has models
-but still no `get`/`list`/`patch`, so the expected-method logic needs a case for it —
-much like the `Permissions` special case already there (`test_check_models.py:389`).
-
-## Open questions
-
-* **Do we want `insert` at all?** It only pays off if we actually hit the JWT length
-  ceiling. Does any eduTAP pass do that today, or is this speculative? If nobody has seen
-  the warning in a log, this is a solution looking for a problem, and the honest answer
-  might be "not yet".
-* **Registry or dedicated function** — step 1 above.
-* **Does `insert` create or upsert?** "Inserts the resources in the JWT" does not say what
-  happens when an object already exists. `create()` maps 409 to
-  `ObjectAlreadyExistsException`; whether `jwt.insert` behaves that way is unknown and
-  only an integration test against a real issuer can answer it.
-* **Is `validate` worth a round trip?** Our models already validate locally, and Pydantic
-  with `extra="forbid"` catches most of what Google would. What does `validate` catch that
-  we do not?
+**`test_methods`.** It silently skips API resources with no registered model of the same
+name, which is why `jwt` never showed up as missing. If anything under `jwt` becomes
+registered, that test needs a case for it — much like the `Permissions` special case
+already there (`tests/test_check_models.py:389`).
 
 ## Environment
 
 * No `Makefile` here, contrary to the eduTAP house style. Tests run through
   `uvx tox -e py313`, lint through `uvx tox -e lint`.
-* **Run the suite through tox, not in a bare venv.** The `py` tox environment (`pyproject.toml:161`) installs
-  `tests/data/test_wallet_google_plugins` as an editable dependency; without it 10 tests
-  fail on missing entry points and look like real breakage.
+* **Run the suite through tox, not in a bare venv.** The `py` tox environment
+  (`pyproject.toml:161`) installs `tests/data/test_wallet_google_plugins` as an editable
+  dependency; without it 10 tests fail on missing entry points and look like real
+  breakage.
 * `tests/test_check_models.py` needs network access. Both Google endpoints are reachable
   without authentication.
-* Integration tests need real credentials and `--run-integration`. For anything in this
-  handoff that touches "what does the API actually do", that is the only way to find out.
+* Integration tests need real credentials and `--run-integration`. Everything this handoff
+  leaves open is a question about behaviour, so that is the only way to close it.
 * Dev extras live in `[project.optional-dependencies]`, not `[dependency-groups]`. Not
   this task's business.
 * After opening the PR, wait for Copilot's review and work through the comments one by
@@ -192,9 +201,10 @@ much like the `Permissions` special case already there (`test_check_models.py:38
 
 ## Suggested skills
 
-* `superpowers:brainstorming` — unlike PR #99, the scope here is **not** settled. Step 1
-  is a real design decision and the first open question may end with "we do not build
-  this". Brainstorm before planning.
-* `superpowers:test-driven-development` — once the direction is set.
+* `superpowers:brainstorming` — for `validate`, if and only if the two questions above
+  come back in its favour. The scope is genuinely open and may end in "we do not build
+  this".
+* `superpowers:test-driven-development` — for the `can_create=False` fix, which needs no
+  brainstorming at all.
 * `superpowers:verification-before-completion` — the discovery document says what Google
   declares. Anything about behaviour needs an integration test or the label "untested".

--- a/superpowers/handoffs/2026-08-18-jwt-insert-validate.md
+++ b/superpowers/handoffs/2026-08-18-jwt-insert-validate.md
@@ -1,0 +1,200 @@
+# Handoff: the `jwt.insert` and `jwt.validate` endpoints
+
+**Written:** 2026-08-18 · **Status:** investigation, not decided · **Language:** English
+(this is an eduTAP package on GitHub)
+
+## Where this comes from
+
+PR #99 held the models against the discovery document. Two schemas turned out to be
+missing, and both belong to endpoints this package does not implement:
+
+* `JsonResource` — the body of `walletobjects.jwt.validate`
+* `ModifyLinkedOfferObjects` — the body of `loyaltyobject.modifylinkedofferobjects`
+
+They were put on `UNIMPLEMENTED_ENDPOINT_SCHEMAS` in `tests/test_check_models.py`, which
+keeps the schema-set assertion honest without pretending the endpoints exist. **This
+handoff covers only the two `jwt` methods.** `modifylinkedofferobjects` is a separate
+question and is out of scope here.
+
+## Already verified — do not redo this
+
+Measured on 2026-08-18 against discovery revision `20260818`.
+
+### What the API offers
+
+```
+walletobjects.jwt.insert    POST walletobjects/v1/jwt
+                            request  JwtResource        {jwt: str}
+                            response JwtInsertResponse  {saveUri: str, resources: Resources}
+                            "Inserts the resources in the JWT."
+
+walletobjects.jwt.validate  POST walletobjects/v1/jwt/validate
+                            request  JwtValidateRequest  {jwtResource?: JwtResource,
+                                                          jsonResource?: JsonResource}
+                            response JwtValidateResponse {}   ← no properties at all
+                            "Checks that the JWT or JSON string in the request
+                             represents a valid pass to be saved."
+```
+
+Both need the scope `https://www.googleapis.com/auth/wallet_object.issuer`, which the
+package already requests. `JwtValidateResponse` is empty by design: valid means an empty
+body, invalid means an error response.
+
+### What the package has today
+
+`api.save_link()` builds the same `savetowallet` JWT **locally** and returns
+`{settings.save_url}/{jwt}` without ever calling Google. `jwt.insert` is the server side
+of the same idea, and the two are not interchangeable — see "Why bother" below.
+
+`JwtResource` is **already registered**, with `url_part="jwt"` and `can_create=True`
+(`src/edutap/wallet_google/models/misc.py:89`). `JwtResponse` — `{saveUri, resources}` —
+exists right below it and is referenced from nowhere but `docs/reference.md`.
+
+**That combination is a latent bug, not just a gap.** `api.create()` parses the response
+with the same model it sent, so `api.create(JwtResource(jwt="..."))` posts to the correct
+URL and then fails on the response. Verified by constructing the objects rather than by
+reading the code:
+
+```python
+>>> from edutap.wallet_google.models.misc import JwtResource, JwtResponse
+>>> body = {"saveUri": "https://pay.google.com/gp/v/save/eyJ...",
+...         "resources": {"genericObjects": [{"id": "...", "classId": "...", "state": "ACTIVE"}]}}
+>>> JwtResource.model_validate(body)
+ValidationError: 3 validation errors for JwtResource
+>>> JwtResponse.model_validate(body)   # parses fine
+```
+
+So whoever picks this up is not starting from zero, and is not starting from something
+that works either.
+
+### Which models are missing
+
+`Resources` and `JwtResponse` exist and match the API. Missing for `validate`:
+`JsonResource` (`{json: str}`), `JwtValidateRequest`, `JwtValidateResponse`.
+
+## Why bother — the case for `insert`
+
+`save_link()` puts the entire JWT in the URL. `api.py:235` already logs a warning past
+1800 bytes, which is Google's documented recommendation. A pass with several objects, or
+one carrying full class definitions instead of `Reference`s, runs into that ceiling, and
+there is nothing `save_link()` can do about it: the payload *is* the link.
+
+`jwt.insert` posts the JWT once, creates the resources server-side and hands back a short
+`saveUri`. The length problem disappears. That, and not convenience, is the reason to
+have it.
+
+The case for `validate` is weaker but real: it is a pre-flight check that costs one call
+and tells you a pass is well formed before you hand a link to a user.
+
+**Neither has been tested against the real API.** The whole section above describes what
+Google *declares*, not what it does.
+
+## What the work is
+
+Roughly in order of value. Each step small and verifiable, test first.
+
+### 1. Decide how a differing response type is expressed
+
+This is the design decision everything else hangs off, and it should be made before any
+code is written.
+
+`RegistryMetadataDict` (`registry.py:16`) has no notion of "the response has a different
+shape than the request". Every registered model is assumed to round-trip. `jwt` is the
+first endpoint where that does not hold.
+
+Two directions, and they are genuinely different in spirit:
+
+* **(a) Teach the registry a `response_model`.** `create()` then parses with it when
+  present. Small change, keeps `jwt.insert` inside the CRUD machinery, and any future
+  endpoint with an asymmetric response gets it for free. Risk: `create()` grows a special
+  case, and `JwtResource` keeps pretending to be a CRUD resource when it is not one —
+  there is nothing to read, update or list.
+* **(b) A dedicated function in `api.py`, outside CRUD.** Something like
+  `insert_jwt(models, ...) -> JwtResponse` (plus `ainsert_jwt`), sitting next to
+  `save_link()` because that is what it is related to, and unregistering `JwtResource`
+  from the CRUD registry. Honest about the shape of the endpoint. Risk: a second path
+  that has to repeat client handling and error handling.
+
+My reading is that (b) fits the endpoint better — `jwt.insert` is not "create a JWT", it
+is "create everything named in this JWT" — but (a) is the smaller diff and I have not
+weighed it against how the maintainers want the registry to evolve. **Ask before
+choosing.**
+
+Whichever wins, `can_create=True` on `JwtResource` must stop meaning what it means today.
+
+### 2. `jwt.insert`
+
+Test first, with `respx`, the way `test_api_sync.py` and `test_api_async.py` mock the
+other endpoints. Sync and async, since every other call has both.
+
+Watch out for:
+
+* the JWT is built by the existing `_create_claims()` / `_create_payload()`; do not write
+  a second JWT builder
+* `JwtResponse.saveUri` is `AnyHttpUrl` while the API declares a plain string — that is a
+  deliberate refinement and `test_property_types` accepts it
+* `Resources` holds the *created* objects, so the return value is worth surfacing, not
+  discarding
+
+### 3. `jwt.validate`
+
+Needs the three models from above. Note the request takes **either** `jwtResource` **or**
+`jsonResource`; Google's description says "Either this or json_resource should be
+provided", so a validator enforcing exactly-one is appropriate.
+
+The empty response needs a decision of its own: return `None`, return `True`, or raise on
+the error path only. Whatever is chosen, `JwtValidateResponse` is a model with no fields,
+which will look odd to a reader — say why in the docstring.
+
+### 4. Remove them from the ignore list
+
+Once modelled, delete `JsonResource` from `UNIMPLEMENTED_ENDPOINT_SCHEMAS` in
+`tests/test_check_models.py`. The schema-set assertion then covers them, and
+`test_property_types` and `test_deprecated_properties` pick them up automatically.
+`ModifyLinkedOfferObjects` stays until someone does that separately.
+
+Also revisit `test_methods`: it silently skips resources with no registered model of the
+same name, which is why `jwt` never showed up as missing. After this, `jwt` has models
+but still no `get`/`list`/`patch`, so the expected-method logic needs a case for it —
+much like the `Permissions` special case already there (`test_check_models.py:389`).
+
+## Open questions
+
+* **Do we want `insert` at all?** It only pays off if we actually hit the JWT length
+  ceiling. Does any eduTAP pass do that today, or is this speculative? If nobody has seen
+  the warning in a log, this is a solution looking for a problem, and the honest answer
+  might be "not yet".
+* **Registry or dedicated function** — step 1 above.
+* **Does `insert` create or upsert?** "Inserts the resources in the JWT" does not say what
+  happens when an object already exists. `create()` maps 409 to
+  `ObjectAlreadyExistsException`; whether `jwt.insert` behaves that way is unknown and
+  only an integration test against a real issuer can answer it.
+* **Is `validate` worth a round trip?** Our models already validate locally, and Pydantic
+  with `extra="forbid"` catches most of what Google would. What does `validate` catch that
+  we do not?
+
+## Environment
+
+* No `Makefile` here, contrary to the eduTAP house style. Tests run through
+  `uvx tox -e py313`, lint through `uvx tox -e lint`.
+* **Run the suite through tox, not in a bare venv.** The `py` tox environment (`pyproject.toml:161`) installs
+  `tests/data/test_wallet_google_plugins` as an editable dependency; without it 10 tests
+  fail on missing entry points and look like real breakage.
+* `tests/test_check_models.py` needs network access. Both Google endpoints are reachable
+  without authentication.
+* Integration tests need real credentials and `--run-integration`. For anything in this
+  handoff that touches "what does the API actually do", that is the only way to find out.
+* Dev extras live in `[project.optional-dependencies]`, not `[dependency-groups]`. Not
+  this task's business.
+* After opening the PR, wait for Copilot's review and work through the comments one by
+  one. On PR #99 it came back empty because the requesting account had hit its quota —
+  check for that before concluding there was nothing to say.
+
+## Suggested skills
+
+* `superpowers:brainstorming` — unlike PR #99, the scope here is **not** settled. Step 1
+  is a real design decision and the first open question may end with "we do not build
+  this". Brainstorm before planning.
+* `superpowers:test-driven-development` — once the direction is set.
+* `superpowers:verification-before-completion` — the discovery document says what Google
+  declares. Anything about behaviour needs an integration test or the label "untested".

--- a/superpowers/handoffs/2026-08-18-jwt-insert-validate.md
+++ b/superpowers/handoffs/2026-08-18-jwt-insert-validate.md
@@ -77,12 +77,26 @@ at the cost of a network round trip `save_link()` does not need today. Not worth
 ### The loose end it leaves — worth fixing on its own
 
 `JwtResource` is registered with `url_part="jwt"` and `can_create=True`
-(`models/misc.py:89`), and `create()` parses the response with the same model it sent.
-So `api.create(JwtResource(jwt="..."))` posts to the correct URL and then fails on the
-response. Verified by constructing the objects, not by reading the code:
+(`models/misc.py:89`), promising an operation that cannot work. Two separate things stand
+in the way, and it is worth keeping them apart:
+
+1. `JwtResource` has no `id`, and `create()` reads one unconditionally
+   (`utils.py:104`).
+2. The endpoint answers with `{saveUri, resources}` while `create()` parses the response
+   with the same model it sent.
+
+**The first one wins, so (2) is never reached.** Measured by calling it, not by reading
+the code — an earlier draft of this handoff claimed the call reaches Google and dies on
+the response, which is wrong:
+
+```
+>>> api.create(JwtResource(jwt="eyJ..."))
+AttributeError: 'JwtResource' object has no attribute 'id'      # utils.py:104
+```
+
+(2) is real all the same, just latent behind (1):
 
 ```python
->>> from edutap.wallet_google.models.misc import JwtResource, JwtResponse
 >>> body = {"saveUri": "https://pay.google.com/gp/v/save/eyJ...",
 ...         "resources": {"genericObjects": [{"id": "...", "classId": "...", "state": "ACTIVE"}]}}
 >>> JwtResource.model_validate(body)
@@ -94,8 +108,8 @@ ValidationError: 3 validation errors for JwtResource
 
 Now that `insert` is off the table, the honest fix is small: **set `can_create=False` on
 `JwtResource`**. `_prepare_create()` then raises through
-`raise_when_operation_not_allowed()` — a clear "not allowed" instead of a confusing
-`ValidationError` three fields deep.
+`raise_when_operation_not_allowed()` — "Operation 'create' not allowed for
+'JwtResource'" instead of an `AttributeError` about a field nobody asked for.
 
 `JwtResource` itself has to stay either way: the API declares that schema, and
 `is_envelope()` does not drop it — "Resource" is not "Response". Whether `JwtResponse`
@@ -107,7 +121,7 @@ While in there: `MODEL_ALIAS_DICT` in `tests/test_check_models.py` maps `"Jwt"` 
 and is harmless — the map is only ever read with `.get()` — but it is dead and can go.
 
 This is a one-line change plus a test. It does not belong in PR #99 and was deliberately
-not smuggled in there.
+not smuggled in there — it is PR #100 instead.
 
 ## `jwt.validate` — open
 

--- a/tests/test_check_models.py
+++ b/tests/test_check_models.py
@@ -75,10 +75,16 @@ def find_all_models() -> dict[str, type[BaseModel]]:
     models: dict[str, type[BaseModel]] = {}
     for module in modules:
         for cls_name, cls in inspect.getmembers(module, inspect.isclass):
-            if cls.__module__.startswith("edutap.wallet_google.models") and issubclass(
-                cls, BaseModel
-            ):
-                models[cls_name] = cls
+            if not cls.__module__.startswith("edutap.wallet_google.models"):
+                continue
+            if not issubclass(cls, BaseModel):
+                continue
+            # models/deprecated.py duplicates Image, ImageUri, LocalizedString
+            # and friends to break an import cycle. Those copies are reduced to
+            # what the deprecated fields need, so the real ones win.
+            if cls.__module__.endswith(".deprecated") and cls_name in models:
+                continue
+            models[cls_name] = cls
     return models
 
 
@@ -323,19 +329,12 @@ def test_known_schemas(wallet_api_data: dict[str, Any]):
             print(f"Model: '{name}' has no property: '{e}'")
 
         model_schema_names = set(model.model_json_schema().get("properties", {}).keys())
-        model_schema = model.model_json_schema().get("properties", {})
 
         assert set(api_schema["properties"].keys()) == model_schema_names, (
             f"Set of properties does not match for: '{name}'"
         )
-
-        for prop, prop_schema in api_schema["properties"].items():
-            assert prop in model_schema_names
-            if "deprecated" in prop_schema:
-                our_prop = model_schema[prop]
-                assert our_prop.get("deprecated", False) is True, (
-                    f"The property: '{prop}' is deprecated, but not marked as such in our schema."
-                )
+        # Deprecations are checked in both directions by
+        # test_deprecated_properties, types by test_property_types.
 
 
 def test_methods(wallet_api_data: dict[str, Any]):
@@ -467,3 +466,161 @@ def test_enum_values(wallet_api_data: dict[str, Any]):
         if findings
     )
     assert not report, f"\nOur enums and the Wallet API disagree:\n{report}"
+
+
+def api_wire_shape(property_schema: dict[str, Any], api_schemas: dict[str, Any]) -> str:
+    """The JSON shape a discovery property describes.
+
+    Reduced to what actually travels over the wire, because that is what both
+    sides have to agree on. Google encodes int64 as a JSON string, so a
+    ``format`` never changes the shape.
+    """
+    if "$ref" in property_schema:
+        target = property_schema["$ref"]
+        if api_schemas.get(target, {}).get("type") == "object":
+            return f"object:{target}"
+        return f"unknown:{target}"
+    if "enum" in property_schema:
+        return "enum"
+    kind = property_schema.get("type")
+    if kind == "array":
+        return (
+            f"array of {api_wire_shape(property_schema.get('items', {}), api_schemas)}"
+        )
+    return str(kind)
+
+
+def our_wire_shape(property_schema: dict[str, Any], definitions: dict[str, Any]) -> str:
+    """The JSON shape one of our model properties describes.
+
+    Pydantic writes ``Foo | None`` as an ``anyOf`` over the type and null, and
+    refines strings via ``format`` (uri, email, date-time). Neither changes the
+    shape, so both are collapsed away.
+    """
+    if "anyOf" in property_schema:
+        shapes = {
+            our_wire_shape(variant, definitions)
+            for variant in property_schema["anyOf"]
+            if variant.get("type") != "null"
+        }
+        return shapes.pop() if len(shapes) == 1 else f"anyOf{sorted(shapes)}"
+    if "$ref" in property_schema:
+        key = property_schema["$ref"].rsplit("/", 1)[-1]
+        definition = definitions.get(key, {})
+        if "enum" in definition:
+            return "enum"
+        # Pydantic qualifies a $defs key with its module path whenever a class
+        # name occurs twice: "..._deprecated__Image" instead of "Image".
+        name = key.rsplit("__", 1)[-1]
+        return f"object:{MODEL_ALIAS_DICT.get(name, name)}"
+    kind = property_schema.get("type")
+    if kind == "array":
+        return (
+            f"array of {our_wire_shape(property_schema.get('items', {}), definitions)}"
+        )
+    return str(kind)
+
+
+def test_property_types(wallet_api_data: dict[str, Any]):
+    """Compare the JSON type of every property against the discovery document.
+
+    ``test_known_schemas`` compares property *names*; a field Google moved from
+    ``string`` to ``object`` would not show up there.
+
+    Required fields cannot be compared: the discovery document carries no
+    ``required`` key on any schema, so there is nothing on Google's side to
+    check ours against.
+    """
+    api_schemas: dict[str, dict[str, Any]] = wallet_api_data["schemas"]
+    our_models = {
+        MODEL_ALIAS_DICT.get(name, name): model
+        for name, model in find_all_models().items()
+    }
+
+    mismatches: dict[str, str] = {}
+    for schema_name, api_schema in sorted(api_schemas.items()):
+        if schema_name in GOOGLE_INTERNAL_SCHEMAS or schema_name not in our_models:
+            continue
+        our_schema = our_models[schema_name].model_json_schema()
+        our_properties = our_schema.get("properties", {})
+        definitions = our_schema.get("$defs", {})
+
+        for name, api_property in sorted(api_schema.get("properties", {}).items()):
+            if name not in our_properties:
+                continue  # covered by test_known_schemas
+            expected = api_wire_shape(api_property, api_schemas)
+            actual = our_wire_shape(our_properties[name], definitions)
+            if expected != actual:
+                mismatches[f"{schema_name}.{name}"] = (
+                    f"API says {expected}, we say {actual}"
+                )
+
+    report = "\n".join(
+        f"  {where}: {what}" for where, what in sorted(mismatches.items())
+    )
+    assert not report, f"\nProperty types disagree with the Wallet API:\n{report}"
+
+
+# Properties we mark as deprecated although the discovery document does not.
+# Google flags "locations" on every class but not on OfferObject; the wording of
+# the description is identical, so this is an oversight on their side rather
+# than a statement about the object.
+DEPRECATED_BEYOND_THE_API = {
+    "OfferObject.locations",
+}
+
+
+def api_says_deprecated(property_schema: dict[str, Any]) -> bool:
+    """Whether the discovery document declares a property deprecated.
+
+    The ``deprecated`` flag alone is not enough: Google sets it on
+    ``EventTicketClass.infoModuleData`` but not on
+    ``EventTicketObject.infoModuleData``, even though both descriptions read
+    "Deprecated. Use textModulesData instead."
+    """
+    return bool(property_schema.get("deprecated")) or property_schema.get(
+        "description", ""
+    ).startswith("Deprecated")
+
+
+def test_deprecated_properties(wallet_api_data: dict[str, Any]):
+    """Every deprecation has to be visible on both sides.
+
+    ``test_known_schemas`` only checks one direction - the API deprecates it, so
+    we have to mark it. A field we still flag after Google has revived it is
+    just as wrong, because our users see a warning that no longer applies.
+    """
+    api_schemas: dict[str, dict[str, Any]] = wallet_api_data["schemas"]
+    our_models = {
+        MODEL_ALIAS_DICT.get(name, name): model
+        for name, model in find_all_models().items()
+    }
+
+    not_marked: list[str] = []
+    marked_without_reason: list[str] = []
+    for schema_name, api_schema in sorted(api_schemas.items()):
+        if schema_name in GOOGLE_INTERNAL_SCHEMAS or schema_name not in our_models:
+            continue
+        our_properties = (
+            our_models[schema_name].model_json_schema().get("properties", {})
+        )
+
+        for name, api_property in sorted(api_schema.get("properties", {}).items()):
+            if name not in our_properties:
+                continue  # covered by test_known_schemas
+            where = f"{schema_name}.{name}"
+            if where in DEPRECATED_BEYOND_THE_API:
+                continue
+            ours_says = bool(our_properties[name].get("deprecated"))
+            if api_says_deprecated(api_property) and not ours_says:
+                not_marked.append(where)
+            if ours_says and not api_says_deprecated(api_property):
+                marked_without_reason.append(where)
+
+    assert not not_marked, (
+        f"\nThe API deprecates these, we do not mark them: {not_marked}"
+    )
+    assert not marked_without_reason, (
+        f"\nWe mark these deprecated, the API does not: {marked_without_reason}"
+        f"\nEither drop the marker or add it to DEPRECATED_BEYOND_THE_API."
+    )

--- a/tests/test_check_models.py
+++ b/tests/test_check_models.py
@@ -1,7 +1,9 @@
 from edutap.wallet_google.registry import _MODEL_REGISTRY_BY_NAME
 from edutap.wallet_google.registry import lookup_metadata_by_name
+from enum import Enum
 from httpx import get
 from httpx import HTTPError
+from pydantic import BaseModel
 from pydantic._internal._model_construction import ModelMetaclass
 from typing import Any
 
@@ -10,6 +12,7 @@ import inspect
 import json
 import pathlib
 import pytest
+import typing
 
 
 MODEL_ALIAS_DICT = {
@@ -18,6 +21,19 @@ MODEL_ALIAS_DICT = {
     "Jwt": "JwtResource",
     "TotpDetails": "RotatingBarcodeTotpDetails",
     "TotpParameters": "RotatingBarcodeTotpDetailsTotpParameters",
+}
+
+# Schemas of Google's internal media/upload machinery. They are part of every
+# discovery document Google publishes, they are not part of the Wallet data
+# model, and no Wallet endpoint we call ever returns them.
+GOOGLE_INTERNAL_SCHEMAS = {
+    "Blobstore2Info",
+    "CompositeMedia",
+    "ContentTypeInfo",
+    "DownloadParameters",
+    "Media",
+    "MediaRequestInfo",
+    "ObjectId",
 }
 
 
@@ -35,6 +51,99 @@ def find_models() -> dict[str, type]:
                 # print(f"Class: '{cls_name}', '{cls}'")
                 models[cls_name] = cls
     return models
+
+
+def find_all_models() -> dict[str, type[BaseModel]]:
+    """All Pydantic models of the package, keyed by class name.
+
+    Unlike :func:`find_models` this walks the whole ``models`` package, so
+    models living outside ``models/datatypes/`` (``models/misc.py``,
+    ``models/deprecated.py``, ``models/passes/``) are found as well.
+    """
+    package = importlib.import_module("edutap.wallet_google.models")
+    root = pathlib.Path(package.__path__[0])
+
+    # Walking the file tree rather than using pkgutil: 'datatypes' carries no
+    # __init__.py, so pkgutil does not descend into it.
+    modules = []
+    for path in sorted(root.rglob("*.py")):
+        parts = path.relative_to(root).with_suffix("").parts
+        if parts[-1] == "__init__":
+            parts = parts[:-1]
+        modules.append(importlib.import_module(".".join((package.__name__, *parts))))
+
+    models: dict[str, type[BaseModel]] = {}
+    for module in modules:
+        for cls_name, cls in inspect.getmembers(module, inspect.isclass):
+            if cls.__module__.startswith("edutap.wallet_google.models") and issubclass(
+                cls, BaseModel
+            ):
+                models[cls_name] = cls
+    return models
+
+
+def enum_types_of(annotation: Any) -> set[type[Enum]]:
+    """Every Enum class reachable from a Pydantic field annotation.
+
+    Fields are declared as ``Foo | None``, ``list[Foo]`` and the like, so the
+    annotation has to be unwrapped recursively.
+    """
+    found: set[type[Enum]] = set()
+    if isinstance(annotation, type) and issubclass(annotation, Enum):
+        found.add(annotation)
+    for argument in typing.get_args(annotation):
+        found |= enum_types_of(argument)
+    return found
+
+
+def find_enum_fields() -> dict[tuple[str, str], type[Enum]]:
+    """Map ``(API schema name, property name)`` to the Enum class we use there.
+
+    Derived from the models themselves rather than from a hand written table,
+    so it cannot drift away from the code it describes.
+    """
+    fields: dict[tuple[str, str], type[Enum]] = {}
+    for name, model in find_all_models().items():
+        schema_name = MODEL_ALIAS_DICT.get(name, name)
+        for field_name, field in model.model_fields.items():
+            enums = enum_types_of(field.annotation)
+            if len(enums) != 1:
+                # No enum at all, or an ambiguous union - nothing to compare.
+                continue
+            fields[(schema_name, field.alias or field_name)] = enums.pop()
+    return fields
+
+
+def canonical_values(enum_class: type[Enum]) -> set[str]:
+    """The values declared in the enum's class body, without generated aliases.
+
+    :class:`~edutap.wallet_google.models.bases.CamelCaseAliasEnum` registers its
+    aliases as extra members, so plain iteration would also yield them. An alias
+    member does not carry the name it is registered under - that is what tells
+    the two apart.
+    """
+    return {
+        member.value
+        for name, member in enum_class._member_map_.items()
+        if member.name == name
+    }
+
+
+def api_enum_of(property_schema: dict[str, Any]) -> tuple[list[str], list[bool]] | None:
+    """The enum values of a discovery property and their deprecation flags.
+
+    Returns ``None`` for properties without an enum. Array properties carry the
+    enum on their ``items``. ``enumDeprecated`` is absent whenever no value is
+    deprecated, so a missing flag list means "nothing is deprecated".
+    """
+    schema = property_schema
+    if schema.get("type") == "array":
+        schema = schema.get("items", {})
+    values = schema.get("enum")
+    if values is None:
+        return None
+    deprecated = schema.get("enumDeprecated", [False] * len(values))
+    return values, deprecated
 
 
 def request_api_data_write_to_file(url: str, file_path: pathlib.Path) -> bool:
@@ -281,3 +390,80 @@ def test_methods(wallet_api_data: dict[str, Any]):
             f"\nExpected methods: {expected_methods}"
             f"\nDifference: {available_methods - expected_methods}"
         )
+
+
+def test_enum_values(wallet_api_data: dict[str, Any]):
+    """Compare our enum values against the enums inlined in the discovery document.
+
+    The discovery document holds no standalone enum schemas; every enum is
+    inlined into the property that uses it. Google lists deprecated legacy
+    spellings next to the canonical values and marks them via
+    ``enumDeprecated``.
+
+    Three things have to hold:
+
+    1. Our canonical values are exactly Google's canonical values.
+    2. Every value Google may send - legacy spellings included - is accepted by
+       our enum, so reading an API response never fails on an alias.
+    3. Wherever the API declares an enum, we use an enum too.
+    """
+    schemas: dict[str, dict[str, Any]] = wallet_api_data["schemas"]
+    our_enum_fields = find_enum_fields()
+
+    problems: dict[str, dict[str, list[str]]] = {
+        "Google knows canonical values we do not": {},
+        "we know canonical values Google does not": {},
+        "our enum rejects values the API may send": {},
+        "the API declares an enum where we use a plain type": {},
+    }
+
+    for schema_name, schema in sorted(schemas.items()):
+        if schema_name in GOOGLE_INTERNAL_SCHEMAS:
+            continue
+        for property_name, property_schema in sorted(
+            schema.get("properties", {}).items()
+        ):
+            api_enum = api_enum_of(property_schema)
+            if api_enum is None:
+                continue
+            values, deprecated = api_enum
+            where = f"{schema_name}.{property_name}"
+
+            our_enum = our_enum_fields.get((schema_name, property_name))
+            if our_enum is None:
+                problems["the API declares an enum where we use a plain type"][
+                    where
+                ] = sorted(values)
+                continue
+
+            where = f"{our_enum.__name__} ({where})"
+            api_canonical = {
+                value
+                for value, is_deprecated in zip(values, deprecated)
+                if not is_deprecated
+            }
+            our_canonical = canonical_values(our_enum)
+
+            if api_canonical - our_canonical:
+                problems["Google knows canonical values we do not"][where] = sorted(
+                    api_canonical - our_canonical
+                )
+            if our_canonical - api_canonical:
+                problems["we know canonical values Google does not"][where] = sorted(
+                    our_canonical - api_canonical
+                )
+            rejected = [
+                value for value in values if value not in our_enum._value2member_map_
+            ]
+            if rejected:
+                problems["our enum rejects values the API may send"][where] = rejected
+
+    report = "\n".join(
+        f"\n{headline}:\n"
+        + "\n".join(
+            f"  {where}: {values}" for where, values in sorted(findings.items())
+        )
+        for headline, findings in problems.items()
+        if findings
+    )
+    assert not report, f"\nOur enums and the Wallet API disagree:\n{report}"

--- a/tests/test_check_models.py
+++ b/tests/test_check_models.py
@@ -4,7 +4,6 @@ from enum import Enum
 from httpx import get
 from httpx import HTTPError
 from pydantic import BaseModel
-from pydantic._internal._model_construction import ModelMetaclass
 from typing import Any
 
 import importlib
@@ -36,29 +35,52 @@ GOOGLE_INTERNAL_SCHEMAS = {
     "ObjectId",
 }
 
+# Bodies of the two endpoints we do not implement: jwt.insert / jwt.validate
+# and loyaltyobject.modifylinkedofferobjects. Both are only ever reachable
+# through a request envelope, so neither is a gap in the pass data model.
+UNIMPLEMENTED_ENDPOINT_SCHEMAS = {
+    "JsonResource",
+    "ModifyLinkedOfferObjects",
+}
 
-def find_models() -> dict[str, type]:
-    models: dict[str, type] = {}
-    pkg = importlib.import_module("edutap.wallet_google")
-    datatypes_module = pkg.models.datatypes
-    for name, module in inspect.getmembers(datatypes_module, inspect.ismodule):
-        # print(f"Module: 'name', '{module}'")
-        for cls_name, cls in inspect.getmembers(module, inspect.isclass):
-            if (
-                cls.__module__.startswith("edutap.wallet_google.models.datatypes")
-                and cls.__class__ == ModelMetaclass
-            ):
-                # print(f"Class: '{cls_name}', '{cls}'")
-                models[cls_name] = cls
-    return models
+# Models that are ours, not Google's, and therefore in no discovery document.
+OUR_OWN_MODELS = {
+    # base classes every pass model derives from
+    "Model",
+    "WithIdModel",
+    "ClassModel",
+    "ObjectModel",
+    # the "Add to Google Wallet" JWT we sign ourselves
+    "JWTClaims",
+    "JWTPayload",
+    "Reference",
+    # payloads Google posts to our callback endpoint
+    "CallbackData",
+    "ImageData",
+    "IntermediateSigningKey",
+    "RootSigningPublicKey",
+    "RootSigningPublicKeys",
+    "SignedKey",
+    "SignedMessage",
+}
+
+
+def is_envelope(schema_name: str) -> bool:
+    """Whether a schema is a per-endpoint request or response envelope.
+
+    Those wrap a resource for one call - GenericObjectListResponse and the like
+    - instead of describing a piece of the Wallet data model. Applied to both
+    sides so the two sets of names stay comparable.
+    """
+    return schema_name.endswith(("Request", "Response"))
 
 
 def find_all_models() -> dict[str, type[BaseModel]]:
     """All Pydantic models of the package, keyed by class name.
 
-    Unlike :func:`find_models` this walks the whole ``models`` package, so
-    models living outside ``models/datatypes/`` (``models/misc.py``,
-    ``models/deprecated.py``, ``models/passes/``) are found as well.
+    Walks the whole ``models`` package, so models living outside
+    ``models/datatypes/`` are found as well - ``models/misc.py``,
+    ``models/deprecated.py``, ``models/passes/``.
     """
     package = importlib.import_module("edutap.wallet_google.models")
     root = pathlib.Path(package.__path__[0])
@@ -276,40 +298,29 @@ def test_known_schemas(wallet_api_data: dict[str, Any]):
     assert isinstance(schemas, dict)
     assert len(schemas) > 0
 
-    api_schemas: set[str] = set()
-    for elem in schemas.keys():
-        if elem.endswith("Request") or elem.endswith("Response"):
-            continue
-        api_schemas.add(elem)
+    # Per-endpoint envelopes are dropped on both sides, by the same rule, so
+    # that the two sets stay comparable.
+    api_schemas = (
+        {name for name in schemas if not is_envelope(name)}
+        - GOOGLE_INTERNAL_SCHEMAS
+        - UNIMPLEMENTED_ENDPOINT_SCHEMAS
+    )
 
-    our_schemas: dict[str, type] = {}
-    our_known_schemas: set[str] = set(_MODEL_REGISTRY_BY_NAME.keys())
-    for name in our_known_schemas:
-        our_schemas[name] = lookup_metadata_by_name(name)["model"]
+    our_schemas: dict[str, type] = {
+        name: lookup_metadata_by_name(name)["model"] for name in _MODEL_REGISTRY_BY_NAME
+    }
+    our_schemas.update(find_all_models())
+    our_schemas = {
+        name: model
+        for name, model in sorted(our_schemas.items())
+        if not is_envelope(name) and name not in OUR_OWN_MODELS
+    }
 
-    for name, model in find_models().items():
-        our_known_schemas.add(name)
-        our_schemas[name] = model
-
-    for name in [
-        "JWTClaims",
-        "JWTPayload",
-        "PaginatedResponse",
-        "Reference",
-    ]:
-        del our_schemas[name]
-
-    # assert api_schemas == our_known_schemas, (
-    #     f"\nAPI schemas do not match our known schemas."
-    #     f"\nAPI schemas: {api_schemas}, "
-    #     f"\nOur known schemas: {our_known_schemas}"
-    #     f"\nDifference: {api_schemas - our_known_schemas}"
-    # )
-
-    our_schemas = dict(sorted(our_schemas.items()))
-    # print("Our known schemas:")
-    # for name in our_schemas.keys():
-    #     print(f" * {name}")
+    assert api_schemas == {MODEL_ALIAS_DICT.get(name, name) for name in our_schemas}, (
+        "\nThe set of schemas the API knows and the set of models we have differ."
+        f"\nOnly in the API: {sorted(api_schemas - {MODEL_ALIAS_DICT.get(n, n) for n in our_schemas})}"
+        f"\nOnly ours: {sorted({MODEL_ALIAS_DICT.get(n, n) for n in our_schemas} - api_schemas)}"
+    )
 
     for name, model in our_schemas.items():
         # print(f"\nCheck: '{name}'", end=" ")

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -60,3 +60,38 @@ def test_pydantic_constraints():
 
     with pytest.raises(pydantic.ValidationError):
         TestModel(foo="wrong")
+
+
+def test_camel_case_alias_enum_with_explicit_aliases():
+    """Aliases that no rule derives from the canonical value.
+
+    Google publishes deprecated legacy spellings next to the canonical enum
+    values. Most of them are the plain camelCase form and are generated, but a
+    few follow no rule at all (``EAN13`` for ``EAN_13``, ``qrcode`` for
+    ``QR_CODE``). Those have to be spelled out.
+    """
+    from edutap.wallet_google.models.bases import CamelCaseAliasEnum
+
+    class TestFoo(CamelCaseAliasEnum):
+        FOO_BAR_BAZ = "FOO_BAR_BAZ", "FOOBARBAZ", "foobarbaz"
+
+    assert TestFoo.FOO_BAR_BAZ.value == "FOO_BAR_BAZ"
+    assert TestFoo("FOO_BAR_BAZ") == TestFoo.FOO_BAR_BAZ
+    # the generated camelCase alias still works
+    assert TestFoo("fooBarBaz") == TestFoo.FOO_BAR_BAZ
+    # ... and so do the explicit ones
+    assert TestFoo("FOOBARBAZ") == TestFoo.FOO_BAR_BAZ
+    assert TestFoo("foobarbaz") == TestFoo.FOO_BAR_BAZ
+    with pytest.raises(ValueError):
+        TestFoo("unrelated")
+
+
+def test_barcode_type_accepts_googles_legacy_spellings():
+    """The Wallet API may send these; reading a response must not fail on them."""
+    from edutap.wallet_google.models.datatypes.enums import ActivationState
+    from edutap.wallet_google.models.datatypes.enums import BarcodeType
+
+    assert BarcodeType("EAN13") == BarcodeType.EAN_13
+    assert BarcodeType("PDF417") == BarcodeType.PDF_417
+    assert BarcodeType("qrcode") == BarcodeType.QR_CODE
+    assert ActivationState("not_activated") == ActivationState.NOT_ACTIVATED


### PR DESCRIPTION
## Summary

`tests/test_check_models.py` compared the *set of property names* against the Wallet API discovery document. That left four blind spots: enum values, JSON types, deprecations in one direction only, and a schema-set assertion that had been commented out since it was written. This closes all four and fixes what they turned up.

The discovery document is the source of truth here, not the HTML reference — see the caveat at the bottom, it matters.

## What the new checks found

**Enum values** — never compared before. `test_enum_values` derives the mapping `(schema, property) -> enum class` from the models themselves rather than from a hand written table, so it cannot drift.

* `GenericType` was missing **seven** values Google has added since, among them `GENERIC_STUDENT_CARD`, `GENERIC_MEMBERSHIP_CARD` and `GENERIC_TRANSIT_PASS`.
* `DateFormat` was missing `YEAR_MONTH` and `YEAR_MONTH_DAY`.
* `BarcodeType` rejected `EAN13`, `PDF417` and `qrcode`; `ActivationState` rejected `not_activated`. These are deprecated legacy spellings Google publishes and `_snake_to_camel` cannot derive, so a response carrying one would have failed validation. `CamelCaseAliasEnum` now takes explicit extra aliases after the canonical value.

**Property types** — `test_property_types` compares the JSON shape both sides describe. A discovery `format` never changes it (Google encodes int64 as a JSON string) and neither does a Pydantic refinement of `string` (`AnyHttpUrl`, `EmailStr`, `datetime`), so both are collapsed away first.

* `wordMark` was `list[Image]` on all six class models. The API declares a single deprecated `Image`.

Required fields cannot be compared at all: no schema in the discovery document carries a `required` key.

**Deprecations** — the existing check only ran one way. A marker we set that the API does not is just as wrong, because it warns users about something that is not deprecated. Google's own flag is inconsistent — `EventTicketClass.infoModuleData` carries it, `EventTicketObject.infoModuleData` does not, with the identical description — so a description starting with "Deprecated" counts too. That leaves `OfferObject.locations`, named in `DEPRECATED_BEYOND_THE_API` with its reason.

**Schema set** — the assertion is live. Both sides are reduced by the same rule: per-endpoint request/response envelopes drop out via `is_envelope()`. Three named lists carry the rest, each with its reason:

* `GOOGLE_INTERNAL_SCHEMAS` — Google's media/upload machinery. `ObjectId` belongs here too: it is Blobstore's, referenced only by `Media` and `CompositeMedia`, and not, as the name suggests, part of the JWT save link.
* `UNIMPLEMENTED_ENDPOINT_SCHEMAS` — `JsonResource` and `ModifyLinkedOfferObjects`, the bodies of `jwt.validate` and `loyaltyobject.modifylinkedofferobjects`. Both are reachable only through a request envelope, so neither is a gap in the pass data model.
* `OUR_OWN_MODELS` — our base classes, the "Add to Google Wallet" JWT we sign ourselves, and the payloads Google posts to our callback endpoint.

## Along the way

* `find_models()` only ever looked into `models/datatypes/`, which is why `InfoModuleData`, `LabelValue`, `LabelValueRow` and `Resources` looked missing. `find_all_models()` replaces it and walks the file tree — `pkgutil` does not descend into `models/datatypes/`, which has no `__init__.py`.
* `models/deprecated.py` duplicates `Image`, `LocalizedString` and friends to break an import cycle, and the copies are **not** field-identical. `find_all_models()` now prefers the real ones.
* The `# last check: 2025-01-22` comments in 25 files become a pointer to the test. They claimed a hand check the test now does automatically, and the date was one nobody kept up. `CONTRIBUTING.md` gains the section explaining which endpoints the test reads, that it needs network access, and why the API revision stays unpinned (Google turns it over almost daily).

## Caveat worth reading: `GENERIC_STUDENT_CARD` and five siblings

The reference page at `developers.google.com/wallet/generic/rest/v1/genericobject#generictype` lists **14 of the 20** values. `GENERIC_STUDENT_CARD`, `GENERIC_BARCODE_PASS`, `GENERIC_BUSINESS_CARD`, `GENERIC_MEMBERSHIP_CARD`, `GENERIC_TRANSIT_PASS` and `GENERIC_VEHICLE_REGISTRATION` appear only in the machine readable schema. They entered it on 2026-03-28 with revision `20260327`: [discovery-artifact-manager@b1b6100](https://github.com/googleapis/discovery-artifact-manager/commit/b1b6100bbf443745a0ca80be074a78bc924346f5). No release notes page documents them either.

They are modelled so that **reading** a pass carrying one of them does not fail validation — which is the actual bug. Whether the API accepts them on **write** is untested, and five months without an entry in the reference is reason enough not to assume it. The docstring says so, and each of the six carries a `schema only` marker.

## Tests

```
uvx tox -e py313   ->  140 passed, 8 skipped
uvx tox -e lint    ->  all 15 hooks passed
```

`tests/test_check_models.py` needs network access; both Google endpoints are reachable without authentication.

## Risks

* `test_enum_values` and `test_property_types` run against the live API and will go red when Google changes something. That is the point. The revision pin stays off.
* `CamelCaseAliasEnum.__new__` now sets `_value_` explicitly, which it has to once extra aliases are passed. Single-argument members behave exactly as before; `tests/test_enum.py` covers both, including the `repr` pinned by #12.
* `wordMark` changes type. It is deprecated, `exclude=True`, and used nowhere in this repository, its tests, examples or docs.

## Open

None blocking. Two API methods stay unimplemented and are now named as such in the ignore list rather than silently absent: `jwt.insert` / `jwt.validate` and `loyaltyobject.modifylinkedofferobjects`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
