### PR TITLE
fix(registry): JwtResource is not creatable

### DIFF
--- a/src/edutap/wallet_google/models/misc.py
+++ b/src/edutap/wallet_google/models/misc.py
@@ -89,6 +89,11 @@ class AddMessageRequest(Model):
 @register_model(
     "JwtResource",
     url_part="jwt",
+    # Registered for lookup by name only - none of the CRUD operations apply.
+    # url_part points at walletobjects.jwt.insert, which this package does not
+    # implement: that endpoint answers with JwtResponse, not with what it was
+    # given, and JwtResource has no id for create() to work with either.
+    can_create=False,
     can_read=False,
     can_update=False,
     can_list=False,

--- a/tests/test_api_create.py
+++ b/tests/test_api_create.py
@@ -94,3 +94,30 @@ def test_api_create_issuer_raises_when_issuer_id_set(mock_session):
 
     assert "must not be set" in str(exc_info.value)
     assert "issuerId" in str(exc_info.value)
+
+
+def test_api_create_jwt_resource_is_not_allowed(mock_session):
+    """JwtResource is not a CRUD resource, and create() must say so.
+
+    It is registered so the model can be looked up by name, and its url_part
+    points at the jwt.insert endpoint. That endpoint is not implemented, and
+    two things stand in the way of it ever working through create():
+    JwtResource has no id, and the endpoint answers with {saveUri, resources}
+    while create() parses the response with the model it sent.
+
+    Without this guard the first of the two wins and the caller gets
+    "AttributeError: 'JwtResource' object has no attribute 'id'" out of
+    utils.py, which says nothing about the real cause.
+
+    jwt.insert is deliberately not wanted - the JWT length ceiling it would
+    solve is already handled by putting a Reference into the JWT rather than
+    the full object.
+    """
+    from edutap.wallet_google.api import create
+    from edutap.wallet_google.models.misc import JwtResource
+
+    with pytest.raises(ValueError) as exc_info:
+        create(JwtResource(jwt="eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.e30.signature"))
+
+    assert "not allowed" in str(exc_info.value)
+    assert "JwtResource" in str(exc_info.value)


### PR DESCRIPTION
## Summary

`JwtResource` is registered with `can_create` left at its default `True`, which promises an operation this package does not implement. `url_part` points at `walletobjects.jwt.insert`.

Two separate things stand in the way of that ever working through `create()`:

1. `JwtResource` has no `id`, and `create()` reads one unconditionally (`utils.py:104`).
2. The endpoint answers with `{saveUri, resources}` — a `JwtResponse` — while `create()` parses the response with the same model it sent.

The first one wins, so today a caller gets:

```
>>> api.create(JwtResource(jwt="eyJ..."))
AttributeError: 'JwtResource' object has no attribute 'id'
```

which says nothing about the real cause. With `can_create=False`, `_prepare_create()` raises through `raise_when_operation_not_allowed()` instead:

```
ValueError: Operation 'create' not allowed for 'JwtResource'
```

The model stays registered — it is still looked up by name, and the API declares the schema.

## Why not implement `jwt.insert` instead

The only problem that endpoint solves is the 1800-byte ceiling on save links: `save_link()` puts the whole JWT in the URL, and `api.py` warns past that. `jwt.insert` posts the JWT once and returns a short `saveUri`.

We hit that ceiling regularly — and it is already solved the other way. Class and object are created up front through the CRUD API, and the JWT carries only the id. This package supports that directly: `JWTPayload` takes `Model | Reference`, and `_create_payload()` sorts a `Reference` into the right list. Measured on a plausible student card (title, header, subheader, logo, hero image, QR barcode, three text modules):

| in the JWT  | claims JSON | JWT (est.) |
| ----------- | ----------- | ---------- |
| full object | 1252 B      | ~2029 B    |
| `Reference` |  212 B      |  ~642 B    |

So `jwt.insert` would be a second route to a problem with a working first route, at the cost of a round trip `save_link()` does not need. The reasoning is written up in the handoff that comes with #99, `superpowers/handoffs/2026-08-18-jwt-insert-validate.md`, together with what is still open about `jwt.validate`.

## Tests

New: `test_api_create_jwt_resource_is_not_allowed`. Written first, watched fail — and it failed for a *different* reason than expected, which is how the `AttributeError` above came to light. My earlier note on #99 claimed the call reaches Google and dies on the response; it does not get that far. The handoff has been corrected accordingly.

```
uvx tox -e py313   ->  136 passed, 8 skipped
uvx tox -e lint    ->  all 15 hooks passed
```

## Risks

Nothing regresses: the operation never worked, in any form, so no caller can be relying on it. The change only swaps one exception for a clearer one.

`JwtResponse` is left alone. It documents the shape of an endpoint we do not call, costs nothing, and `is_envelope()` in the parity test drops the name either way.

## Relation to #99

Independent — this branches from `main`, not from #99. #99 is the discovery-document parity check; this is a behaviour change and was deliberately kept out of it. Merge order does not matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
