### PR TITLE
fix(ci): build-and-inspect-python-package auf v3.0.1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@
               fetch-depth: 0
               persist-credentials: false
 
-          - uses: hynek/build-and-inspect-python-package@v2
+          - uses: hynek/build-and-inspect-python-package@v3.0.1
             with:
               attest-build-provenance-github: 'true'
 


### PR DESCRIPTION
## Der Release-Workflow ist rot, seit mindestens 9. August

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

Das Paket baut sauber; abgelehnt wird es beim Prüfen. Neuere Build-Backends schreiben `Metadata-Version: 2.5`, und das `twine`, das in `build-and-inspect-python-package@v2` steckt, kennt sie nicht.

## Der Fix ist ein Nachziehen, keine Erfindung

Sechs andere Repositories im Baum fahren längst `@v3.0.1`. Diese beiden waren die letzten auf `@v2`.

## Vorbestehend

Nicht durch die Metadaten-Ergänzung von heute verursacht — die Läufe vom 9. und 14. August sind aus demselben Grund gescheitert. Es fiel nur niemandem auf, weil der Workflow ohnehin schon rot stand.